### PR TITLE
updated search function documentation

### DIFF
--- a/docs/build/OpenSearch/Client.asciidoc
+++ b/docs/build/OpenSearch/Client.asciidoc
@@ -501,7 +501,7 @@ $params['index']                         = (list) A comma-separated list of inde
 $params['search_type']                   = (enum) Search operation type (Options = query_then_fetch,query_and_fetch,dfs_query_then_fetch,dfs_query_and_fetch)
 $params['max_concurrent_searches']       = (number) Controls the maximum number of concurrent searches the multi search api will execute
 $params['typed_keys']                    = (boolean) Specify whether aggregation and suggester names should be prefixed by their respective types in the response
-$params['pre_filter_shard_size']         = (number) A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint.
+$params['pre_filter_shard_size']         = (number) A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint.
 */
 ----
 ****
@@ -699,6 +699,24 @@ $params['_source']                       = (list) True or false to return the _s
 $params['_source_excludes']              = (list) A list of fields to exclude from the returned _source field
 $params['_source_includes']              = (list) A list of fields to extract and return from the _source field
 $params['terminate_after']               = (number) The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.
+$params['stats']                         = (list) Specific 'tag' of the request for logging and statistical purposes
+$params['suggest_field']                 = (string) Specify which field to use for suggestions
+$params['suggest_mode']                  = (enum) Specify suggest mode (Options = missing,popular,always) (Default = missing)
+$params['suggest_size']                  = (number) How many suggestions to return in response
+$params['suggest_text']                  = (string) The source text for which the suggestions should be returned
+$params['timeout']                       = (time) Explicit operation timeout
+$params['track_scores']                  = (boolean) Whether to calculate and return scores even if they are not used for sorting
+$params['track_total_hits']              = (boolean) Indicate if the number of documents that match the query should be tracked
+$params['allow_partial_search_results']  = (boolean) Indicate if an error should be returned if there is a partial search failure or timeout (Default = true)
+$params['typed_keys']                    = (boolean) Specify whether aggregation and suggester names should be prefixed by their respective types in the response
+$params['version']                       = (boolean) Specify whether to return document version as part of a hit
+$params['seq_no_primary_term']           = (boolean) Specify whether to return sequence number and primary term of the last modification of each hit
+$params['request_cache']                 = (boolean) Specify if request cache should be used for this request or not, defaults to index level setting
+$params['batched_reduce_size']           = (number) The number of shard results that should be reduced at once on the coordinating node. This value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large. (Default = 512)
+$params['max_concurrent_shard_requests'] = (number) The number of concurrent shard requests per node this search executes concurrently. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests (Default = 5)
+$params['pre_filter_shard_size']         = (number) A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint.
+$params['rest_total_hits_as_int']        = (boolean) Indicates whether hits.total should be rendered as an integer or an object in the rest search response (Default = false)
+$params['body']                          = (array) The search definition using the Query DSL
 */
 ----
 ****
@@ -1201,5 +1219,4 @@ Catchall for registered namespaces
 */
 ----
 ****
-
 


### PR DESCRIPTION
### Description
search(array $params = []) function does not show the following. so I added it

```php
/*
* $params['stats']                         = (list) Specific 'tag' of the request for logging and statistical purposes
     * $params['suggest_field']                 = (string) Specify which field to use for suggestions
     * $params['suggest_mode']                  = (enum) Specify suggest mode (Options = missing,popular,always) (Default = missing)
     * $params['suggest_size']                  = (number) How many suggestions to return in response
     * $params['suggest_text']                  = (string) The source text for which the suggestions should be returned
     * $params['timeout']                       = (time) Explicit operation timeout
     * $params['track_scores']                  = (boolean) Whether to calculate and return scores even if they are not used for sorting
     * $params['track_total_hits']              = (boolean) Indicate if the number of documents that match the query should be tracked
     * $params['allow_partial_search_results']  = (boolean) Indicate if an error should be returned if there is a partial search failure or timeout (Default = true)
     * $params['typed_keys']                    = (boolean) Specify whether aggregation and suggester names should be prefixed by their respective types in the response
     * $params['version']                       = (boolean) Specify whether to return document version as part of a hit
     * $params['seq_no_primary_term']           = (boolean) Specify whether to return sequence number and primary term of the last modification of each hit
     * $params['request_cache']                 = (boolean) Specify if request cache should be used for this request or not, defaults to index level setting
     * $params['batched_reduce_size']           = (number) The number of shard results that should be reduced at once on the coordinating node. This value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large. (Default = 512)
     * $params['max_concurrent_shard_requests'] = (number) The number of concurrent shard requests per node this search executes concurrently. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests (Default = 5)
     * $params['pre_filter_shard_size']         = (number) A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint.
     * $params['rest_total_hits_as_int']        = (boolean) Indicates whether hits.total should be rendered as an integer or an object in the rest search response (Default = false)
     * $params['body']
     * @param array $params Associative array of parameters
     * @return array
     * 
     * */
    
```

### Issues Resolved
#101
