### PR TITLE
Add SignatureV4 handler

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -14,6 +14,9 @@ require __DIR__ . '/vendor/autoload.php';
 $client = (new \OpenSearch\ClientBuilder())
     ->setHosts(['https://localhost:9200'])
     ->setBasicAuthentication('admin', 'admin') // For testing only. Don't store credentials in code.
+    // or, if using AWS SigV4 authentication:
+    ->setSigV4Region('us-east-2')
+    ->setSigV4CredentialProvider(true)
     ->setSSLVerification(false) // For testing only. Use certificate for validation
     ->build();
 

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
   },
   "require-dev": {
     "ext-zip": "*",
+    "aws/aws-sdk-php": "^3.0",
     "friendsofphp/php-cs-fixer": "^3.0",
     "mockery/mockery": "^1.2",
     "phpstan/phpstan": "^0.12",
@@ -29,7 +30,8 @@
     "symfony/finder": "~4.0"
   },
   "suggest": {
-    "monolog/monolog": "Allows for client-level logging and tracing"
+    "monolog/monolog": "Allows for client-level logging and tracing",
+    "aws/aws-sdk-php": "Required (^3.0.0) in order to use the SigV4 handler"
   },
   "autoload": {
     "psr-4": {

--- a/src/OpenSearch/ClientBuilder.php
+++ b/src/OpenSearch/ClientBuilder.php
@@ -476,8 +476,7 @@ class ClientBuilder
      */
     public function setSigV4CredentialProvider($credentialProvider): ClientBuilder
     {
-        if ($credentialProvider !== null && $credentialProvider !== false)
-        {
+        if ($credentialProvider !== null && $credentialProvider !== false) {
             $this->sigV4CredentialProvider = $this->normalizeCredentialProvider($credentialProvider);
         }
 
@@ -814,8 +813,7 @@ class ClientBuilder
 
     private function normalizeCredentialProvider($provider): ?callable
     {
-        if ($provider === null && $provider === false)
-        {
+        if ($provider === null && $provider === false) {
             return null;
         }
 
@@ -825,16 +823,13 @@ class ClientBuilder
 
         SigV4Handler::assertDependenciesInstalled();
 
-        if ($provider === true)
-        {
+        if ($provider === true) {
             return CredentialProvider::defaultProvider();
         }
 
-        if ($provider instanceof CredentialsInterface)
-        {
+        if ($provider instanceof CredentialsInterface) {
             return CredentialProvider::fromCredentials($provider);
-        } elseif (is_array($provider) && isset($provider['key']) && isset($provider['secret']))
-        {
+        } elseif (is_array($provider) && isset($provider['key']) && isset($provider['secret'])) {
             return CredentialProvider::fromCredentials(
                 new Credentials(
                     $provider['key'],

--- a/src/OpenSearch/ClientBuilder.php
+++ b/src/OpenSearch/ClientBuilder.php
@@ -21,6 +21,9 @@ declare(strict_types=1);
 
 namespace OpenSearch;
 
+use Aws\Credentials\CredentialProvider;
+use Aws\Credentials\Credentials;
+use Aws\Credentials\CredentialsInterface;
 use OpenSearch\Common\Exceptions\InvalidArgumentException;
 use OpenSearch\Common\Exceptions\RuntimeException;
 use OpenSearch\Common\Exceptions\AuthenticationConfigException;
@@ -31,6 +34,7 @@ use OpenSearch\ConnectionPool\StaticNoPingConnectionPool;
 use OpenSearch\Connections\ConnectionFactory;
 use OpenSearch\Connections\ConnectionFactoryInterface;
 use OpenSearch\Connections\ConnectionInterface;
+use OpenSearch\Handlers\SigV4Handler;
 use OpenSearch\Namespaces\NamespaceBuilderInterface;
 use OpenSearch\Serializers\SerializerInterface;
 use OpenSearch\Serializers\SmartSerializer;
@@ -114,6 +118,16 @@ class ClientBuilder
      * @var int
      */
     private $retries;
+
+    /**
+     * @var null|callable
+     */
+    private $sigV4CredentialProvider;
+
+    /**
+     * @var null|string
+     */
+    private $sigV4Region;
 
     /**
      * @var bool
@@ -455,6 +469,34 @@ class ClientBuilder
     }
 
     /**
+     * Set the credential provider for SigV4 request signing. The value provider should be a
+     * callable object that will return
+     *
+     * @param callable|bool|array|CredentialsInterface|null $credentialProvider
+     */
+    public function setSigV4CredentialProvider($credentialProvider): ClientBuilder
+    {
+        if ($credentialProvider !== null && $credentialProvider !== false)
+        {
+            $this->sigV4CredentialProvider = $this->normalizeCredentialProvider($credentialProvider);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set the region for SigV4 signing.
+     *
+     * @param string|null $credentialProvider
+     */
+    public function setSigV4Region($region): ClientBuilder
+    {
+        $this->sigV4Region = $region;
+
+        return $this;
+    }
+
+    /**
      * Set sniff on start
      *
      * @param bool $sniffOnStart enable or disable sniff on start
@@ -526,6 +568,14 @@ class ClientBuilder
 
         if (is_null($this->handler)) {
             $this->handler = ClientBuilder::defaultHandler();
+        }
+
+        if (!is_null($this->sigV4CredentialProvider)) {
+            if (is_null($this->sigV4Region)) {
+                throw new RuntimeException("A region must be supplied for SigV4 request signing.");
+            }
+
+            $this->handler = new SigV4Handler($this->sigV4Region, $this->sigV4CredentialProvider, $this->handler);
         }
 
         $sslOptions = null;
@@ -760,5 +810,43 @@ class ClientBuilder
         }
 
         return $host;
+    }
+
+    private function normalizeCredentialProvider($provider): ?callable
+    {
+        if ($provider === null && $provider === false)
+        {
+            return null;
+        }
+
+        if (is_callable($provider)) {
+            return $provider;
+        }
+
+        SigV4Handler::assertDependenciesInstalled();
+
+        if ($provider === true)
+        {
+            return CredentialProvider::defaultProvider();
+        }
+
+        if ($provider instanceof CredentialsInterface)
+        {
+            return CredentialProvider::fromCredentials($provider);
+        } elseif (is_array($provider) && isset($provider['key']) && isset($provider['secret']))
+        {
+            return CredentialProvider::fromCredentials(
+                new Credentials(
+                    $provider['key'],
+                    $provider['secret'],
+                    isset($provider['token']) ? $provider['token'] : null,
+                    isset($provider['expires']) ? $provider['expires'] : null
+                )
+            );
+        }
+
+        throw new InvalidArgumentException('Credentials must be an instance of Aws\Credentials\CredentialsInterface, an'
+            . ' associative array that contains "key", "secret", and an optional "token" key-value pairs, a credentials'
+            . ' provider function, or true.');
     }
 }

--- a/src/OpenSearch/ClientBuilder.php
+++ b/src/OpenSearch/ClientBuilder.php
@@ -486,7 +486,7 @@ class ClientBuilder
     /**
      * Set the region for SigV4 signing.
      *
-     * @param string|null $credentialProvider
+     * @param string|null $region
      */
     public function setSigV4Region($region): ClientBuilder
     {

--- a/src/OpenSearch/ClientBuilder.php
+++ b/src/OpenSearch/ClientBuilder.php
@@ -813,7 +813,7 @@ class ClientBuilder
 
     private function normalizeCredentialProvider($provider): ?callable
     {
-        if ($provider === null && $provider === false) {
+        if ($provider === null || $provider === false) {
             return null;
         }
 

--- a/src/OpenSearch/Handlers/SigV4Handler.php
+++ b/src/OpenSearch/Handlers/SigV4Handler.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Handlers;
+
+use Aws\Credentials\CredentialProvider;
+use Aws\Signature\SignatureV4;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Uri;
+use OpenSearch\ClientBuilder;
+use Psr\Http\Message\RequestInterface;
+use RuntimeException;
+
+class SigV4Handler
+{
+    private $signer;
+    private $credentialProvider;
+    private $wrappedHandler;
+
+    /**
+     * A handler that applies an AWS V4 signature before dispatching requests.
+     *
+     * @param string        $region                 The region of your Amazon
+     *                                              Elasticsearch Service domain
+     * @param callable|null $credentialProvider     A callable that returns a
+     *                                              promise that is fulfilled
+     *                                              with an instance of
+     *                                              Aws\Credentials\Credentials
+     * @param callable|null $wrappedHandler         A RingPHP handler
+     */
+    public function __construct(
+        string $region,
+        callable $credentialProvider = null,
+        callable $wrappedHandler = null
+    ) {
+        if (!class_exists(SignatureV4::class)) {
+            throw new RuntimeException(
+                'The AWS SDK for PHP must be installed in order to use the SigV4 signing handler'
+            );
+        }
+
+        $this->signer = new SignatureV4('es', $region);
+        $this->wrappedHandler = $wrappedHandler
+            ?: ClientBuilder::defaultHandler();
+        $this->credentialProvider = $credentialProvider
+            ?: CredentialProvider::defaultProvider();
+    }
+
+    public function __invoke(array $request)
+    {
+        $creds = call_user_func($this->credentialProvider)->wait();
+        $psr7Request = $this->createPsr7Request($request);
+        $signedRequest = $this->signer
+            ->signRequest($psr7Request, $creds);
+
+        return call_user_func($this->wrappedHandler, $this->createRingRequest($signedRequest));
+    }
+
+    private function createPsr7Request(array $ringPhpRequest)
+    {
+        // fix for uppercase 'Host' array key in elasticsearch-php 5.3.1 and backward compatible
+        // https://github.com/aws/aws-sdk-php/issues/1225
+        $hostKey = isset($ringPhpRequest['headers']['Host']) ? 'Host' : 'host';
+
+        // Amazon ES/OS listens on standard ports (443 for HTTPS, 80 for HTTP).
+        // Consequently, the port should be stripped from the host header.
+        $parsedUrl = parse_url($ringPhpRequest['headers'][$hostKey][0]);
+        if (isset($parsedUrl['host'])) {
+            $ringPhpRequest['headers'][$hostKey][0] = $parsedUrl['host'];
+        }
+
+        // Create a PSR-7 URI from the array passed to the handler
+        $uri = (new Uri($ringPhpRequest['uri']))
+            ->withScheme($ringPhpRequest['scheme'])
+            ->withHost($ringPhpRequest['headers'][$hostKey][0]);
+        if (isset($ringPhpRequest['query_string'])) {
+            $uri = $uri->withQuery($ringPhpRequest['query_string']);
+        }
+
+        // Create a PSR-7 request from the array passed to the handler
+        return new Request(
+            $ringPhpRequest['http_method'],
+            $uri,
+            $ringPhpRequest['headers'],
+            $ringPhpRequest['body']
+        );
+    }
+
+    private function createRingRequest(RequestInterface $request)
+    {
+        $uri = $request->getUri();
+        $body = (string) $request->getBody();
+
+        // RingPHP currently expects empty message bodies to be null:
+        // https://github.com/guzzle/RingPHP/blob/4c8fe4c48a0fb7cc5e41ef529e43fecd6da4d539/src/Client/CurlFactory.php#L202
+        if (empty($body)) {
+            $body = null;
+        }
+
+        $ringRequest = [
+            'http_method' => $request->getMethod(),
+            'scheme' => $uri->getScheme(),
+            'uri' => $uri->getPath(),
+            'body' => $body,
+            'headers' => $request->getHeaders(),
+        ];
+        if ($uri->getQuery()) {
+            $ringRequest['query_string'] = $uri->getQuery();
+        }
+
+        return $ringRequest;
+    }
+}

--- a/src/OpenSearch/Handlers/SigV4Handler.php
+++ b/src/OpenSearch/Handlers/SigV4Handler.php
@@ -34,11 +34,7 @@ class SigV4Handler
         callable $credentialProvider = null,
         callable $wrappedHandler = null
     ) {
-        if (!class_exists(SignatureV4::class)) {
-            throw new RuntimeException(
-                'The AWS SDK for PHP must be installed in order to use the SigV4 signing handler'
-            );
-        }
+        self::assertDependenciesInstalled();
 
         $this->signer = new SignatureV4('es', $region);
         $this->wrappedHandler = $wrappedHandler
@@ -57,7 +53,16 @@ class SigV4Handler
         return call_user_func($this->wrappedHandler, $this->createRingRequest($signedRequest));
     }
 
-    private function createPsr7Request(array $ringPhpRequest)
+    public static function assertDependenciesInstalled(): void
+    {
+        if (!class_exists(SignatureV4::class)) {
+            throw new RuntimeException(
+                'The AWS SDK for PHP must be installed in order to use the SigV4 signing handler'
+            );
+        }
+    }
+
+    private function createPsr7Request(array $ringPhpRequest): Request
     {
         // fix for uppercase 'Host' array key in elasticsearch-php 5.3.1 and backward compatible
         // https://github.com/aws/aws-sdk-php/issues/1225
@@ -87,7 +92,7 @@ class SigV4Handler
         );
     }
 
-    private function createRingRequest(RequestInterface $request)
+    private function createRingRequest(RequestInterface $request): array
     {
         $uri = $request->getUri();
         $body = (string) $request->getBody();

--- a/tests/Handlers/SigV4HandlerTest.php
+++ b/tests/Handlers/SigV4HandlerTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Tests\Handlers;
+
+use Aws\Credentials\CredentialProvider;
+use Aws\Credentials\Credentials;
+use GuzzleHttp\Ring\Future\CompletedFutureArray;
+use OpenSearch\ClientBuilder;
+use OpenSearch\Handlers\SigV4Handler;
+use PHPUnit\Framework\TestCase;
+
+class SigV4HandlerTest extends TestCase
+{
+    public function testSignsRequestsTheSdkDefaultCredentialProviderChain()
+    {
+        $key = 'foo';
+        $toWrap = function (array $ringRequest) use ($key) {
+            $this->assertArrayHasKey('X-Amz-Date', $ringRequest['headers']);
+            $this->assertArrayHasKey('Authorization', $ringRequest['headers']);
+            $this->assertMatchesRegularExpression(
+                "~^AWS4-HMAC-SHA256 Credential=$key/\\d{8}/us-west-2/es/aws4_request~",
+                $ringRequest['headers']['Authorization'][0]
+            );
+
+            return $this->getGenericResponse();
+        };
+        putenv(CredentialProvider::ENV_KEY . "=$key");
+        putenv(CredentialProvider::ENV_SECRET . '=bar');
+        $client = $this->getClient(new SigV4Handler('us-west-2', null, $toWrap));
+
+        $client->search([
+            'index' => 'index',
+            'body' => [
+                'query' => [ 'match_all' => (object)[] ],
+            ],
+        ]);
+    }
+
+    public function testSignsWithProvidedCredentials()
+    {
+        $provider = CredentialProvider::fromCredentials(
+            new Credentials('foo', 'bar', 'baz')
+        );
+        $toWrap = function (array $ringRequest) {
+            $this->assertArrayHasKey('X-Amz-Security-Token', $ringRequest['headers']);
+            $this->assertSame('baz', $ringRequest['headers']['X-Amz-Security-Token'][0]);
+            $this->assertMatchesRegularExpression(
+                '~^AWS4-HMAC-SHA256 Credential=foo/\d{8}/us-west-2/es/aws4_request~',
+                $ringRequest['headers']['Authorization'][0]
+            );
+
+            return $this->getGenericResponse();
+        };
+
+        $client = $this->getClient(new SigV4Handler('us-west-2', $provider, $toWrap));
+
+        $client->search([
+            'index' => 'index',
+            'body' => [
+                'query' => [ 'match_all' => (object)[] ],
+            ],
+        ]);
+    }
+
+    public function testEmptyRequestBodiesShouldBeNull()
+    {
+        $toWrap = function (array $ringRequest) {
+            $this->assertNull($ringRequest['body']);
+
+            return $this->getGenericResponse();
+        };
+
+        $client = $this->getClient(new SigV4Handler('us-west-2', null, $toWrap));
+
+        $client->indices()->exists(['index' => 'index']);
+    }
+
+    public function testNonEmptyRequestBodiesShouldNotBeNull()
+    {
+        $toWrap = function (array $ringRequest) {
+            $this->assertNotNull($ringRequest['body']);
+
+            return $this->getGenericResponse();
+        };
+
+        $client = $this->getClient(new SigV4Handler('us-west-2', null, $toWrap));
+
+        $client->search([
+            'index' => 'index',
+            'body' => [
+                'query' => [ 'match_all' => (object)[] ],
+            ],
+        ]);
+    }
+
+    private function getClient(SigV4Handler $handler)
+    {
+        $builder = ClientBuilder::create()
+            ->setHandler($handler);
+
+        if (method_exists($builder, 'allowBadJSONSerialization')) {
+            $builder = $builder->allowBadJSONSerialization();
+        }
+
+        return $builder->build();
+    }
+
+    private function getGenericResponse()
+    {
+        return new CompletedFutureArray([
+            'status' => 200,
+            'body' => fopen('php://memory', 'r'),
+            'transfer_stats' => ['total_time' => 0],
+            'effective_url' => 'https://www.example.com',
+        ]);
+    }
+}

--- a/tests/Handlers/SigV4HandlerTest.php
+++ b/tests/Handlers/SigV4HandlerTest.php
@@ -17,7 +17,8 @@ class SigV4HandlerTest extends TestCase
 
     private $envTemp = [];
 
-    protected function setUp(): void {
+    protected function setUp(): void
+    {
         $this->envTemp = array_combine(self::ENV_KEYS_USED, array_map(
             function ($envVarName) {
                 $current = getenv($envVarName);
@@ -28,7 +29,8 @@ class SigV4HandlerTest extends TestCase
         ));
     }
 
-    protected function tearDown(): void {
+    protected function tearDown(): void
+    {
         foreach ($this->envTemp as $key => $value) {
             putenv("$key=$value");
         }

--- a/tests/Handlers/SigV4HandlerTest.php
+++ b/tests/Handlers/SigV4HandlerTest.php
@@ -135,13 +135,6 @@ class SigV4HandlerTest extends TestCase
         ]);
     }
 
-    private function getClient(SigV4Handler $handler)
-    {
-        return ClientBuilder::create()
-            ->setHandler($handler)
-            ->build();
-    }
-
     private function getGenericResponse()
     {
         return new CompletedFutureArray([

--- a/tests/Handlers/SigV4HandlerTest.php
+++ b/tests/Handlers/SigV4HandlerTest.php
@@ -50,7 +50,11 @@ class SigV4HandlerTest extends TestCase
         };
         putenv(CredentialProvider::ENV_KEY . "=$key");
         putenv(CredentialProvider::ENV_SECRET . '=bar');
-        $client = $this->getClient(new SigV4Handler('us-west-2', null, $toWrap));
+        $client = ClientBuilder::create()
+            ->setHandler($toWrap)
+            ->setSigV4Region('us-west-2')
+            ->setSigV4CredentialProvider(true)
+            ->build();
 
         $client->search([
             'index' => 'index',
@@ -76,7 +80,11 @@ class SigV4HandlerTest extends TestCase
             return $this->getGenericResponse();
         };
 
-        $client = $this->getClient(new SigV4Handler('us-west-2', $this->getCredentialProvider(), $toWrap));
+        $client = ClientBuilder::create()
+            ->setHandler($toWrap)
+            ->setSigV4Region('us-west-2')
+            ->setSigV4CredentialProvider(new Credentials('foo', 'bar', 'baz'))
+            ->build();
 
         $client->search([
             'index' => 'index',
@@ -94,7 +102,11 @@ class SigV4HandlerTest extends TestCase
             return $this->getGenericResponse();
         };
 
-        $client = $this->getClient(new SigV4Handler('us-west-2', $this->getCredentialProvider(), $toWrap));
+        $client = ClientBuilder::create()
+            ->setHandler($toWrap)
+            ->setSigV4Region('us-west-2')
+            ->setSigV4CredentialProvider(new Credentials('foo', 'bar', 'baz'))
+            ->build();
 
         $client->indices()->exists(['index' => 'index']);
     }
@@ -107,7 +119,11 @@ class SigV4HandlerTest extends TestCase
             return $this->getGenericResponse();
         };
 
-        $client = $this->getClient(new SigV4Handler('us-west-2', $this->getCredentialProvider(), $toWrap));
+        $client = ClientBuilder::create()
+            ->setHandler($toWrap)
+            ->setSigV4Region('us-west-2')
+            ->setSigV4CredentialProvider(new Credentials('foo', 'bar', 'baz'))
+            ->build();
 
         $client->search([
             'index' => 'index',
@@ -132,12 +148,5 @@ class SigV4HandlerTest extends TestCase
             'transfer_stats' => ['total_time' => 0],
             'effective_url' => 'https://www.example.com',
         ]);
-    }
-
-    private function getCredentialProvider()
-    {
-        return CredentialProvider::fromCredentials(
-            new Credentials('foo', 'bar', 'baz')
-        );
     }
 }


### PR DESCRIPTION
### Description

This PR adds an AWS SigV4 signing handler. It is not used by default but is available for use provided the user has also installed the AWS SDK for PHP (which contains the signer).

Let me know if the naming is not right or if you'd prefer integration into the ClientBuilder.

### Issues Resolved

Closes #59 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
