### PR TITLE
Allowing when creating the id isn't required

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -37,6 +37,7 @@ $client->indices()->create([
     ]
 ]);
 
+// Create a document passing the id
 $client->create([
     'index' => $indexName,
     'id' => 1,
@@ -44,6 +45,16 @@ $client->create([
         'title' => 'Moneyball',
         'director' => 'Bennett Miller',
         'year' => 2011
+    ]
+]);
+
+// Create a document without passing the id (will be generated automatically)
+$client->create([
+    'index' => $indexName,
+    'body' => [
+        'title' => 'Remember the Titans',
+        'director' => 'Boaz Yakin',
+        'year' => 2000
     ]
 ]);
 

--- a/src/OpenSearch/Endpoints/Create.php
+++ b/src/OpenSearch/Endpoints/Create.php
@@ -28,19 +28,18 @@ class Create extends AbstractEndpoint
 {
     public function getURI(): string
     {
-        if (isset($this->id) !== true) {
-            throw new RuntimeException(
-                'id is required for create'
-            );
-        }
-        $id = $this->id;
         if (isset($this->index) !== true) {
             throw new RuntimeException(
                 'index is required for create'
             );
         }
         $index = $this->index;
-        return "/$index/_create/$id";
+
+        if (isset($this->id) !== true) {
+            return "/$index/_doc";
+        }
+
+        return "/$index/_create/$this->id";
     }
 
     public function getParamWhitelist(): array
@@ -58,7 +57,7 @@ class Create extends AbstractEndpoint
 
     public function getMethod(): string
     {
-        return 'PUT';
+        return isset($this->id) ? 'PUT' : 'POST';
     }
 
     public function setBody($body): Create

--- a/tests/Endpoints/CreateIntegrationTest.php
+++ b/tests/Endpoints/CreateIntegrationTest.php
@@ -23,6 +23,12 @@ namespace OpenSearch\Tests\Endpoints;
 
 use OpenSearch\Tests\Utility;
 
+/**
+ * Class CreateIntegrationTest
+ *
+ * @subpackage Tests\Endpoints
+ * @group Integration
+ */
 class CreateIntegrationTest extends \PHPUnit\Framework\TestCase
 {
     public function testCreatePassingId()

--- a/tests/Endpoints/CreateIntegrationTest.php
+++ b/tests/Endpoints/CreateIntegrationTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Elasticsearch PHP client
+ *
+ * @link      https://github.com/elastic/elasticsearch-php/
+ * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
+ *
+ * Licensed to Elasticsearch B.V under one or more agreements.
+ * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
+ * the GNU Lesser General Public License, Version 2.1, at your option.
+ * See the LICENSE file in the project root for more information.
+ */
+
+namespace OpenSearch\Tests\Endpoints;
+
+use OpenSearch\Tests\Utility;
+
+class CreateIntegrationTest extends \PHPUnit\Framework\TestCase
+{
+    public function testCreatePassingId()
+    {
+        // Arrange
+        $expectedIndex = 'movies';
+        $expectedType = '_doc';
+        $expectedResult = 'created';
+        $expectedId = 100;
+
+        $client = Utility::getClient();
+
+        // Act
+        $result = $client->create([
+            'index' => $expectedIndex,
+            'id' => $expectedId,
+            'body' => [
+                'title' => 'Remember the Titans',
+                'director' => 'Boaz Yakin',
+                'year' => 2000
+            ]
+        ]);
+
+        // Assert
+        $this->assertEquals($expectedIndex, $result['_index']);
+        $this->assertEquals($expectedType, $result['_type']);
+        $this->assertEquals($expectedResult, $result['result']);
+        $this->assertEquals($expectedId, $result['_id']);
+    }
+
+    public function testCreateWithoutPassId()
+    {
+        // Arrange
+        $expectedIndex = 'movies';
+        $expectedType = '_doc';
+        $expectedResult = 'created';
+
+        $client = Utility::getClient();
+
+        // Act
+        $result = $client->create([
+            'index' => $expectedIndex,
+            'body' => [
+                'title' => 'Remember the Titans',
+                'director' => 'Boaz Yakin',
+                'year' => 2000
+            ]
+        ]);
+
+        // Assert
+        $this->assertEquals($expectedIndex, $result['_index']);
+        $this->assertEquals($expectedType, $result['_type']);
+        $this->assertEquals($expectedResult, $result['result']);
+        $this->assertNotEmpty($result['_id']);
+    }
+}

--- a/tests/Endpoints/CreateIntegrationTest.php
+++ b/tests/Endpoints/CreateIntegrationTest.php
@@ -35,7 +35,6 @@ class CreateIntegrationTest extends \PHPUnit\Framework\TestCase
     {
         // Arrange
         $expectedIndex = 'movies';
-        $expectedType = '_doc';
         $expectedResult = 'created';
         $expectedId = 100;
 
@@ -54,7 +53,6 @@ class CreateIntegrationTest extends \PHPUnit\Framework\TestCase
 
         // Assert
         $this->assertEquals($expectedIndex, $result['_index']);
-        $this->assertEquals($expectedType, $result['_type']);
         $this->assertEquals($expectedResult, $result['result']);
         $this->assertEquals($expectedId, $result['_id']);
     }
@@ -63,7 +61,6 @@ class CreateIntegrationTest extends \PHPUnit\Framework\TestCase
     {
         // Arrange
         $expectedIndex = 'movies';
-        $expectedType = '_doc';
         $expectedResult = 'created';
 
         $client = Utility::getClient();
@@ -80,7 +77,6 @@ class CreateIntegrationTest extends \PHPUnit\Framework\TestCase
 
         // Assert
         $this->assertEquals($expectedIndex, $result['_index']);
-        $this->assertEquals($expectedType, $result['_type']);
         $this->assertEquals($expectedResult, $result['result']);
         $this->assertNotEmpty($result['_id']);
     }

--- a/tests/Endpoints/CreateTest.php
+++ b/tests/Endpoints/CreateTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Elasticsearch PHP client
+ *
+ * @link      https://github.com/elastic/elasticsearch-php/
+ * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
+ *
+ * Licensed to Elasticsearch B.V under one or more agreements.
+ * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
+ * the GNU Lesser General Public License, Version 2.1, at your option.
+ * See the LICENSE file in the project root for more information.
+ */
+
+namespace OpenSearch\Tests\Endpoints;
+
+use OpenSearch\Common\Exceptions\RuntimeException;
+use OpenSearch\Endpoints\Create;
+
+class CreateTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var Create */
+    private $instance;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        // Instance
+        $this->instance = new Create();
+    }
+
+    public function testGetURIWhenIndexAndIdAreDefined(): void
+    {
+        // Arrange
+        $expected = '/index/_create/10';
+
+        $this->instance->setIndex('index');
+        $this->instance->setId(10);
+
+        // Act
+        $result = $this->instance->getURI();
+
+        // Assert
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testGetURIWhenIndexIsDefinedAndIdIsNotDefined(): void
+    {
+        // Arrange
+        $expected = '/index/_doc';
+
+        $this->instance->setIndex('index');
+
+        // Act
+        $result = $this->instance->getURI();
+
+        // Assert
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testGetURIWhenIndexIsNotDefined(): void
+    {
+        // Arrange
+        $expected = RuntimeException::class;
+        $expectedMessage = 'index is required for create';
+
+        // Assert
+        $this->expectException($expected);
+        $this->expectExceptionMessage($expectedMessage);
+
+        // Act
+        $this->instance->getURI();
+    }
+
+    public function testGetMethodWhenIdIsDefined(): void
+    {
+        // Arrange
+        $expected = 'PUT';
+
+        $this->instance->setId(10);
+
+        // Act
+        $result = $this->instance->getMethod();
+
+        // Assert
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testGetMethodWhenIdIsNotDefined(): void
+    {
+        // Arrange
+        $expected = 'POST';
+
+        // Act
+        $result = $this->instance->getMethod();
+
+        // Assert
+        $this->assertEquals($expected, $result);
+    }
+}


### PR DESCRIPTION
### Description
Allow create without id (will be generate by opensearch)

### Issues Resolved
- #70

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
