### PR TITLE
Add includePortInHostHeader in fromConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added PHP 8.2 to the CI
 - Github workflow for changelog verification ([#92](https://github.com/opensearch-project/opensearch-php/pull/92))
 - Added class docs generator ([#96](https://github.com/opensearch-project/opensearch-php/pull/96))
-- Added optional `includePortInHostHeader` option to `ClientBuilder::fromConfig` ([#118](https://github.com/opensearch-project/opensearch-php/pull/118))
+- Added `includePortInHostHeader` option to `ClientBuilder::fromConfig` ([#118](https://github.com/opensearch-project/opensearch-php/pull/118))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added PHP 8.2 to the CI
 - Github workflow for changelog verification ([#92](https://github.com/opensearch-project/opensearch-php/pull/92))
 - Added class docs generator ([#96](https://github.com/opensearch-project/opensearch-php/pull/96))
+- Added optional `includePortInHostHeader` option to `ClientBuilder::fromConfig` ([#118](https://github.com/opensearch-project/opensearch-php/pull/118))
 
 ### Changed
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -208,7 +208,7 @@ $client = (new \OpenSearch\ClientBuilder())
 ```
 ## Disabling Port Modification
 
-To prevent port modifications, pass an `includePortInHostHeader` option into `ClientBuilder::fromConfig`.
+To prevent port modifications, include the `includePortInHostHeader` option into `ClientBuilder::fromConfig`.
 This will ensure that the port from the supplied URL is unchanged. 
 
 The following example will force port `9100` usage.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -206,3 +206,26 @@ $client = (new \OpenSearch\ClientBuilder())
     ->setRetries(3)
     ->build();
 ```
+## Disabling Port Modification
+
+To prevent port modifications, pass an `includePortInHostHeader` option into `ClientBuilder::fromConfig`.
+This will ensure that the port from the supplied URL is unchanged. 
+
+The following example will force port `9100` usage.
+
+```php
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+
+$config = [
+    'Hosts' => ['https://localhost:9100'],
+    'BasicAuthentication' => [username: 'admin', password: 'admin'],
+    'SSLVerification' => false,
+    'includePortInHostHeader' => true, // forces port from Hosts URL
+];
+
+$client = \OpenSearch\ClientBuilder::fromConfig($config);
+
+...
+```

--- a/src/OpenSearch/ClientBuilder.php
+++ b/src/OpenSearch/ClientBuilder.php
@@ -47,6 +47,8 @@ use ReflectionClass;
 
 class ClientBuilder
 {
+    public const ALLOWED_METHODS_FROM_CONFIG = ['includePortInHostHeader'];
+
     /**
      * @var Transport|null
      */
@@ -212,7 +214,7 @@ class ClientBuilder
     {
         $builder = new self();
         foreach ($config as $key => $value) {
-            $method = "set$key";
+            $method = in_array($key, self::ALLOWED_METHODS_FROM_CONFIG, true) ? $key : "set$key";
             $reflection = new ReflectionClass($builder);
             if ($reflection->hasMethod($method)) {
                 $func = $reflection->getMethod($method);

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -208,4 +208,31 @@ class ClientBuilderTest extends TestCase
             $this->assertNotContains('application/vnd.elasticsearch+json;compatible-with=7', $request['request']['headers']['Accept']);
         }
     }
+
+    public function testFromConfigWithIncludePortInHostHeader()
+    {
+        $url = 'localhost:1234';
+        $config = [
+            'hosts' => [$url],
+            'includePortInHostHeader' => true,
+            'connectionParams' => [
+                'client' => [
+                    'verbose' => true
+                ]
+            ],
+        ];
+
+        $client = ClientBuilder::fromConfig($config);
+
+        $this->assertInstanceOf(Client::class, $client);
+
+        try {
+            $client->info();
+            $this->assertTrue(false, 'Exception was not thrown!');
+        } catch (OpenSearchException $e) {
+            $request = $client->transport->getLastConnection()->getLastRequestInfo();
+            $this->assertTrue(isset($request['request']['headers']['Host'][0]));
+            $this->assertEquals($url, $request['request']['headers']['Host'][0]);
+        }
+    }
 }


### PR DESCRIPTION
### Description
This Pull Request adds a new optional configuration `includePortInHostHeader` to the `\OpenSearch\ClientBuilder::fromConfig()`. By default, it is not set. 

Passing  `includePortInHostHeader` into `\OpenSearch\ClientBuilder::fromConfig()` forces the Opensearch Client Url Port to be used from the configured client url.

### Issues Resolved
Closes [Don't modify the client port use](https://github.com/opensearch-project/opensearch-php/issues/86)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
