### PR TITLE
Add refresh search analyzers api endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added class docs generator ([#96](https://github.com/opensearch-project/opensearch-php/pull/96))
 - Added support for Amazon OpenSearch Serverless SigV4 signing ([#119](https://github.com/opensearch-project/opensearch-php/pull/119))
 - Added `includePortInHostHeader` option to `ClientBuilder::fromConfig` ([#118](https://github.com/opensearch-project/opensearch-php/pull/118))
+- Added the `RefreshSearchAnalyzers` endpoint ([[#152](https://github.com/opensearch-project/opensearch-php/issues/152)) 
 
 ### Changed
 

--- a/src/OpenSearch/Endpoints/Indices/RefreshSearchAnalyzers.php
+++ b/src/OpenSearch/Endpoints/Indices/RefreshSearchAnalyzers.php
@@ -33,7 +33,7 @@ class RefreshSearchAnalyzers extends AbstractEndpoint
         if (isset($index)) {
             return "/_plugins/_refresh_search_analyzers/$index";
         }
-        throw new RuntimeException('Missing parameter for the endpoint indices.refresh_search_analyzers');
+        throw new RuntimeException('Missing index parameter for the endpoint indices.refresh_search_analyzers');
     }
 
     public function getParamWhitelist(): array

--- a/src/OpenSearch/Endpoints/Indices/RefreshSearchAnalyzers.php
+++ b/src/OpenSearch/Endpoints/Indices/RefreshSearchAnalyzers.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Elasticsearch PHP client
+ *
+ * @link      https://github.com/elastic/elasticsearch-php/
+ * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
+ *
+ * Licensed to Elasticsearch B.V under one or more agreements.
+ * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
+ * the GNU Lesser General Public License, Version 2.1, at your option.
+ * See the LICENSE file in the project root for more information.
+ */
+
+namespace OpenSearch\Endpoints\Indices;
+
+use OpenSearch\Common\Exceptions\RuntimeException;
+use OpenSearch\Endpoints\AbstractEndpoint;
+
+class RefreshSearchAnalyzers extends AbstractEndpoint
+{
+    public function getURI(): string
+    {
+        $index = $this->index ?? null;
+
+        if (isset($index)) {
+            return "/_plugins/_refresh_search_analyzers/$index";
+        }
+        throw new RuntimeException('Missing parameter for the endpoint indices.refresh_search_analyzers');
+    }
+
+    public function getParamWhitelist(): array
+    {
+        return [];
+    }
+
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
+}

--- a/src/OpenSearch/Namespaces/IndicesNamespace.php
+++ b/src/OpenSearch/Namespaces/IndicesNamespace.php
@@ -1183,7 +1183,7 @@ class IndicesNamespace extends AbstractNamespace
     {
         $index = $this->extractArgument($params, 'index');
 
-        $endpointBuilder = $this-endpoints;
+        $endpointBuilder = $this->endpoints;
         $endpoint = $endpointBuilder('Indices\RefreshSearchAnalyzers');
         $endpoint->setParams($params);
         $endpoint->setIndex($index);

--- a/src/OpenSearch/Namespaces/IndicesNamespace.php
+++ b/src/OpenSearch/Namespaces/IndicesNamespace.php
@@ -1174,6 +1174,23 @@ class IndicesNamespace extends AbstractNamespace
         return $this->performRequest($endpoint);
     }
     /**
+     * $params['index']              = (list) A comma-separated list of index names to refresh analyzers for
+     * 
+     * @param array $params Associative array of parameters
+     * @return array
+     */
+    public function refreshSearchAnalyzers(array $params = [])
+    {
+        $index = $this->extractArgument($params, 'index');
+
+        $endpointBuilder = $this-endpoints;
+        $endpoint = $endpointBuilder('Indices\RefreshSearchAnalyzers');
+        $endpoint->setParams($params);
+        $endpoint->setIndex($index);
+
+        return $this->performRequest($endpoint);
+    }
+    /**
      * $params['index']              = (list) A comma-separated list of index names to reload analyzers for
      * $params['ignore_unavailable'] = (boolean) Whether specified concrete indices should be ignored when unavailable (missing or closed)
      * $params['allow_no_indices']   = (boolean) Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)

--- a/tests/Endpoints/RefreshSearchAnalyzersTest.php
+++ b/tests/Endpoints/RefreshSearchAnalyzersTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Elasticsearch PHP client
+ *
+ * @link      https://github.com/elastic/elasticsearch-php/
+ * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
+ *
+ * Licensed to Elasticsearch B.V under one or more agreements.
+ * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
+ * the GNU Lesser General Public License, Version 2.1, at your option.
+ * See the LICENSE file in the project root for more information.
+ */
+
+namespace OpenSearch\Tests\Endpoints;
+
+use OpenSearch\Common\Exceptions\RuntimeException;
+use OpenSearch\Endpoints\Indices\RefreshSearchAnalyzers;
+
+class RefreshSearchAnalyzersTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var RefreshSearchAnalyzers */
+    private $instance;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        // Instance
+        $this->instance = new RefreshSearchAnalyzers();
+    }
+
+    public function testGetURIWhenIndexAndIdAreDefined(): void
+    {
+        // Arrange
+        $expected = '/_plugins/_refresh_search_analyzers/index';
+
+        $this->instance->setIndex('index');
+        $this->instance->setId(10);
+
+        // Act
+        $result = $this->instance->getURI();
+
+        // Assert
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testGetURIWhenIndexIsDefinedAndIdIsNotDefined(): void
+    {
+        // Arrange
+        $expected = '/_plugins/_refresh_search_analyzers/index';
+
+        $this->instance->setIndex('index');
+
+        // Act
+        $result = $this->instance->getURI();
+
+        // Assert
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testGetURIWhenIndexIsNotDefined(): void
+    {
+        // Arrange
+        $expected = RuntimeException::class;
+        $expectedMessage = 'Missing index parameter for the endpoint indices.refresh_search_analyzers';
+
+        // Assert
+        $this->expectException($expected);
+        $this->expectExceptionMessage($expectedMessage);
+
+        // Act
+        $this->instance->getURI();
+    }
+
+    public function testGetMethodWhenIdIsDefined(): void
+    {
+        // Arrange
+        $expected = 'POST';
+
+        $this->instance->setId(10);
+
+        // Act
+        $result = $this->instance->getMethod();
+
+        // Assert
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testGetMethodWhenIdIsNotDefined(): void
+    {
+        // Arrange
+        $expected = 'POST';
+
+        // Act
+        $result = $this->instance->getMethod();
+
+        // Assert
+        $this->assertEquals($expected, $result);
+    }
+}


### PR DESCRIPTION
### Description
Added the refresh search analyzers endpoint.

### Issues Resolved
https://github.com/opensearch-project/opensearch-php/issues/152

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
