### PR TITLE
Fixed bug in ClientBuilder where basic authentication is overridden by connection params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Updated backport helper version and add fix to backport workflow when tag is applied before closing PR ([#131](https://github.com/opensearch-project/opensearch-php/pull/131))
 - Fixed host urls with trailing slash in the url ([#130](https://github.com/opensearch-project/opensearch-php/pull/140))
 - Fixed point-in-time APIs ([#142](https://github.com/opensearch-project/opensearch-php/pull/142))
+- Fixed bug in ClientBuilder where basic authentication is overridden by connection params ([#160](https://github.com/opensearch-project/opensearch-php/pull/160))
 
 ### Security
 

--- a/src/OpenSearch/ClientBuilder.php
+++ b/src/OpenSearch/ClientBuilder.php
@@ -162,6 +162,11 @@ class ClientBuilder
     private $includePortInHostHeader = false;
 
     /**
+     * @var string|null
+     */
+    private $basicAuthentication = null;
+
+    /**
      * Create an instance of ClientBuilder
      */
     public static function create(): ClientBuilder
@@ -427,14 +432,7 @@ class ClientBuilder
      */
     public function setBasicAuthentication(string $username, string $password): ClientBuilder
     {
-        if (isset($this->connectionParams['client']['curl']) === false) {
-            $this->connectionParams['client']['curl'] = [];
-        }
-
-        $this->connectionParams['client']['curl'] += [
-            CURLOPT_HTTPAUTH => CURLAUTH_BASIC,
-            CURLOPT_USERPWD  => $username.':'.$password
-        ];
+        $this->basicAuthentication = $username.':'.$password;
 
         return $this;
     }
@@ -633,6 +631,17 @@ class ClientBuilder
         }
 
         $this->connectionParams['client']['port_in_header'] = $this->includePortInHostHeader;
+
+        if (! is_null($this->basicAuthentication)) {
+            if (isset($this->connectionParams['client']['curl']) === false) {
+                $this->connectionParams['client']['curl'] = [];
+            }
+
+            $this->connectionParams['client']['curl'] += [
+                CURLOPT_HTTPAUTH => CURLAUTH_BASIC,
+                CURLOPT_USERPWD  => $this->basicAuthentication
+            ];
+        }
 
         if (is_null($this->connectionFactory)) {
             // Make sure we are setting Content-Type and Accept (unless the user has explicitly

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -164,7 +164,7 @@ class ClientBuilderTest extends TestCase
     public function testFromConfigUsingBasicAuthentication()
     {
         $config = [
-            'basicAuthentication' => ["admin", "admin"],
+            'basicAuthentication' => ["foo", "bar"],
             'connectionParams' => [],
         ];
         $client = ClientBuilder::fromConfig($config);
@@ -179,7 +179,7 @@ class ClientBuilderTest extends TestCase
             $this->assertEquals(CURLAUTH_BASIC, $request['request']['client']['curl'][CURLOPT_HTTPAUTH]);
 
             $this->assertTrue(isset($request['request']['client']['curl'][CURLOPT_USERPWD]));
-            $this->assertEquals('admin:admin', $request['request']['client']['curl'][CURLOPT_USERPWD]);
+            $this->assertEquals('foo:bar', $request['request']['client']['curl'][CURLOPT_USERPWD]);
         }
     }
 

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -169,18 +169,7 @@ class ClientBuilderTest extends TestCase
         ];
         $client = ClientBuilder::fromConfig($config);
 
-        try {
-            $client->info();
-            $this->assertTrue(false, 'Exception was not thrown!');
-        } catch (OpenSearchException $e) {
-            $request = $client->transport->getLastConnection()->getLastRequestInfo();
-
-            $this->assertTrue(isset($request['request']['client']['curl'][CURLOPT_HTTPAUTH]));
-            $this->assertEquals(CURLAUTH_BASIC, $request['request']['client']['curl'][CURLOPT_HTTPAUTH]);
-
-            $this->assertTrue(isset($request['request']['client']['curl'][CURLOPT_USERPWD]));
-            $this->assertEquals('foo:bar', $request['request']['client']['curl'][CURLOPT_USERPWD]);
-        }
+        $this->assertEquals('foo:bar', $client->transport->getConnection()->getUserPass());
     }
 
     public function testCompatibilityHeaderDefaultIsOff()

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -161,6 +161,28 @@ class ClientBuilderTest extends TestCase
         );
     }
 
+    public function testFromConfigUsingBasicAuthentication()
+    {
+        $config = [
+            'basicAuthentication' => ["admin", "admin"],
+            'connectionParams' => [],
+        ];
+        $client = ClientBuilder::fromConfig($config);
+
+        try {
+            $client->info();
+            $this->assertTrue(false, 'Exception was not thrown!');
+        } catch (OpenSearchException $e) {
+            $request = $client->transport->getLastConnection()->getLastRequestInfo();
+
+            $this->assertTrue(isset($request['request']['client']['curl'][CURLOPT_HTTPAUTH]));
+            $this->assertEquals(CURLAUTH_BASIC, $request['request']['client']['curl'][CURLOPT_HTTPAUTH]);
+
+            $this->assertTrue(isset($request['request']['client']['curl'][CURLOPT_USERPWD]));
+            $this->assertEquals('admin:admin', $request['request']['client']['curl'][CURLOPT_USERPWD]);
+        }
+    }
+
     public function testCompatibilityHeaderDefaultIsOff()
     {
         $client = ClientBuilder::create()


### PR DESCRIPTION
### Description
This fixes a bug in ClientBuilder where basic authentication is overridden when first basic authentication then connection params is set.

### Issues Resolved

Fixes #159 
