### PR TITLE
Fix warning in Connection::tryDeserializeError()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed host urls with trailing slash in the url ([#130](https://github.com/opensearch-project/opensearch-php/pull/140))
 - Fixed point-in-time APIs ([#142](https://github.com/opensearch-project/opensearch-php/pull/142))
 - Fixed bug in ClientBuilder where basic authentication is overridden by connection params ([#160](https://github.com/opensearch-project/opensearch-php/pull/160))
+- Fixed PHP warning in `Connection::tryDeserializeError()` for some error responses ([#167](https://github.com/opensearch-project/opensearch-php/issues/167))
 
 ### Security
 

--- a/src/OpenSearch/Connections/Connection.php
+++ b/src/OpenSearch/Connections/Connection.php
@@ -748,8 +748,8 @@ class Connection implements ConnectionInterface
             // 2.0 structured exceptions
             if (is_array($error['error']) && array_key_exists('reason', $error['error']) === true) {
                 // Try to use root cause first (only grabs the first root cause)
-                $root = $error['error']['root_cause'];
-                if (isset($root) && isset($root[0])) {
+                $root = $error['error']['root_cause'] ?? NULL;
+                if (isset($root[0])) {
                     $cause = $root[0]['reason'];
                     $type = $root[0]['type'];
                 } else {

--- a/src/OpenSearch/Connections/Connection.php
+++ b/src/OpenSearch/Connections/Connection.php
@@ -748,14 +748,9 @@ class Connection implements ConnectionInterface
             // 2.0 structured exceptions
             if (is_array($error['error']) && array_key_exists('reason', $error['error']) === true) {
                 // Try to use root cause first (only grabs the first root cause)
-                $root = $error['error']['root_cause'] ?? NULL;
-                if (isset($root[0])) {
-                    $cause = $root[0]['reason'];
-                    $type = $root[0]['type'];
-                } else {
-                    $cause = $error['error']['reason'];
-                    $type = $error['error']['type'];
-                }
+                $info = $error['error']['root_cause'][0] ?? $error['error'];
+                $cause = $info['reason'];
+                $type = $info['type'];
                 // added json_encode to convert into a string
                 $original = new $errorClass(json_encode($response['body']), $response['status']);
 


### PR DESCRIPTION
### Description
Fixes code in `\OpenSearch\Connections\Connection::tryDeserializeError()` to properly check whether `$error['error']['root_cause']` exists before accessing it.

### Issues Resolved
Closes #167.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
