### PR TITLE
Remove X-Elastic-Client-Meta header

### DIFF
--- a/src/OpenSearch/ClientBuilder.php
+++ b/src/OpenSearch/ClientBuilder.php
@@ -134,11 +134,6 @@ class ClientBuilder
     /**
      * @var bool
      */
-    private $elasticMetaHeader = true;
-
-    /**
-     * @var bool
-     */
     private $includePortInHostHeader = false;
 
     /**
@@ -507,16 +502,6 @@ class ClientBuilder
     }
 
     /**
-     * Set or disable the x-elastic-client-meta header
-     */
-    public function setElasticMetaHeader($value = true): ClientBuilder
-    {
-        $this->elasticMetaHeader = $value;
-
-        return $this;
-    }
-
-    /**
      * Include the port in Host header
      *
      * @see https://github.com/elastic/elasticsearch-php/issues/993
@@ -571,7 +556,6 @@ class ClientBuilder
             $this->serializer = new $this->serializer();
         }
 
-        $this->connectionParams['client']['x-elastic-client-meta']= $this->elasticMetaHeader;
         $this->connectionParams['client']['port_in_header'] = $this->includePortInHostHeader;
 
         if (is_null($this->connectionFactory)) {

--- a/src/OpenSearch/Connections/Connection.php
+++ b/src/OpenSearch/Connections/Connection.php
@@ -165,11 +165,6 @@ class Connection implements ConnectionInterface
             phpversion()
         )];
 
-        // Add x-elastic-client-meta header, if enabled
-        if (isset($connectionParams['client']['x-elastic-client-meta']) && $connectionParams['client']['x-elastic-client-meta']) {
-            $this->headers['x-elastic-client-meta'] = [$this->getElasticMetaHeader($connectionParams)];
-        }
-
         $host = $hostDetails['host'];
         $path = null;
         if (isset($hostDetails['path']) === true) {
@@ -580,33 +575,6 @@ class Connection implements ConnectionInterface
         }
 
         return $exception;
-    }
-
-    /**
-     * Get the x-elastic-client-meta header
-     *
-     * The header format is specified by the following regex:
-     * ^[a-z]{1,}=[a-z0-9\.\-]{1,}(?:,[a-z]{1,}=[a-z0-9\.\-]+)*$
-     */
-    private function getElasticMetaHeader(array $connectionParams): string
-    {
-        $phpSemVersion = sprintf("%d.%d.%d", PHP_MAJOR_VERSION, PHP_MINOR_VERSION, PHP_RELEASE_VERSION);
-        // Reduce the size in case of '-snapshot' version
-        $clientVersion = str_replace('-snapshot', '-s', strtolower(Client::VERSION));
-        $clientMeta = sprintf(
-            "es=%s,php=%s,t=%s,a=%d",
-            $clientVersion,
-            $phpSemVersion,
-            $clientVersion,
-            isset($connectionParams['client']['future']) && $connectionParams['client']['future'] === 'lazy' ? 1 : 0
-        );
-        if (function_exists('curl_version')) {
-            $curlVersion = curl_version();
-            if (isset($curlVersion['version'])) {
-                $clientMeta .= sprintf(",cu=%s", $curlVersion['version']); // cu = curl library
-            }
-        }
-        return $clientMeta;
     }
 
     /**

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -168,64 +168,6 @@ class ClientBuilderTest extends TestCase
         );
     }
 
-    public function testElasticClientMetaHeaderIsSentByDefault()
-    {
-        $client = ClientBuilder::create()
-            ->build();
-        $this->assertInstanceOf(Client::class, $client);
-
-        try {
-            $result = $client->info();
-        } catch (OpenSearchException $e) {
-            $request = $client->transport->getLastConnection()->getLastRequestInfo();
-            $this->assertTrue(isset($request['request']['headers']['x-elastic-client-meta']));
-            $this->assertEquals(
-                1,
-                preg_match(
-                    '/^[a-z]{1,}=[a-z0-9\.\-]{1,}(?:,[a-z]{1,}=[a-z0-9\.\-]+)*$/',
-                    $request['request']['headers']['x-elastic-client-meta'][0]
-                )
-            );
-        }
-    }
-
-    public function testElasticClientMetaHeaderIsSentWhenEnabled()
-    {
-        $client = ClientBuilder::create()
-            ->setElasticMetaHeader(true)
-            ->build();
-        $this->assertInstanceOf(Client::class, $client);
-
-        try {
-            $result = $client->info();
-        } catch (OpenSearchException $e) {
-            $request = $client->transport->getLastConnection()->getLastRequestInfo();
-            $this->assertTrue(isset($request['request']['headers']['x-elastic-client-meta']));
-            $this->assertEquals(
-                1,
-                preg_match(
-                    '/^[a-z]{1,}=[a-z0-9\.\-]{1,}(?:,[a-z]{1,}=[a-z0-9\.\-]+)*$/',
-                    $request['request']['headers']['x-elastic-client-meta'][0]
-                )
-            );
-        }
-    }
-
-    public function testElasticClientMetaHeaderIsNotSentWhenDisabled()
-    {
-        $client = ClientBuilder::create()
-            ->setElasticMetaHeader(false)
-            ->build();
-        $this->assertInstanceOf(Client::class, $client);
-
-        try {
-            $result = $client->info();
-        } catch (OpenSearchException $e) {
-            $request = $client->transport->getLastConnection()->getLastRequestInfo();
-            $this->assertFalse(isset($request['request']['headers']['x-elastic-client-meta']));
-        }
-    }
-
     public function getCompatibilityHeaders()
     {
         return [

--- a/tests/Connections/ConnectionTest.php
+++ b/tests/Connections/ConnectionTest.php
@@ -363,69 +363,6 @@ class ConnectionTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($headersBefore, $headersAfter);
     }
 
-    /**
-     * Test if the x-elastic-client-meta header is sent if $params['client']['x-elastic-client-meta'] is true
-     */
-    public function testElasticMetaClientHeaderIsSentWhenParameterIsTrue()
-    {
-        $params = [
-            'client' => [
-                'x-elastic-client-meta'=> true
-            ]
-        ];
-        $host = [
-            'host' => 'localhost'
-        ];
-
-        $connection = new Connection(
-            ClientBuilder::defaultHandler(),
-            $host,
-            $params,
-            $this->serializer,
-            $this->logger,
-            $this->trace
-        );
-        $result  = $connection->performRequest('GET', '/');
-        $request = $connection->getLastRequestInfo()['request'];
-
-        $this->assertArrayHasKey('x-elastic-client-meta', $request['headers']);
-        $this->assertEquals(
-            1,
-            preg_match(
-                '/^[a-z]{1,}=[a-z0-9\.\-]{1,}(?:,[a-z]{1,}=[a-z0-9\.\-]+)*$/',
-                $request['headers']['x-elastic-client-meta'][0]
-            )
-        );
-    }
-
-    /**
-     * Test if the x-elastic-client-meta header is sent if $params['client']['x-elastic-client-meta'] is true
-     */
-    public function testElasticMetaClientHeaderIsNotSentWhenParameterIsFalse()
-    {
-        $params = [
-            'client' => [
-                'x-elastic-client-meta'=> false
-            ]
-        ];
-        $host = [
-            'host' => 'localhost'
-        ];
-
-        $connection = new Connection(
-            ClientBuilder::defaultHandler(),
-            $host,
-            $params,
-            $this->serializer,
-            $this->logger,
-            $this->trace
-        );
-        $result  = $connection->performRequest('GET', '/');
-        $request = $connection->getLastRequestInfo()['request'];
-
-        $this->assertArrayNotHasKey('x-elastic-client-meta', $request['headers']);
-    }
-
     public function testParametersAreSent()
     {
         $connectionParams = [];


### PR DESCRIPTION
Signed-off-by: Soner Sayakci <s.sayakci@shopware.com>

### Description
The `X-Elastic-Client-Meta header` is not required and have been removed also in other clients
 
### Issues Resolved
#1
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
