### PR TITLE
Check if root cause exists in $error['error']

### DIFF
--- a/src/OpenSearch/Connections/Connection.php
+++ b/src/OpenSearch/Connections/Connection.php
@@ -748,7 +748,7 @@ class Connection implements ConnectionInterface
             // 2.0 structured exceptions
             if (is_array($error['error']) && array_key_exists('reason', $error['error']) === true) {
                 // Try to use root cause first (only grabs the first root cause)
-                $root = $error['error']['root_cause'];
+                $root = array_key_exists('root_cause',$error['error']) ? $error['error']['root_cause']:'';
                 if (isset($root) && isset($root[0])) {
                     $cause = $root[0]['reason'];
                     $type = $root[0]['type'];


### PR DESCRIPTION
### Description
Opensearch failed with missing array key root_cause in Connection.php

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
