### PR TITLE
Upgrade Doctum to 5.4.1 and twig templates to Twig 3

### DIFF
--- a/util/docstheme/macros.twig
+++ b/util/docstheme/macros.twig
@@ -3,7 +3,7 @@
 {%- endmacro -%}
 
 {% macro class_name(class, short = false, suffix = "") -%}
-{% spaceless -%}
+{% apply spaceless -%}
 {% if class.projectclass or class.phpclass %}
 {% if class.projectclass %}
 <<{{_self.replace_backslash( (short ? class.shortname : class)~suffix) }},{{ class }}>>
@@ -13,11 +13,11 @@ http://php.net/class.{{ class }}[{{ short ? class.shortname : class }}{{ suffix 
 {% else %}
 `{{ class }}`
 {% endif %}
-{%- endspaceless %}
+{%- endapply %}
 {%- endmacro -%}
 
 {% macro class_type(class, sentence = false) -%}
-{% spaceless %}
+{% apply spaceless %}
 {% if class.interface %}
 {% if sentence %}an {% endif %}
 interface
@@ -26,59 +26,59 @@ interface
 {% if class.abstract %}abstract {% endif %}
 class
 {%- endif -%}
-{% endspaceless %}
+{% endapply %}
 {%- endmacro -%}
 
 {% macro hint(hint) -%}
-{% spaceless %}
+{% apply spaceless %}
 {% if hint.class -%}
 {{ _self.class_name(hint.name) }}
 {%- elseif hint.name -%}
 {{ hint.name }}
 {%- endif %}
-{% endspaceless %}
+{% endapply %}
 {%- endmacro -%}
 
 {% macro markdown_path(path) -%}
-{% spaceless %}
+{% apply spaceless %}
 {{- path|replace({".html": ".md"}) -}}
-{% endspaceless %}
+{% endapply %}
 {%- endmacro -%}
 
 {% macro replace_backslash(path) -%}
-    {% spaceless %}
+    {% apply spaceless %}
         {{- path|replace({"\\": "_"}) -}}
-    {% endspaceless %}
+    {% endapply %}
 {%- endmacro -%}
 
 {% macro back_to_forward(path) -%}
-    {% spaceless %}
+    {% apply spaceless %}
         {{- path|replace({"\\": "/"}) -}}
-    {% endspaceless %}
+    {% endapply %}
 {%- endmacro -%}
 
 {% macro sanitize(path) -%}
-    {% spaceless %}
+    {% apply spaceless %}
         {{- path|replace({"$": "", "::": "", "__": "-"}) -}}
-    {% endspaceless %}
+    {% endapply %}
 {%- endmacro -%}
 
 {% macro get_namespace(class) -%}
-    {% spaceless %}
+    {% apply spaceless %}
         {% if class.shortname == 'Client' %}
             $client
         {% else %}
             $client->{{ class.shortname|lower|replace({"namespace": ""}) }}()
         {% endif %}
-    {% endspaceless %}
+    {% endapply %}
 {%- endmacro -%}
 
 
 
 {% macro param_list(member) -%}
-    {% spaceless %}
+    {% apply spaceless %}
         {% for parameter in member.parameters %}${{ parameter.name }},{% endfor %}
-    {% endspaceless %}
+    {% endapply %}
 {%- endmacro -%}
 
 {% macro member_signature(type, member) -%}
@@ -131,10 +131,10 @@ class
 {%- endmacro -%}
 
 {% macro member_visibility(member) -%}
-{% spaceless %}
+{% apply spaceless %}
 {% if member.private %}private{% elseif member.protected %}protected{% else %}public{% endif %}
 {% if member.static %} static{% endif %}
-{% endspaceless %}
+{% endapply %}
 {%- endmacro -%}
 
 {% macro method_parameters_signature(method) -%}

--- a/util/docstheme/pages/classes.twig
+++ b/util/docstheme/pages/classes.twig
@@ -13,14 +13,18 @@ This is a complete list of namespaces and their associated endpoints.
 
 NOTE: This is auto-generated documentation
 
-{% for class in classes if not class.interface %}
+{% for class in classes %}
+{% if not class.interface %}
 * <<{{ replace_backslash(class) }}, {{ class }}>>
 {% else %}
 * There are no endpoints available.
+{% endif %}
 {% endfor %}
-{% for class in classes if not class.interface %}
+{% for class in classes %}
+{% if not class.interface %}
 include::{{ back_to_forward(class) }}.asciidoc[]
 {% else %}
+{% endif %}
 {% endfor %}
 {% endblock %}
 

--- a/util/docstheme/pages/interfaces.twig
+++ b/util/docstheme/pages/interfaces.twig
@@ -11,13 +11,17 @@
 
 This is a complete list of available interfaces:
 
-{% for interface in classes if interface.interface %}
+{% for interface in classes %}
+{% if interface.interface %}
 * <<{{ replace_backslash(interface) }}, {{ interface }}>>
 {% else %}
 * There are no interfaces available.
+{% endif %}
 {% endfor %}
-{% for interface in classes if interface.interface %}
+{% for interface in classes %}
+{% if interface.interface %}
 include::{{ back_to_forward(interface) }}.asciidoc[]
 {% else %}
+{% endif %}
 {% endfor %}
 {% endblock %}

--- a/util/generate_docs.sh
+++ b/util/generate_docs.sh
@@ -6,17 +6,18 @@ set -e
 rm -f doctum.phar
 rm -f doctum.phar.sha256
 
-# Download the latest (5.1.x) release
-curl -O https://doctum.long-term.support/releases/5.3/doctum.phar
-curl -O https://doctum.long-term.support/releases/5.3/doctum.phar.sha256
+# Download the latest (5.x.x) release
+curl -O https://doctum.long-term.support/releases/5/doctum.phar
+curl -O https://doctum.long-term.support/releases/5/doctum.phar.sha256
 
 sha256sum --strict --check doctum.phar.sha256
 rm -f doctum.phar.sha256
-# You can fetch the latest (5.3.x) version code here:
-# https://doctum.long-term.support/releases/5.1/VERSION
+chmod +x ./doctum.phar
+# You can fetch the latest (5.x.x) version code here:
+# https://doctum.long-term.support/releases/5/VERSION
 
 # Show the version to inform users of the script
-php doctum.phar --version
+./doctum.phar version --text
 
 # Only exit if the process fails, not if parse errors are found
-php doctum.phar update --force --ignore-parse-errors -v util/docsConfig.php
+./doctum.phar update --force --ignore-parse-errors -v util/docsConfig.php


### PR DESCRIPTION
Signed-off-by: Soner Sayakci <s.sayakci@shopware.com>

### Description
Updates the Doctum (doc generator)

I asked the maintainer for the deprecations and he said he as created a PR to fix that at Elastic repository https://github.com/elastic/elasticsearch-php/pull/1128. So I asked him that I can import that pull request to OpenSearch he agreed.
https://github.com/code-lts/doctum/issues/34
 
### Issues Resolved
Generation does not throw deprecations anymore 😅 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
