### PR TITLE
Unset port for SigV4Handler, fixes #84

### DIFF
--- a/src/OpenSearch/Handlers/SigV4Handler.php
+++ b/src/OpenSearch/Handlers/SigV4Handler.php
@@ -103,13 +103,17 @@ class SigV4Handler
             $body = null;
         }
 
+        // Reset the explicit port in the URL
+        $client = $originalRequest['client'];
+        unset($client['curl'][CURLOPT_PORT]);
+
         $ringRequest = [
             'http_method' => $request->getMethod(),
             'scheme' => $uri->getScheme(),
             'uri' => $uri->getPath(),
             'body' => $body,
             'headers' => $request->getHeaders(),
-            'client' => $originalRequest['client']
+            'client' => $client
         ];
         if ($uri->getQuery()) {
             $ringRequest['query_string'] = $uri->getQuery();


### PR DESCRIPTION
Signed-off-by: Soner Sayakci <s.sayakci@shopware.com>

### Description

By passing the `client` in https://github.com/opensearch-project/opensearch-php/pull/76 we made the port explicit in the SigV4Handler. I just removed that single parameter from the client array

The root cause is https://github.com/opensearch-project/opensearch-php/blob/main/src/OpenSearch/Connections/Connection.php#L141 that we set any port to 443. We should make it explicit in the next major version that people has to write http://localhost:9200 for the Host instead of http://localhost


### Issues Resolved
#86

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
