### PR TITLE
Implement model, model group and connector apis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added `includePortInHostHeader` option to `ClientBuilder::fromConfig` ([#118](https://github.com/opensearch-project/opensearch-php/pull/118))
 - Added the `RefreshSearchAnalyzers` endpoint ([[#152](https://github.com/opensearch-project/opensearch-php/issues/152))
 - Added support for `format` parameter to specify the sql response format ([#161](https://github.com/opensearch-project/opensearch-php/pull/161))
-- Implemented the Model, Model Group and Connector apis ([#170](https://github.com/opensearch-project/opensearch-php/pull/170))
+- Added ml commons model, model group and connector APIs ([#170](https://github.com/opensearch-project/opensearch-php/pull/170))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added class docs generator ([#96](https://github.com/opensearch-project/opensearch-php/pull/96))
 - Added support for Amazon OpenSearch Serverless SigV4 signing ([#119](https://github.com/opensearch-project/opensearch-php/pull/119))
 - Added `includePortInHostHeader` option to `ClientBuilder::fromConfig` ([#118](https://github.com/opensearch-project/opensearch-php/pull/118))
-- Added the `RefreshSearchAnalyzers` endpoint ([[#152](https://github.com/opensearch-project/opensearch-php/issues/152)) 
+- Added the `RefreshSearchAnalyzers` endpoint ([[#152](https://github.com/opensearch-project/opensearch-php/issues/152))
 - Added support for `format` parameter to specify the sql response format ([#161](https://github.com/opensearch-project/opensearch-php/pull/161))
+- Implemented the Model, Model Group and Connector apis ([#170](https://github.com/opensearch-project/opensearch-php/pull/170))
 
 ### Changed
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -24,7 +24,7 @@ class MyOpenSearchClass
 
     public function __construct()
     {
-        //simple Setup 
+        //simple Setup
         $this->client = OpenSearch\ClientBuilder::fromConfig([
             'hosts' => [
                 'https://localhost:9200'
@@ -66,7 +66,7 @@ class MyOpenSearchClass
         var_dump($this->client->info());
     }
 
-    // Create a document 
+    // Create a document
     public function create()
     {
         $time = time();
@@ -259,7 +259,7 @@ class MyOpenSearchClass
         ]);
         var_dump($docs['hits']['total']['value'] > 0);
     }
-    
+
     public function searchByPointInTime()
     {
         $result = $this->client->createPointInTime([
@@ -267,7 +267,7 @@ class MyOpenSearchClass
             'keep_alive' => '10m'
         ]);
         $pitId = $result['pit_id'];
-    
+
         // Get first page of results in Point-in-Time
         $result = $this->client->search([
             'body' => [
@@ -283,7 +283,7 @@ class MyOpenSearchClass
             ]
         ]);
         var_dump($result['hits']['total']['value'] > 0);
-        
+
         $last = end($result['hits']['hits']);
         $lastSort = $last['sort'] ?? null;
 
@@ -303,7 +303,7 @@ class MyOpenSearchClass
             ]
         ]);
         var_dump($result['hits']['total']['value'] > 0);
-        
+
         // Close Point-in-Time
         $result = $this->client->deletePointInTime([
             'body' => [
@@ -405,15 +405,15 @@ $client = (new \OpenSearch\ClientBuilder())
     ->setSigV4Region('us-east-2')
 
     ->setSigV4Service('es')
-    
+
     // Default credential provider.
     ->setSigV4CredentialProvider(true)
-    
+
     ->setSigV4CredentialProvider([
       'key' => 'awskeyid',
       'secret' => 'awssecretkey',
     ])
-    
+
     ->build();
 ```
 
@@ -426,15 +426,15 @@ $client = (new \OpenSearch\ClientBuilder())
     ->setSigV4Region('us-east-2')
 
     ->setSigV4Service('aoss')
-    
+
     // Default credential provider.
     ->setSigV4CredentialProvider(true)
-    
+
     ->setSigV4CredentialProvider([
       'key' => 'awskeyid',
       'secret' => 'awssecretkey',
     ])
-    
+
     ->build();
 ```
 
@@ -481,7 +481,7 @@ $client = (new \OpenSearch\ClientBuilder())
 ## Disabling Port Modification
 
 To prevent port modifications, include the `includePortInHostHeader` option into `ClientBuilder::fromConfig`.
-This will ensure that the port from the supplied URL is unchanged. 
+This will ensure that the port from the supplied URL is unchanged.
 
 The following example will force port `9100` usage.
 
@@ -500,4 +500,70 @@ $config = [
 $client = \OpenSearch\ClientBuilder::fromConfig($config);
 
 ...
+```
+## Machine Learning Example Usage
+
+This example assumes you are using the AWS managed OpenSearch
+service. See [The ML Commons documentation for more examples and further information.](https://github.com/opensearch-project/ml-commons/blob/main/docs/remote_inference_blueprints/openai_connector_embedding_blueprint.md)
+
+It walks through the process of setting up a model to generate
+vector embeddings from OpenAI.
+```php
+<?php
+
+# Register a model group.
+$modelGroupResponse = $client->ml()->registerModelGroup([
+  'body' => [
+    'name' => 'openai_model_group',
+    'description' => 'Group containing models for OpenAI',
+  ],
+]);
+
+# Create the connector.
+$connectorResponse = $client->ml()->createConnector([
+  'body' => [
+    'name' => "Open AI Embedding Connector",
+    'description' => "Creates a connector to Open AI's embedding endpoint",
+    'version' => 1,
+    'protocol' => 'http',
+    'parameters' => ['model' => 'text-embedding-ada-002'],
+    'credential' => [
+      "secretArn" => '<Your Secret ARN from AWS Secrets Manager>',
+      "roleArn" => '<Your IAM role ARN>',
+    ]
+    'actions' => [
+      [
+        'action_type' => 'predict',
+        'method' => 'POST',
+        'url' => 'https://api.openai.com/v1/embeddings',
+        'headers' => [
+          'Authorization': 'Bearer ${credential.secretArn.<Your Open AI Secret in Secrets Manager>}'
+        ],
+        'request_body' => "{ \"input\": \${parameters.input}, \"model\": \"\${parameters.model}\" }",
+        'pre_process_function' => "connector.pre_process.openai.embedding",
+        'post_process_function' => "connector.post_process.openai.embedding",
+      ],
+    ],
+  ],
+]);
+
+# Register the model.
+$registerModelResponse = $client->ml()->registerModel([
+  'body' => [
+    'name' => 'OpenAI embedding model',
+    'function_name' => 'remote',
+    'model_group_id' => $modelGroupResponse['model_group_id'],
+    'description' => 'Model for retrieving vector embeddings from OpenAI',
+    'connector_id' => $connectorResponse['connector_id'],
+  ],
+]);
+
+# Monitor the state of the register model task.
+$taskResponse = $client->ml()->getTask(['id' => $registerModelResponse['task_id']]);
+
+assert($taskResponse['state'] === 'COMPLETED');
+
+# Finally deploy the model. You will now be able to generate vector
+# embeddings from OpenSearch (via OpenAI).
+$client->ml()->deployModel(['id' => $taskResponse['model_id']]);
 ```

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -24,7 +24,7 @@ class MyOpenSearchClass
 
     public function __construct()
     {
-        //simple Setup
+        // Simple Setup
         $this->client = OpenSearch\ClientBuilder::fromConfig([
             'hosts' => [
                 'https://localhost:9200'
@@ -501,69 +501,7 @@ $client = \OpenSearch\ClientBuilder::fromConfig($config);
 
 ...
 ```
-## Machine Learning Example Usage
 
-This example assumes you are using the AWS managed OpenSearch
-service. See [The ML Commons documentation for more examples and further information.](https://github.com/opensearch-project/ml-commons/blob/main/docs/remote_inference_blueprints/openai_connector_embedding_blueprint.md)
+## Advanced Features
 
-It walks through the process of setting up a model to generate
-vector embeddings from OpenAI.
-```php
-<?php
-
-# Register a model group.
-$modelGroupResponse = $client->ml()->registerModelGroup([
-  'body' => [
-    'name' => 'openai_model_group',
-    'description' => 'Group containing models for OpenAI',
-  ],
-]);
-
-# Create the connector.
-$connectorResponse = $client->ml()->createConnector([
-  'body' => [
-    'name' => "Open AI Embedding Connector",
-    'description' => "Creates a connector to Open AI's embedding endpoint",
-    'version' => 1,
-    'protocol' => 'http',
-    'parameters' => ['model' => 'text-embedding-ada-002'],
-    'credential' => [
-      "secretArn" => '<Your Secret ARN from AWS Secrets Manager>',
-      "roleArn" => '<Your IAM role ARN>',
-    ]
-    'actions' => [
-      [
-        'action_type' => 'predict',
-        'method' => 'POST',
-        'url' => 'https://api.openai.com/v1/embeddings',
-        'headers' => [
-          'Authorization': 'Bearer ${credential.secretArn.<Your Open AI Secret in Secrets Manager>}'
-        ],
-        'request_body' => "{ \"input\": \${parameters.input}, \"model\": \"\${parameters.model}\" }",
-        'pre_process_function' => "connector.pre_process.openai.embedding",
-        'post_process_function' => "connector.post_process.openai.embedding",
-      ],
-    ],
-  ],
-]);
-
-# Register the model.
-$registerModelResponse = $client->ml()->registerModel([
-  'body' => [
-    'name' => 'OpenAI embedding model',
-    'function_name' => 'remote',
-    'model_group_id' => $modelGroupResponse['model_group_id'],
-    'description' => 'Model for retrieving vector embeddings from OpenAI',
-    'connector_id' => $connectorResponse['connector_id'],
-  ],
-]);
-
-# Monitor the state of the register model task.
-$taskResponse = $client->ml()->getTask(['id' => $registerModelResponse['task_id']]);
-
-assert($taskResponse['state'] === 'COMPLETED');
-
-# Finally deploy the model. You will now be able to generate vector
-# embeddings from OpenSearch (via OpenAI).
-$client->ml()->deployModel(['id' => $taskResponse['model_id']]);
-```
+* [ML Commons](guides/ml-commons.md)

--- a/guides/ml-commons.md
+++ b/guides/ml-commons.md
@@ -1,0 +1,71 @@
+# Machine Learning Example Usage
+
+Walks through the process of setting up a model to generate
+vector embeddings from OpenAI on AWS managed Opensearch.
+
+### Prerequisites
+
+* This example assumes you are using the AWS managed OpenSearch
+  service. See [The ml commons documentation](https://github.com/opensearch-project/ml-commons/blob/main/docs/remote_inference_blueprints/openai_connector_embedding_blueprint.md) for more examples and further information.
+* You will need an API key from OpenAI. [Sign up](https://platform.openai.com/signup)
+* The API key must be stored in [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/)
+
+```php
+<?php
+
+# Register a model group.
+$modelGroupResponse = $client->ml()->registerModelGroup([
+  'body' => [
+    'name' => 'openai_model_group',
+    'description' => 'Group containing models for OpenAI',
+  ],
+]);
+
+# Create the connector.
+$connectorResponse = $client->ml()->createConnector([
+  'body' => [
+    'name' => "Open AI Embedding Connector",
+    'description' => "Creates a connector to Open AI's embedding endpoint",
+    'version' => 1,
+    'protocol' => 'http',
+    'parameters' => ['model' => 'text-embedding-ada-002'],
+    'credential' => [
+      "secretArn" => '<Your Secret ARN from AWS Secrets Manager>',
+      "roleArn" => '<Your IAM role ARN>',
+    ]
+    'actions' => [
+      [
+        'action_type' => 'predict',
+        'method' => 'POST',
+        'url' => 'https://api.openai.com/v1/embeddings',
+        'headers' => [
+          'Authorization': 'Bearer ${credential.secretArn.<Your Open AI Secret in Secrets Manager>}'
+        ],
+        'request_body' => "{ \"input\": \${parameters.input}, \"model\": \"\${parameters.model}\" }",
+        'pre_process_function' => "connector.pre_process.openai.embedding",
+        'post_process_function' => "connector.post_process.openai.embedding",
+      ],
+    ],
+  ],
+]);
+
+# Register the model.
+$registerModelResponse = $client->ml()->registerModel([
+  'body' => [
+    'name' => 'OpenAI embedding model',
+    'function_name' => 'remote',
+    'model_group_id' => $modelGroupResponse['model_group_id'],
+    'description' => 'Model for retrieving vector embeddings from OpenAI',
+    'connector_id' => $connectorResponse['connector_id'],
+  ],
+]);
+
+# Monitor the state of the register model task.
+$taskResponse = $client->ml()->getTask(['id' => $registerModelResponse['task_id']]);
+
+assert($taskResponse['state'] === 'COMPLETED');
+
+# Finally deploy the model. You will now be able to generate vector
+# embeddings from OpenSearch (via OpenAI).
+$client->ml()->deployModel(['id' => $taskResponse['model_id']]);
+```

--- a/src/OpenSearch/Client.php
+++ b/src/OpenSearch/Client.php
@@ -29,6 +29,7 @@ use OpenSearch\Common\Exceptions\Missing404Exception;
 use OpenSearch\Common\Exceptions\TransportException;
 use OpenSearch\Endpoints\AbstractEndpoint;
 use OpenSearch\Namespaces\AbstractNamespace;
+use OpenSearch\Namespaces\MachineLearningNamespace;
 use OpenSearch\Namespaces\NamespaceBuilderInterface;
 use OpenSearch\Namespaces\BooleanRequestWrapper;
 use OpenSearch\Namespaces\CatNamespace;
@@ -154,6 +155,11 @@ class Client
     protected $sql;
 
     /**
+     * @var MachineLearningNamespace
+     */
+    protected $ml;
+
+    /**
      * Client constructor
      *
      * @param Transport                   $transport
@@ -179,6 +185,7 @@ class Client
         $this->security = new SecurityNamespace($transport, $endpoint);
         $this->ssl = new SslNamespace($transport, $endpoint);
         $this->sql = new SqlNamespace($transport, $endpoint);
+        $this->ml = new MachineLearningNamespace($transport, $endpoint);
 
         $this->registeredNamespaces = $registeredNamespaces;
     }
@@ -1346,6 +1353,11 @@ class Client
     public function sql(): SqlNamespace
     {
         return $this->sql;
+    }
+
+    public function ml(): MachineLearningNamespace
+    {
+      return $this->ml;
     }
 
     /**

--- a/src/OpenSearch/Endpoints/MachineLearning/Connectors/CreateConnector.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Connectors/CreateConnector.php
@@ -21,7 +21,6 @@ declare(strict_types=1);
 
 namespace OpenSearch\Endpoints\MachineLearning\Connectors;
 
-use OpenSearch\Common\Exceptions\RuntimeException;
 use OpenSearch\Endpoints\AbstractEndpoint;
 
 class CreateConnector extends AbstractEndpoint

--- a/src/OpenSearch/Endpoints/MachineLearning/Connectors/CreateConnector.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Connectors/CreateConnector.php
@@ -17,28 +17,27 @@ use OpenSearch\Endpoints\AbstractEndpoint;
 
 class CreateConnector extends AbstractEndpoint
 {
+    /**
+     * @return string[]
+     */
+    public function getParamWhitelist(): array
+    {
+        return [];
+    }
 
-  /**
-   * @return string[]
-   */
-  public function getParamWhitelist(): array
-  {
-    return [];
-  }
+    /**
+     * @return string
+     */
+    public function getURI(): string
+    {
+        return "/_plugins/_ml/connectors/_create";
+    }
 
-  /**
-   * @return string
-   */
-  public function getURI(): string
-  {
-    return "/_plugins/_ml/connectors/_create";
-  }
-
-  /**
-   * @return string
-   */
-  public function getMethod(): string
-  {
-    return 'POST';
-  }
+    /**
+     * @return string
+     */
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
 }

--- a/src/OpenSearch/Endpoints/MachineLearning/Connectors/CreateConnector.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Connectors/CreateConnector.php
@@ -3,20 +3,12 @@
 declare(strict_types=1);
 
 /**
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ *  Copyright OpenSearch Contributors
+ *   SPDX-License-Identifier: Apache-2.0
  *
- * Elasticsearch PHP client
- *
- * @link      https://github.com/elastic/elasticsearch-php/
- * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
- * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
- * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
- *
- * Licensed to Elasticsearch B.V under one or more agreements.
- * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
- * the GNU Lesser General Public License, Version 2.1, at your option.
- * See the LICENSE file in the project root for more information.
+ *   The OpenSearch Contributors require contributions made to
+ *   this file be licensed under the Apache-2.0 license or a
+ *   compatible open source license.
  */
 
 namespace OpenSearch\Endpoints\MachineLearning\Connectors;

--- a/src/OpenSearch/Endpoints/MachineLearning/Connectors/CreateConnector.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Connectors/CreateConnector.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Elasticsearch PHP client
+ *
+ * @link      https://github.com/elastic/elasticsearch-php/
+ * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
+ *
+ * Licensed to Elasticsearch B.V under one or more agreements.
+ * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
+ * the GNU Lesser General Public License, Version 2.1, at your option.
+ * See the LICENSE file in the project root for more information.
+ */
+
+namespace OpenSearch\Endpoints\MachineLearning\Connectors;
+
+use OpenSearch\Common\Exceptions\RuntimeException;
+use OpenSearch\Endpoints\AbstractEndpoint;
+
+class CreateConnector extends AbstractEndpoint
+{
+
+  /**
+   * @return string[]
+   */
+  public function getParamWhitelist(): array
+  {
+    return [];
+  }
+
+  /**
+   * @return string
+   */
+  public function getURI(): string
+  {
+    return "/_plugins/_ml/connectors/_create";
+  }
+
+  /**
+   * @return string
+   */
+  public function getMethod(): string
+  {
+    return 'POST';
+  }
+}

--- a/src/OpenSearch/Endpoints/MachineLearning/Connectors/DeleteConnector.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Connectors/DeleteConnector.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Elasticsearch PHP client
+ *
+ * @link      https://github.com/elastic/elasticsearch-php/
+ * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
+ *
+ * Licensed to Elasticsearch B.V under one or more agreements.
+ * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
+ * the GNU Lesser General Public License, Version 2.1, at your option.
+ * See the LICENSE file in the project root for more information.
+ */
+
+namespace OpenSearch\Endpoints\MachineLearning\Connectors;
+
+use OpenSearch\Common\Exceptions\RuntimeException;
+use OpenSearch\Endpoints\AbstractEndpoint;
+
+class DeleteConnector extends AbstractEndpoint
+{
+
+  /**
+   * @return string[]
+   */
+  public function getParamWhitelist(): array
+  {
+    return [];
+  }
+
+  /**
+   * @return string
+   */
+  public function getURI(): string
+  {
+    if ($this->id) {
+      return "/_plugins/_ml/connectors/$this->id";
+    }
+
+    throw new RuntimeException(
+      'id is required for delete'
+    );
+
+  }
+
+  /**
+   * @return string
+   */
+  public function getMethod(): string
+  {
+    return 'DELETE';
+  }
+}

--- a/src/OpenSearch/Endpoints/MachineLearning/Connectors/DeleteConnector.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Connectors/DeleteConnector.php
@@ -18,35 +18,34 @@ use OpenSearch\Endpoints\AbstractEndpoint;
 
 class DeleteConnector extends AbstractEndpoint
 {
-
-  /**
-   * @return string[]
-   */
-  public function getParamWhitelist(): array
-  {
-    return [];
-  }
-
-  /**
-   * @return string
-   */
-  public function getURI(): string
-  {
-    if ($this->id) {
-      return "/_plugins/_ml/connectors/$this->id";
+    /**
+     * @return string[]
+     */
+    public function getParamWhitelist(): array
+    {
+        return [];
     }
 
-    throw new RuntimeException(
-      'id is required for delete'
-    );
+    /**
+     * @return string
+     */
+    public function getURI(): string
+    {
+        if ($this->id) {
+            return "/_plugins/_ml/connectors/$this->id";
+        }
 
-  }
+        throw new RuntimeException(
+            'id is required for delete'
+        );
 
-  /**
-   * @return string
-   */
-  public function getMethod(): string
-  {
-    return 'DELETE';
-  }
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethod(): string
+    {
+        return 'DELETE';
+    }
 }

--- a/src/OpenSearch/Endpoints/MachineLearning/Connectors/DeleteConnector.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Connectors/DeleteConnector.php
@@ -3,20 +3,12 @@
 declare(strict_types=1);
 
 /**
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ *  Copyright OpenSearch Contributors
+ *   SPDX-License-Identifier: Apache-2.0
  *
- * Elasticsearch PHP client
- *
- * @link      https://github.com/elastic/elasticsearch-php/
- * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
- * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
- * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
- *
- * Licensed to Elasticsearch B.V under one or more agreements.
- * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
- * the GNU Lesser General Public License, Version 2.1, at your option.
- * See the LICENSE file in the project root for more information.
+ *   The OpenSearch Contributors require contributions made to
+ *   this file be licensed under the Apache-2.0 license or a
+ *   compatible open source license.
  */
 
 namespace OpenSearch\Endpoints\MachineLearning\Connectors;

--- a/src/OpenSearch/Endpoints/MachineLearning/Connectors/GetConnector.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Connectors/GetConnector.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Elasticsearch PHP client
+ *
+ * @link      https://github.com/elastic/elasticsearch-php/
+ * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
+ *
+ * Licensed to Elasticsearch B.V under one or more agreements.
+ * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
+ * the GNU Lesser General Public License, Version 2.1, at your option.
+ * See the LICENSE file in the project root for more information.
+ */
+
+namespace OpenSearch\Endpoints\MachineLearning\Connectors;
+
+use OpenSearch\Common\Exceptions\RuntimeException;
+use OpenSearch\Endpoints\AbstractEndpoint;
+
+class GetConnector extends AbstractEndpoint
+{
+
+  /**
+   * @return string[]
+   */
+  public function getParamWhitelist(): array
+  {
+    return [];
+  }
+
+  /**
+   * @return string
+   */
+  public function getURI(): string
+  {
+    if ($this->id) {
+      return "/_plugins/_ml/connectors/$this->id";
+    }
+
+    throw new RuntimeException(
+      'id is required for get'
+    );
+
+  }
+
+  /**
+   * @return string
+   */
+  public function getMethod(): string
+  {
+    return 'GET';
+  }
+}

--- a/src/OpenSearch/Endpoints/MachineLearning/Connectors/GetConnector.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Connectors/GetConnector.php
@@ -18,35 +18,34 @@ use OpenSearch\Endpoints\AbstractEndpoint;
 
 class GetConnector extends AbstractEndpoint
 {
-
-  /**
-   * @return string[]
-   */
-  public function getParamWhitelist(): array
-  {
-    return [];
-  }
-
-  /**
-   * @return string
-   */
-  public function getURI(): string
-  {
-    if ($this->id) {
-      return "/_plugins/_ml/connectors/$this->id";
+    /**
+     * @return string[]
+     */
+    public function getParamWhitelist(): array
+    {
+        return [];
     }
 
-    throw new RuntimeException(
-      'id is required for get'
-    );
+    /**
+     * @return string
+     */
+    public function getURI(): string
+    {
+        if ($this->id) {
+            return "/_plugins/_ml/connectors/$this->id";
+        }
 
-  }
+        throw new RuntimeException(
+            'id is required for get'
+        );
 
-  /**
-   * @return string
-   */
-  public function getMethod(): string
-  {
-    return 'GET';
-  }
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
 }

--- a/src/OpenSearch/Endpoints/MachineLearning/Connectors/GetConnector.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Connectors/GetConnector.php
@@ -3,20 +3,12 @@
 declare(strict_types=1);
 
 /**
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ *  Copyright OpenSearch Contributors
+ *   SPDX-License-Identifier: Apache-2.0
  *
- * Elasticsearch PHP client
- *
- * @link      https://github.com/elastic/elasticsearch-php/
- * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
- * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
- * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
- *
- * Licensed to Elasticsearch B.V under one or more agreements.
- * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
- * the GNU Lesser General Public License, Version 2.1, at your option.
- * See the LICENSE file in the project root for more information.
+ *   The OpenSearch Contributors require contributions made to
+ *   this file be licensed under the Apache-2.0 license or a
+ *   compatible open source license.
  */
 
 namespace OpenSearch\Endpoints\MachineLearning\Connectors;

--- a/src/OpenSearch/Endpoints/MachineLearning/Connectors/GetConnectors.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Connectors/GetConnectors.php
@@ -17,28 +17,27 @@ use OpenSearch\Endpoints\AbstractEndpoint;
 
 class GetConnectors extends AbstractEndpoint
 {
+    /**
+     * @return string[]
+     */
+    public function getParamWhitelist(): array
+    {
+        return [];
+    }
 
-  /**
-   * @return string[]
-   */
-  public function getParamWhitelist(): array
-  {
-    return [];
-  }
+    /**
+     * @return string
+     */
+    public function getURI(): string
+    {
+        return '/_plugins/_ml/connectors/_search';
+    }
 
-  /**
-   * @return string
-   */
-  public function getURI(): string
-  {
-    return '/_plugins/_ml/connectors/_search';
-  }
-
-  /**
-   * @return string
-   */
-  public function getMethod(): string
-  {
-    return 'POST';
-  }
+    /**
+     * @return string
+     */
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
 }

--- a/src/OpenSearch/Endpoints/MachineLearning/Connectors/GetConnectors.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Connectors/GetConnectors.php
@@ -19,31 +19,35 @@ declare(strict_types=1);
  * See the LICENSE file in the project root for more information.
  */
 
-namespace OpenSearch\Endpoints\MachineLearning;
+namespace OpenSearch\Endpoints\MachineLearning\Connectors;
 
 use OpenSearch\Common\Exceptions\RuntimeException;
 use OpenSearch\Endpoints\AbstractEndpoint;
 
-class CreateConnector extends AbstractEndpoint
+class GetConnectors extends AbstractEndpoint
 {
+
   /**
    * @return string[]
    */
-  public function getParamWhitelist(): array {
-    return [];
+  public function getParamWhitelist(): array
+  {
+    return ['query', 'size'];
   }
 
   /**
    * @return string
    */
-  public function getURI(): string {
-    return "/_plugins/_ml/connectors/_create";
+  public function getURI(): string
+  {
+    return '/_plugins/_ml/connectors/_search';
   }
 
   /**
    * @return string
    */
-  public function getMethod(): string {
+  public function getMethod(): string
+  {
     return 'POST';
   }
 }

--- a/src/OpenSearch/Endpoints/MachineLearning/Connectors/GetConnectors.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Connectors/GetConnectors.php
@@ -3,20 +3,12 @@
 declare(strict_types=1);
 
 /**
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ *  Copyright OpenSearch Contributors
+ *   SPDX-License-Identifier: Apache-2.0
  *
- * Elasticsearch PHP client
- *
- * @link      https://github.com/elastic/elasticsearch-php/
- * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
- * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
- * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
- *
- * Licensed to Elasticsearch B.V under one or more agreements.
- * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
- * the GNU Lesser General Public License, Version 2.1, at your option.
- * See the LICENSE file in the project root for more information.
+ *   The OpenSearch Contributors require contributions made to
+ *   this file be licensed under the Apache-2.0 license or a
+ *   compatible open source license.
  */
 
 namespace OpenSearch\Endpoints\MachineLearning\Connectors;

--- a/src/OpenSearch/Endpoints/MachineLearning/CreateConnector.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/CreateConnector.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Elasticsearch PHP client
+ *
+ * @link      https://github.com/elastic/elasticsearch-php/
+ * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
+ *
+ * Licensed to Elasticsearch B.V under one or more agreements.
+ * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
+ * the GNU Lesser General Public License, Version 2.1, at your option.
+ * See the LICENSE file in the project root for more information.
+ */
+
+namespace OpenSearch\Endpoints\MachineLearning;
+
+use OpenSearch\Common\Exceptions\RuntimeException;
+use OpenSearch\Endpoints\AbstractEndpoint;
+
+class CreateConnector extends AbstractEndpoint
+{
+  /**
+   * @return string[]
+   */
+  public function getParamWhitelist(): array {
+    return [];
+  }
+
+  /**
+   * @return string
+   */
+  public function getURI(): string {
+    return "/_plugins/_ml/connectors/_create";
+  }
+
+  /**
+   * @return string
+   */
+  public function getMethod(): string {
+    return 'POST';
+  }
+}

--- a/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/DeleteModelGroup.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/DeleteModelGroup.php
@@ -3,20 +3,12 @@
 declare(strict_types=1);
 
 /**
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ *  Copyright OpenSearch Contributors
+ *   SPDX-License-Identifier: Apache-2.0
  *
- * Elasticsearch PHP client
- *
- * @link      https://github.com/elastic/elasticsearch-php/
- * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
- * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
- * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
- *
- * Licensed to Elasticsearch B.V under one or more agreements.
- * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
- * the GNU Lesser General Public License, Version 2.1, at your option.
- * See the LICENSE file in the project root for more information.
+ *   The OpenSearch Contributors require contributions made to
+ *   this file be licensed under the Apache-2.0 license or a
+ *   compatible open source license.
  */
 
 namespace OpenSearch\Endpoints\MachineLearning\ModelGroups;

--- a/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/DeleteModelGroup.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/DeleteModelGroup.php
@@ -19,11 +19,12 @@ declare(strict_types=1);
  * See the LICENSE file in the project root for more information.
  */
 
-namespace OpenSearch\Endpoints\MachineLearning\Connectors;
+namespace OpenSearch\Endpoints\MachineLearning\ModelGroups;
 
+use OpenSearch\Common\Exceptions\RuntimeException;
 use OpenSearch\Endpoints\AbstractEndpoint;
 
-class GetConnectors extends AbstractEndpoint
+class DeleteModelGroup extends AbstractEndpoint
 {
 
   /**
@@ -39,7 +40,14 @@ class GetConnectors extends AbstractEndpoint
    */
   public function getURI(): string
   {
-    return '/_plugins/_ml/connectors/_search';
+    if ($this->id) {
+      return "/_plugins/_ml/model_groups/$this->id";
+    }
+
+    throw new RuntimeException(
+      'id is required for delete'
+    );
+
   }
 
   /**
@@ -47,6 +55,6 @@ class GetConnectors extends AbstractEndpoint
    */
   public function getMethod(): string
   {
-    return 'POST';
+    return 'DELETE';
   }
 }

--- a/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/DeleteModelGroup.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/DeleteModelGroup.php
@@ -18,35 +18,34 @@ use OpenSearch\Endpoints\AbstractEndpoint;
 
 class DeleteModelGroup extends AbstractEndpoint
 {
-
-  /**
-   * @return string[]
-   */
-  public function getParamWhitelist(): array
-  {
-    return [];
-  }
-
-  /**
-   * @return string
-   */
-  public function getURI(): string
-  {
-    if ($this->id) {
-      return "/_plugins/_ml/model_groups/$this->id";
+    /**
+     * @return string[]
+     */
+    public function getParamWhitelist(): array
+    {
+        return [];
     }
 
-    throw new RuntimeException(
-      'id is required for delete'
-    );
+    /**
+     * @return string
+     */
+    public function getURI(): string
+    {
+        if ($this->id) {
+            return "/_plugins/_ml/model_groups/$this->id";
+        }
 
-  }
+        throw new RuntimeException(
+            'id is required for delete'
+        );
 
-  /**
-   * @return string
-   */
-  public function getMethod(): string
-  {
-    return 'DELETE';
-  }
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethod(): string
+    {
+        return 'DELETE';
+    }
 }

--- a/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/GetModelGroups.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/GetModelGroups.php
@@ -3,20 +3,12 @@
 declare(strict_types=1);
 
 /**
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ *  Copyright OpenSearch Contributors
+ *   SPDX-License-Identifier: Apache-2.0
  *
- * Elasticsearch PHP client
- *
- * @link      https://github.com/elastic/elasticsearch-php/
- * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
- * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
- * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
- *
- * Licensed to Elasticsearch B.V under one or more agreements.
- * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
- * the GNU Lesser General Public License, Version 2.1, at your option.
- * See the LICENSE file in the project root for more information.
+ *   The OpenSearch Contributors require contributions made to
+ *   this file be licensed under the Apache-2.0 license or a
+ *   compatible open source license.
  */
 
 namespace OpenSearch\Endpoints\MachineLearning\ModelGroups;

--- a/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/GetModelGroups.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/GetModelGroups.php
@@ -17,28 +17,27 @@ use OpenSearch\Endpoints\AbstractEndpoint;
 
 class GetModelGroups extends AbstractEndpoint
 {
+    /**
+     * @return string[]
+     */
+    public function getParamWhitelist(): array
+    {
+        return [];
+    }
 
-  /**
-   * @return string[]
-   */
-  public function getParamWhitelist(): array
-  {
-    return [];
-  }
+    /**
+     * @return string
+     */
+    public function getURI(): string
+    {
+        return '/_plugins/_ml/model_groups/_search';
+    }
 
-  /**
-   * @return string
-   */
-  public function getURI(): string
-  {
-    return '/_plugins/_ml/model_groups/_search';
-  }
-
-  /**
-   * @return string
-   */
-  public function getMethod(): string
-  {
-    return 'POST';
-  }
+    /**
+     * @return string
+     */
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
 }

--- a/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/GetModelGroups.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/GetModelGroups.php
@@ -19,11 +19,11 @@ declare(strict_types=1);
  * See the LICENSE file in the project root for more information.
  */
 
-namespace OpenSearch\Endpoints\MachineLearning\Connectors;
+namespace OpenSearch\Endpoints\MachineLearning\ModelGroups;
 
 use OpenSearch\Endpoints\AbstractEndpoint;
 
-class GetConnectors extends AbstractEndpoint
+class GetModelGroups extends AbstractEndpoint
 {
 
   /**
@@ -39,7 +39,7 @@ class GetConnectors extends AbstractEndpoint
    */
   public function getURI(): string
   {
-    return '/_plugins/_ml/connectors/_search';
+    return '/_plugins/_ml/model_groups/_search';
   }
 
   /**

--- a/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/RegisterModelGroup.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/RegisterModelGroup.php
@@ -3,20 +3,12 @@
 declare(strict_types=1);
 
 /**
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ *  Copyright OpenSearch Contributors
+ *   SPDX-License-Identifier: Apache-2.0
  *
- * Elasticsearch PHP client
- *
- * @link      https://github.com/elastic/elasticsearch-php/
- * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
- * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
- * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
- *
- * Licensed to Elasticsearch B.V under one or more agreements.
- * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
- * the GNU Lesser General Public License, Version 2.1, at your option.
- * See the LICENSE file in the project root for more information.
+ *   The OpenSearch Contributors require contributions made to
+ *   this file be licensed under the Apache-2.0 license or a
+ *   compatible open source license.
  */
 
 namespace OpenSearch\Endpoints\MachineLearning\ModelGroups;

--- a/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/RegisterModelGroup.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/RegisterModelGroup.php
@@ -19,11 +19,11 @@ declare(strict_types=1);
  * See the LICENSE file in the project root for more information.
  */
 
-namespace OpenSearch\Endpoints\MachineLearning\Connectors;
+namespace OpenSearch\Endpoints\MachineLearning\ModelGroups;
 
 use OpenSearch\Endpoints\AbstractEndpoint;
 
-class GetConnectors extends AbstractEndpoint
+class RegisterModelGroup extends AbstractEndpoint
 {
 
   /**
@@ -39,7 +39,7 @@ class GetConnectors extends AbstractEndpoint
    */
   public function getURI(): string
   {
-    return '/_plugins/_ml/connectors/_search';
+    return "/_plugins/_ml/model_groups/_register";
   }
 
   /**

--- a/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/RegisterModelGroup.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/RegisterModelGroup.php
@@ -17,28 +17,27 @@ use OpenSearch\Endpoints\AbstractEndpoint;
 
 class RegisterModelGroup extends AbstractEndpoint
 {
+    /**
+     * @return string[]
+     */
+    public function getParamWhitelist(): array
+    {
+        return [];
+    }
 
-  /**
-   * @return string[]
-   */
-  public function getParamWhitelist(): array
-  {
-    return [];
-  }
+    /**
+     * @return string
+     */
+    public function getURI(): string
+    {
+        return "/_plugins/_ml/model_groups/_register";
+    }
 
-  /**
-   * @return string
-   */
-  public function getURI(): string
-  {
-    return "/_plugins/_ml/model_groups/_register";
-  }
-
-  /**
-   * @return string
-   */
-  public function getMethod(): string
-  {
-    return 'POST';
-  }
+    /**
+     * @return string
+     */
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
 }

--- a/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/UpdateModelGroup.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/UpdateModelGroup.php
@@ -18,34 +18,33 @@ use OpenSearch\Endpoints\AbstractEndpoint;
 
 class UpdateModelGroup extends AbstractEndpoint
 {
-
-  /**
-   * @return string[]
-   */
-  public function getParamWhitelist(): array
-  {
-    return [];
-  }
-
-  /**
-   * @return string
-   */
-  public function getURI(): string
-  {
-    if ($this->id) {
-      return "/_plugins/_ml/model_groups/$this->id";
+    /**
+     * @return string[]
+     */
+    public function getParamWhitelist(): array
+    {
+        return [];
     }
 
-    throw new RuntimeException(
-      'id is required for update'
-    );
-  }
+    /**
+     * @return string
+     */
+    public function getURI(): string
+    {
+        if ($this->id) {
+            return "/_plugins/_ml/model_groups/$this->id";
+        }
 
-  /**
-   * @return string
-   */
-  public function getMethod(): string
-  {
-    return 'PUT';
-  }
+        throw new RuntimeException(
+            'id is required for update'
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethod(): string
+    {
+        return 'PUT';
+    }
 }

--- a/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/UpdateModelGroup.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/UpdateModelGroup.php
@@ -3,20 +3,12 @@
 declare(strict_types=1);
 
 /**
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ *  Copyright OpenSearch Contributors
+ *   SPDX-License-Identifier: Apache-2.0
  *
- * Elasticsearch PHP client
- *
- * @link      https://github.com/elastic/elasticsearch-php/
- * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
- * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
- * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
- *
- * Licensed to Elasticsearch B.V under one or more agreements.
- * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
- * the GNU Lesser General Public License, Version 2.1, at your option.
- * See the LICENSE file in the project root for more information.
+ *   The OpenSearch Contributors require contributions made to
+ *   this file be licensed under the Apache-2.0 license or a
+ *   compatible open source license.
  */
 
 namespace OpenSearch\Endpoints\MachineLearning\ModelGroups;

--- a/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/UpdateModelGroup.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/ModelGroups/UpdateModelGroup.php
@@ -19,11 +19,12 @@ declare(strict_types=1);
  * See the LICENSE file in the project root for more information.
  */
 
-namespace OpenSearch\Endpoints\MachineLearning\Connectors;
+namespace OpenSearch\Endpoints\MachineLearning\ModelGroups;
 
+use OpenSearch\Common\Exceptions\RuntimeException;
 use OpenSearch\Endpoints\AbstractEndpoint;
 
-class GetConnectors extends AbstractEndpoint
+class UpdateModelGroup extends AbstractEndpoint
 {
 
   /**
@@ -39,7 +40,13 @@ class GetConnectors extends AbstractEndpoint
    */
   public function getURI(): string
   {
-    return '/_plugins/_ml/connectors/_search';
+    if ($this->id) {
+      return "/_plugins/_ml/model_groups/$this->id";
+    }
+
+    throw new RuntimeException(
+      'id is required for update'
+    );
   }
 
   /**
@@ -47,6 +54,6 @@ class GetConnectors extends AbstractEndpoint
    */
   public function getMethod(): string
   {
-    return 'POST';
+    return 'PUT';
   }
 }

--- a/src/OpenSearch/Endpoints/MachineLearning/Models/DeleteModel.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Models/DeleteModel.php
@@ -3,20 +3,12 @@
 declare(strict_types=1);
 
 /**
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ *  Copyright OpenSearch Contributors
+ *   SPDX-License-Identifier: Apache-2.0
  *
- * Elasticsearch PHP client
- *
- * @link      https://github.com/elastic/elasticsearch-php/
- * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
- * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
- * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
- *
- * Licensed to Elasticsearch B.V under one or more agreements.
- * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
- * the GNU Lesser General Public License, Version 2.1, at your option.
- * See the LICENSE file in the project root for more information.
+ *   The OpenSearch Contributors require contributions made to
+ *   this file be licensed under the Apache-2.0 license or a
+ *   compatible open source license.
  */
 
 namespace OpenSearch\Endpoints\MachineLearning\Models;

--- a/src/OpenSearch/Endpoints/MachineLearning/Models/DeleteModel.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Models/DeleteModel.php
@@ -18,35 +18,34 @@ use OpenSearch\Endpoints\AbstractEndpoint;
 
 class DeleteModel extends AbstractEndpoint
 {
-
-  /**
-   * @return string[]
-   */
-  public function getParamWhitelist(): array
-  {
-    return [];
-  }
-
-  /**
-   * @return string
-   */
-  public function getURI(): string
-  {
-    if ($this->id) {
-      return "/_plugins/_ml/models/$this->id";
+    /**
+     * @return string[]
+     */
+    public function getParamWhitelist(): array
+    {
+        return [];
     }
 
-    throw new RuntimeException(
-      'id is required for delete'
-    );
+    /**
+     * @return string
+     */
+    public function getURI(): string
+    {
+        if ($this->id) {
+            return "/_plugins/_ml/models/$this->id";
+        }
 
-  }
+        throw new RuntimeException(
+            'id is required for delete'
+        );
 
-  /**
-   * @return string
-   */
-  public function getMethod(): string
-  {
-    return 'DELETE';
-  }
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethod(): string
+    {
+        return 'DELETE';
+    }
 }

--- a/src/OpenSearch/Endpoints/MachineLearning/Models/DeleteModel.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Models/DeleteModel.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Elasticsearch PHP client
+ *
+ * @link      https://github.com/elastic/elasticsearch-php/
+ * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
+ *
+ * Licensed to Elasticsearch B.V under one or more agreements.
+ * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
+ * the GNU Lesser General Public License, Version 2.1, at your option.
+ * See the LICENSE file in the project root for more information.
+ */
+
+namespace OpenSearch\Endpoints\MachineLearning\Models;
+
+use OpenSearch\Common\Exceptions\RuntimeException;
+use OpenSearch\Endpoints\AbstractEndpoint;
+
+class DeleteModel extends AbstractEndpoint
+{
+
+  /**
+   * @return string[]
+   */
+  public function getParamWhitelist(): array
+  {
+    return [];
+  }
+
+  /**
+   * @return string
+   */
+  public function getURI(): string
+  {
+    if ($this->id) {
+      return "/_plugins/_ml/models/$this->id";
+    }
+
+    throw new RuntimeException(
+      'id is required for delete'
+    );
+
+  }
+
+  /**
+   * @return string
+   */
+  public function getMethod(): string
+  {
+    return 'DELETE';
+  }
+}

--- a/src/OpenSearch/Endpoints/MachineLearning/Models/DeployModel.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Models/DeployModel.php
@@ -3,20 +3,12 @@
 declare(strict_types=1);
 
 /**
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ *  Copyright OpenSearch Contributors
+ *   SPDX-License-Identifier: Apache-2.0
  *
- * Elasticsearch PHP client
- *
- * @link      https://github.com/elastic/elasticsearch-php/
- * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
- * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
- * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
- *
- * Licensed to Elasticsearch B.V under one or more agreements.
- * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
- * the GNU Lesser General Public License, Version 2.1, at your option.
- * See the LICENSE file in the project root for more information.
+ *   The OpenSearch Contributors require contributions made to
+ *   this file be licensed under the Apache-2.0 license or a
+ *   compatible open source license.
  */
 
 namespace OpenSearch\Endpoints\MachineLearning\Models;

--- a/src/OpenSearch/Endpoints/MachineLearning/Models/DeployModel.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Models/DeployModel.php
@@ -18,35 +18,34 @@ use OpenSearch\Endpoints\AbstractEndpoint;
 
 class DeployModel extends AbstractEndpoint
 {
-
-  /**
-   * @return string[]
-   */
-  public function getParamWhitelist(): array
-  {
-    return [];
-  }
-
-  /**
-   * @return string
-   */
-  public function getURI(): string
-  {
-    if ($this->id) {
-      return "/_plugins/_ml/models/$this->id/_deploy";
+    /**
+     * @return string[]
+     */
+    public function getParamWhitelist(): array
+    {
+        return [];
     }
 
-    throw new RuntimeException(
-      'id is required for deploy'
-    );
+    /**
+     * @return string
+     */
+    public function getURI(): string
+    {
+        if ($this->id) {
+            return "/_plugins/_ml/models/$this->id/_deploy";
+        }
 
-  }
+        throw new RuntimeException(
+            'id is required for deploy'
+        );
 
-  /**
-   * @return string
-   */
-  public function getMethod(): string
-  {
-    return 'POST';
-  }
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
 }

--- a/src/OpenSearch/Endpoints/MachineLearning/Models/DeployModel.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Models/DeployModel.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Elasticsearch PHP client
+ *
+ * @link      https://github.com/elastic/elasticsearch-php/
+ * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
+ *
+ * Licensed to Elasticsearch B.V under one or more agreements.
+ * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
+ * the GNU Lesser General Public License, Version 2.1, at your option.
+ * See the LICENSE file in the project root for more information.
+ */
+
+namespace OpenSearch\Endpoints\MachineLearning\Models;
+
+use OpenSearch\Common\Exceptions\RuntimeException;
+use OpenSearch\Endpoints\AbstractEndpoint;
+
+class DeployModel extends AbstractEndpoint
+{
+
+  /**
+   * @return string[]
+   */
+  public function getParamWhitelist(): array
+  {
+    return [];
+  }
+
+  /**
+   * @return string
+   */
+  public function getURI(): string
+  {
+    if ($this->id) {
+      return "/_plugins/_ml/models/$this->id/_deploy";
+    }
+
+    throw new RuntimeException(
+      'id is required for deploy'
+    );
+
+  }
+
+  /**
+   * @return string
+   */
+  public function getMethod(): string
+  {
+    return 'POST';
+  }
+}

--- a/src/OpenSearch/Endpoints/MachineLearning/Models/GetModel.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Models/GetModel.php
@@ -3,20 +3,12 @@
 declare(strict_types=1);
 
 /**
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ *  Copyright OpenSearch Contributors
+ *   SPDX-License-Identifier: Apache-2.0
  *
- * Elasticsearch PHP client
- *
- * @link      https://github.com/elastic/elasticsearch-php/
- * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
- * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
- * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
- *
- * Licensed to Elasticsearch B.V under one or more agreements.
- * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
- * the GNU Lesser General Public License, Version 2.1, at your option.
- * See the LICENSE file in the project root for more information.
+ *   The OpenSearch Contributors require contributions made to
+ *   this file be licensed under the Apache-2.0 license or a
+ *   compatible open source license.
  */
 
 namespace OpenSearch\Endpoints\MachineLearning\Models;

--- a/src/OpenSearch/Endpoints/MachineLearning/Models/GetModel.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Models/GetModel.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Elasticsearch PHP client
+ *
+ * @link      https://github.com/elastic/elasticsearch-php/
+ * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
+ *
+ * Licensed to Elasticsearch B.V under one or more agreements.
+ * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
+ * the GNU Lesser General Public License, Version 2.1, at your option.
+ * See the LICENSE file in the project root for more information.
+ */
+
+namespace OpenSearch\Endpoints\MachineLearning\Models;
+
+use OpenSearch\Common\Exceptions\RuntimeException;
+use OpenSearch\Endpoints\AbstractEndpoint;
+
+class GetModel extends AbstractEndpoint
+{
+
+  /**
+   * @return string[]
+   */
+  public function getParamWhitelist(): array
+  {
+    return [];
+  }
+
+  /**
+   * @return string
+   */
+  public function getURI(): string
+  {
+    if ($this->id) {
+      return "/_plugins/_ml/models/$this->id";
+    }
+
+    throw new RuntimeException(
+      'id is required for get'
+    );
+
+  }
+
+  /**
+   * @return string
+   */
+  public function getMethod(): string
+  {
+    return 'GET';
+  }
+}

--- a/src/OpenSearch/Endpoints/MachineLearning/Models/GetModel.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Models/GetModel.php
@@ -18,35 +18,34 @@ use OpenSearch\Endpoints\AbstractEndpoint;
 
 class GetModel extends AbstractEndpoint
 {
-
-  /**
-   * @return string[]
-   */
-  public function getParamWhitelist(): array
-  {
-    return [];
-  }
-
-  /**
-   * @return string
-   */
-  public function getURI(): string
-  {
-    if ($this->id) {
-      return "/_plugins/_ml/models/$this->id";
+    /**
+     * @return string[]
+     */
+    public function getParamWhitelist(): array
+    {
+        return [];
     }
 
-    throw new RuntimeException(
-      'id is required for get'
-    );
+    /**
+     * @return string
+     */
+    public function getURI(): string
+    {
+        if ($this->id) {
+            return "/_plugins/_ml/models/$this->id";
+        }
 
-  }
+        throw new RuntimeException(
+            'id is required for get'
+        );
 
-  /**
-   * @return string
-   */
-  public function getMethod(): string
-  {
-    return 'GET';
-  }
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
 }

--- a/src/OpenSearch/Endpoints/MachineLearning/Models/GetModels.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Models/GetModels.php
@@ -17,28 +17,27 @@ use OpenSearch\Endpoints\AbstractEndpoint;
 
 class GetModels extends AbstractEndpoint
 {
+    /**
+     * @return string[]
+     */
+    public function getParamWhitelist(): array
+    {
+        return [];
+    }
 
-  /**
-   * @return string[]
-   */
-  public function getParamWhitelist(): array
-  {
-    return [];
-  }
+    /**
+     * @return string
+     */
+    public function getURI(): string
+    {
+        return "/_plugins/_ml/models/_search";
+    }
 
-  /**
-   * @return string
-   */
-  public function getURI(): string
-  {
-    return "/_plugins/_ml/models/_search";
-  }
-
-  /**
-   * @return string
-   */
-  public function getMethod(): string
-  {
-    return 'POST';
-  }
+    /**
+     * @return string
+     */
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
 }

--- a/src/OpenSearch/Endpoints/MachineLearning/Models/GetModels.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Models/GetModels.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ *  Copyright OpenSearch Contributors
+ *   SPDX-License-Identifier: Apache-2.0
+ *
+ *   The OpenSearch Contributors require contributions made to
+ *   this file be licensed under the Apache-2.0 license or a
+ *   compatible open source license.
+ */
+
+namespace OpenSearch\Endpoints\MachineLearning\Models;
+
+use OpenSearch\Endpoints\AbstractEndpoint;
+
+class GetModels extends AbstractEndpoint
+{
+
+  /**
+   * @return string[]
+   */
+  public function getParamWhitelist(): array
+  {
+    return [];
+  }
+
+  /**
+   * @return string
+   */
+  public function getURI(): string
+  {
+    return "/_plugins/_ml/models/_search";
+  }
+
+  /**
+   * @return string
+   */
+  public function getMethod(): string
+  {
+    return 'POST';
+  }
+}

--- a/src/OpenSearch/Endpoints/MachineLearning/Models/Predict.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Models/Predict.php
@@ -3,20 +3,12 @@
 declare(strict_types=1);
 
 /**
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ *  Copyright OpenSearch Contributors
+ *   SPDX-License-Identifier: Apache-2.0
  *
- * Elasticsearch PHP client
- *
- * @link      https://github.com/elastic/elasticsearch-php/
- * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
- * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
- * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
- *
- * Licensed to Elasticsearch B.V under one or more agreements.
- * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
- * the GNU Lesser General Public License, Version 2.1, at your option.
- * See the LICENSE file in the project root for more information.
+ *   The OpenSearch Contributors require contributions made to
+ *   this file be licensed under the Apache-2.0 license or a
+ *   compatible open source license.
  */
 
 namespace OpenSearch\Endpoints\MachineLearning\Models;

--- a/src/OpenSearch/Endpoints/MachineLearning/Models/Predict.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Models/Predict.php
@@ -18,35 +18,34 @@ use OpenSearch\Endpoints\AbstractEndpoint;
 
 class Predict extends AbstractEndpoint
 {
-
-  /**
-   * @return string[]
-   */
-  public function getParamWhitelist(): array
-  {
-    return [];
-  }
-
-  /**
-   * @return string
-   */
-  public function getURI(): string
-  {
-    if ($this->id) {
-      return "/_plugins/_ml/models/$this->id/_predict";
+    /**
+     * @return string[]
+     */
+    public function getParamWhitelist(): array
+    {
+        return [];
     }
 
-    throw new RuntimeException(
-      'id is required for predict'
-    );
+    /**
+     * @return string
+     */
+    public function getURI(): string
+    {
+        if ($this->id) {
+            return "/_plugins/_ml/models/$this->id/_predict";
+        }
 
-  }
+        throw new RuntimeException(
+            'id is required for predict'
+        );
 
-  /**
-   * @return string
-   */
-  public function getMethod(): string
-  {
-    return 'POST';
-  }
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
 }

--- a/src/OpenSearch/Endpoints/MachineLearning/Models/Predict.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Models/Predict.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Elasticsearch PHP client
+ *
+ * @link      https://github.com/elastic/elasticsearch-php/
+ * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
+ *
+ * Licensed to Elasticsearch B.V under one or more agreements.
+ * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
+ * the GNU Lesser General Public License, Version 2.1, at your option.
+ * See the LICENSE file in the project root for more information.
+ */
+
+namespace OpenSearch\Endpoints\MachineLearning\Models;
+
+use OpenSearch\Common\Exceptions\RuntimeException;
+use OpenSearch\Endpoints\AbstractEndpoint;
+
+class Predict extends AbstractEndpoint
+{
+
+  /**
+   * @return string[]
+   */
+  public function getParamWhitelist(): array
+  {
+    return [];
+  }
+
+  /**
+   * @return string
+   */
+  public function getURI(): string
+  {
+    if ($this->id) {
+      return "/_plugins/_ml/models/$this->id/_predict";
+    }
+
+    throw new RuntimeException(
+      'id is required for predict'
+    );
+
+  }
+
+  /**
+   * @return string
+   */
+  public function getMethod(): string
+  {
+    return 'POST';
+  }
+}

--- a/src/OpenSearch/Endpoints/MachineLearning/Models/RegisterModel.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Models/RegisterModel.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Elasticsearch PHP client
+ *
+ * @link      https://github.com/elastic/elasticsearch-php/
+ * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
+ *
+ * Licensed to Elasticsearch B.V under one or more agreements.
+ * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
+ * the GNU Lesser General Public License, Version 2.1, at your option.
+ * See the LICENSE file in the project root for more information.
+ */
+
+namespace OpenSearch\Endpoints\MachineLearning\Models;
+
+use OpenSearch\Endpoints\AbstractEndpoint;
+
+class RegisterModel extends AbstractEndpoint
+{
+
+  /**
+   * @return string[]
+   */
+  public function getParamWhitelist(): array
+  {
+    return [];
+  }
+
+  /**
+   * @return string
+   */
+  public function getURI(): string
+  {
+    return "/_plugins/_ml/models/_register";
+  }
+
+  /**
+   * @return string
+   */
+  public function getMethod(): string
+  {
+    return 'POST';
+  }
+}

--- a/src/OpenSearch/Endpoints/MachineLearning/Models/RegisterModel.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Models/RegisterModel.php
@@ -3,22 +3,13 @@
 declare(strict_types=1);
 
 /**
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ *  Copyright OpenSearch Contributors
+ *   SPDX-License-Identifier: Apache-2.0
  *
- * Elasticsearch PHP client
- *
- * @link      https://github.com/elastic/elasticsearch-php/
- * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
- * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
- * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
- *
- * Licensed to Elasticsearch B.V under one or more agreements.
- * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
- * the GNU Lesser General Public License, Version 2.1, at your option.
- * See the LICENSE file in the project root for more information.
+ *   The OpenSearch Contributors require contributions made to
+ *   this file be licensed under the Apache-2.0 license or a
+ *   compatible open source license.
  */
-
 namespace OpenSearch\Endpoints\MachineLearning\Models;
 
 use OpenSearch\Endpoints\AbstractEndpoint;

--- a/src/OpenSearch/Endpoints/MachineLearning/Models/RegisterModel.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Models/RegisterModel.php
@@ -10,34 +10,34 @@ declare(strict_types=1);
  *   this file be licensed under the Apache-2.0 license or a
  *   compatible open source license.
  */
+
 namespace OpenSearch\Endpoints\MachineLearning\Models;
 
 use OpenSearch\Endpoints\AbstractEndpoint;
 
 class RegisterModel extends AbstractEndpoint
 {
+    /**
+     * @return string[]
+     */
+    public function getParamWhitelist(): array
+    {
+        return [];
+    }
 
-  /**
-   * @return string[]
-   */
-  public function getParamWhitelist(): array
-  {
-    return [];
-  }
+    /**
+     * @return string
+     */
+    public function getURI(): string
+    {
+        return "/_plugins/_ml/models/_register";
+    }
 
-  /**
-   * @return string
-   */
-  public function getURI(): string
-  {
-    return "/_plugins/_ml/models/_register";
-  }
-
-  /**
-   * @return string
-   */
-  public function getMethod(): string
-  {
-    return 'POST';
-  }
+    /**
+     * @return string
+     */
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
 }

--- a/src/OpenSearch/Endpoints/MachineLearning/Models/UndeployModel.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Models/UndeployModel.php
@@ -18,35 +18,34 @@ use OpenSearch\Endpoints\AbstractEndpoint;
 
 class UndeployModel extends AbstractEndpoint
 {
-
-  /**
-   * @return string[]
-   */
-  public function getParamWhitelist(): array
-  {
-    return [];
-  }
-
-  /**
-   * @return string
-   */
-  public function getURI(): string
-  {
-    if ($this->id) {
-      return "/_plugins/_ml/models/$this->id/_undeploy";
+    /**
+     * @return string[]
+     */
+    public function getParamWhitelist(): array
+    {
+        return [];
     }
 
-    throw new RuntimeException(
-      'id is required for undeploy'
-    );
+    /**
+     * @return string
+     */
+    public function getURI(): string
+    {
+        if ($this->id) {
+            return "/_plugins/_ml/models/$this->id/_undeploy";
+        }
 
-  }
+        throw new RuntimeException(
+            'id is required for undeploy'
+        );
 
-  /**
-   * @return string
-   */
-  public function getMethod(): string
-  {
-    return 'POST';
-  }
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethod(): string
+    {
+        return 'POST';
+    }
 }

--- a/src/OpenSearch/Endpoints/MachineLearning/Models/UndeployModel.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Models/UndeployModel.php
@@ -3,20 +3,12 @@
 declare(strict_types=1);
 
 /**
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ *  Copyright OpenSearch Contributors
+ *   SPDX-License-Identifier: Apache-2.0
  *
- * Elasticsearch PHP client
- *
- * @link      https://github.com/elastic/elasticsearch-php/
- * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
- * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
- * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
- *
- * Licensed to Elasticsearch B.V under one or more agreements.
- * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
- * the GNU Lesser General Public License, Version 2.1, at your option.
- * See the LICENSE file in the project root for more information.
+ *   The OpenSearch Contributors require contributions made to
+ *   this file be licensed under the Apache-2.0 license or a
+ *   compatible open source license.
  */
 
 namespace OpenSearch\Endpoints\MachineLearning\Models;

--- a/src/OpenSearch/Endpoints/MachineLearning/Models/UndeployModel.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Models/UndeployModel.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Elasticsearch PHP client
+ *
+ * @link      https://github.com/elastic/elasticsearch-php/
+ * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
+ *
+ * Licensed to Elasticsearch B.V under one or more agreements.
+ * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
+ * the GNU Lesser General Public License, Version 2.1, at your option.
+ * See the LICENSE file in the project root for more information.
+ */
+
+namespace OpenSearch\Endpoints\MachineLearning\Models;
+
+use OpenSearch\Common\Exceptions\RuntimeException;
+use OpenSearch\Endpoints\AbstractEndpoint;
+
+class UndeployModel extends AbstractEndpoint
+{
+
+  /**
+   * @return string[]
+   */
+  public function getParamWhitelist(): array
+  {
+    return [];
+  }
+
+  /**
+   * @return string
+   */
+  public function getURI(): string
+  {
+    if ($this->id) {
+      return "/_plugins/_ml/models/$this->id/_undeploy";
+    }
+
+    throw new RuntimeException(
+      'id is required for undeploy'
+    );
+
+  }
+
+  /**
+   * @return string
+   */
+  public function getMethod(): string
+  {
+    return 'POST';
+  }
+}

--- a/src/OpenSearch/Endpoints/MachineLearning/Tasks/GetTask.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Tasks/GetTask.php
@@ -18,35 +18,34 @@ use OpenSearch\Endpoints\AbstractEndpoint;
 
 class GetTask extends AbstractEndpoint
 {
-
-  /**
-   * @return string[]
-   */
-  public function getParamWhitelist(): array
-  {
-    return [];
-  }
-
-  /**
-   * @return string
-   */
-  public function getURI(): string
-  {
-    if ($this->id) {
-      return "/_plugins/_ml/tasks/$this->id";
+    /**
+     * @return string[]
+     */
+    public function getParamWhitelist(): array
+    {
+        return [];
     }
 
-    throw new RuntimeException(
-      'id is required for get'
-    );
+    /**
+     * @return string
+     */
+    public function getURI(): string
+    {
+        if ($this->id) {
+            return "/_plugins/_ml/tasks/$this->id";
+        }
 
-  }
+        throw new RuntimeException(
+            'id is required for get'
+        );
 
-  /**
-   * @return string
-   */
-  public function getMethod(): string
-  {
-    return 'GET';
-  }
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethod(): string
+    {
+        return 'GET';
+    }
 }

--- a/src/OpenSearch/Endpoints/MachineLearning/Tasks/GetTask.php
+++ b/src/OpenSearch/Endpoints/MachineLearning/Tasks/GetTask.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ *  Copyright OpenSearch Contributors
+ *   SPDX-License-Identifier: Apache-2.0
+ *
+ *   The OpenSearch Contributors require contributions made to
+ *   this file be licensed under the Apache-2.0 license or a
+ *   compatible open source license.
+ */
+
+namespace OpenSearch\Endpoints\MachineLearning\Tasks;
+
+use OpenSearch\Common\Exceptions\RuntimeException;
+use OpenSearch\Endpoints\AbstractEndpoint;
+
+class GetTask extends AbstractEndpoint
+{
+
+  /**
+   * @return string[]
+   */
+  public function getParamWhitelist(): array
+  {
+    return [];
+  }
+
+  /**
+   * @return string
+   */
+  public function getURI(): string
+  {
+    if ($this->id) {
+      return "/_plugins/_ml/tasks/$this->id";
+    }
+
+    throw new RuntimeException(
+      'id is required for get'
+    );
+
+  }
+
+  /**
+   * @return string
+   */
+  public function getMethod(): string
+  {
+    return 'GET';
+  }
+}

--- a/src/OpenSearch/Namespaces/MachineLearningNamespace.php
+++ b/src/OpenSearch/Namespaces/MachineLearningNamespace.php
@@ -16,7 +16,13 @@ namespace OpenSearch\Namespaces;
 use OpenSearch\Namespaces\AbstractNamespace;
 
 /**
- * Class ConnectorsNamespace
+ * Class MachineLearningNamespace
+ *
+ * This class implements common functionality from the
+ * ML Commons API. Please refer to that documentation
+ * for more details about each API operation.
+ *
+ * @link https://opensearch.org/docs/latest/ml-commons-plugin/api/index/
  */
 class MachineLearningNamespace extends AbstractNamespace
 {

--- a/src/OpenSearch/Namespaces/MachineLearningNamespace.php
+++ b/src/OpenSearch/Namespaces/MachineLearningNamespace.php
@@ -29,19 +29,84 @@ use OpenSearch\Namespaces\AbstractNamespace;
 class MachineLearningNamespace extends AbstractNamespace {
 
   /**
-   * $params['body']             = (string) The connector configuration (Required)
+   * $params['body']             = (string) The body of the request (Required)
    *
    * @param array $params Associative array of parameters
    *
-   * @return string
-   *   The connector id.
+   * @return array
+   *   The response.
    */
-  public function createConnector(array $params = []): string {
+  public function createConnector(array $params = []): array
+  {
     $body = $this->extractArgument($params, 'body');
     $endpointBuilder = $this->endpoints;
-    $endpoint = $endpointBuilder('MachineLearning\CreateConnector');
+    $endpoint = $endpointBuilder('MachineLearning\Connectors\CreateConnector');
     $endpoint->setParams($params);
     $endpoint->setBody($body);
+
+    return $this->performRequest($endpoint);
+  }
+
+  /**
+   * $params['id']             = (string) The id of the connector (Required)
+   *
+   * @param array $params Associative array of parameters
+   *
+   * @return array
+   *   The response.
+   */
+  public function getConnector(array $params = []): array
+  {
+    $id = $this->extractArgument($params, 'id');
+    $endpointBuilder = $this->endpoints;
+    $endpoint = $endpointBuilder('MachineLearning\Connectors\GetConnector');
+    $endpoint->setParams($params);
+    $endpoint->setId($id);
+
+    return $this->performRequest($endpoint);
+  }
+
+  /**
+   * $params['body']             = (string) The body of the request
+   *
+   * @param array $params Associative array of parameters
+   *
+   * @return array
+   *   The response.
+   */
+  public function getConnectors(array $params = []): array
+  {
+    if (!isset($params['body'])) {
+      $params['body'] = [
+        'query' => [
+          'match_all' => new \StdClass(),
+        ],
+        'size' => 1000,
+      ];
+    }
+    $body = $this->extractArgument($params, 'body');
+    $endpointBuilder = $this->endpoints;
+    $endpoint = $endpointBuilder('MachineLearning\Connectors\GetConnectors');
+    $endpoint->setBody($body);
+
+    return $this->performRequest($endpoint);
+  }
+
+  /**
+   * $params['id']             = (string) The id of the connector (Required)
+   *
+   * @param array $params Associative array of parameters
+   *
+   * @return array
+   *   The response.
+   */
+  public function deleteConnector(array $params = []): array
+  {
+    $id = $this->extractArgument($params, 'id');
+    $endpointBuilder = $this->endpoints;
+    $endpoint = $endpointBuilder('MachineLearning\Connectors\DeleteConnector');
+    $endpoint->setParams($params);
+    $endpoint->setId($id);
 
     return $this->performRequest($endpoint);
   }

--- a/src/OpenSearch/Namespaces/MachineLearningNamespace.php
+++ b/src/OpenSearch/Namespaces/MachineLearningNamespace.php
@@ -18,348 +18,348 @@ use OpenSearch\Namespaces\AbstractNamespace;
 /**
  * Class ConnectorsNamespace
  */
-class MachineLearningNamespace extends AbstractNamespace {
+class MachineLearningNamespace extends AbstractNamespace
+{
+    /**
+     * $params['body']             = (string) The body of the request (Required)
+     *
+     * @param array $params Associative array of parameters
+     *
+     * @return array
+     *   The response.
+     */
+    public function createConnector(array $params = []): array
+    {
+        $body = $this->extractArgument($params, 'body');
+        $endpointBuilder = $this->endpoints;
+        $endpoint = $endpointBuilder('MachineLearning\Connectors\CreateConnector');
+        $endpoint->setParams($params);
+        $endpoint->setBody($body);
 
-  /**
-   * $params['body']             = (string) The body of the request (Required)
-   *
-   * @param array $params Associative array of parameters
-   *
-   * @return array
-   *   The response.
-   */
-  public function createConnector(array $params = []): array
-  {
-    $body = $this->extractArgument($params, 'body');
-    $endpointBuilder = $this->endpoints;
-    $endpoint = $endpointBuilder('MachineLearning\Connectors\CreateConnector');
-    $endpoint->setParams($params);
-    $endpoint->setBody($body);
-
-    return $this->performRequest($endpoint);
-  }
-
-  /**
-   * $params['id']             = (string) The id of the connector (Required)
-   *
-   * @param array $params Associative array of parameters
-   *
-   * @return array
-   *   The response.
-   */
-  public function getConnector(array $params = []): array
-  {
-    $id = $this->extractArgument($params, 'id');
-    $endpointBuilder = $this->endpoints;
-    $endpoint = $endpointBuilder('MachineLearning\Connectors\GetConnector');
-    $endpoint->setParams($params);
-    $endpoint->setId($id);
-
-    return $this->performRequest($endpoint);
-  }
-
-  /**
-   * $params['body']             = (string) The body of the request
-   *
-   * @param array $params Associative array of parameters
-   *
-   * @return array
-   *   The response.
-   */
-  public function getConnectors(array $params = []): array
-  {
-    if (!isset($params['body'])) {
-      $params['body'] = [
-        'query' => [
-          'match_all' => new \StdClass(),
-        ],
-        'size' => 1000,
-      ];
-    }
-    $body = $this->extractArgument($params, 'body');
-    $endpointBuilder = $this->endpoints;
-    $endpoint = $endpointBuilder('MachineLearning\Connectors\GetConnectors');
-    $endpoint->setBody($body);
-
-    return $this->performRequest($endpoint);
-  }
-
-  /**
-   * $params['id']             = (string) The id of the connector (Required)
-   *
-   * @param array $params Associative array of parameters
-   *
-   * @return array
-   *   The response.
-   */
-  public function deleteConnector(array $params = []): array
-  {
-    $id = $this->extractArgument($params, 'id');
-    $endpointBuilder = $this->endpoints;
-    $endpoint = $endpointBuilder('MachineLearning\Connectors\DeleteConnector');
-    $endpoint->setParams($params);
-    $endpoint->setId($id);
-
-    return $this->performRequest($endpoint);
-  }
-
-  /**
-   * $params['body']             = (string) The body of the request (Required)
-   *
-   * @param array $params Associative array of parameters
-   *
-   * @return array
-   *   The response.
-   */
-  public function registerModelGroup(array $params = []): array
-  {
-    $body = $this->extractArgument($params, 'body');
-    $endpointBuilder = $this->endpoints;
-    $endpoint = $endpointBuilder('MachineLearning\ModelGroups\RegisterModelGroup');
-    $endpoint->setParams($params);
-    $endpoint->setBody($body);
-
-    return $this->performRequest($endpoint);
-  }
-
-  /**
-   * $params['body']             = (string) The body of the request
-   *
-   * @param array $params Associative array of parameters
-   *
-   * @return array
-   *   The response.
-   */
-  public function getModelGroups(array $params = []): array
-  {
-    if (!isset($params['body'])) {
-      $params['body'] = [
-        'query' => [
-          'match_all' => new \StdClass(),
-        ],
-        'size' => 1000,
-      ];
-    }
-    $body = $this->extractArgument($params, 'body');
-    $endpointBuilder = $this->endpoints;
-    $endpoint = $endpointBuilder('MachineLearning\ModelGroups\GetModelGroups');
-    $endpoint->setBody($body);
-
-    return $this->performRequest($endpoint);
-  }
-
-  /**
-   * $params['id']             = (string) The id of the model group (Required)
-   * $params['body']           = (array) The body of the request (Required)
-   *
-   * @param array $params Associative array of parameters
-   *
-   * @return array
-   *   The response.
-   */
-  public function updateModelGroup(array $params = []): array
-  {
-    $id = $this->extractArgument($params, 'id');
-    $body = $this->extractArgument($params, 'body');
-    $endpointBuilder = $this->endpoints;
-    $endpoint = $endpointBuilder('MachineLearning\ModelGroups\UpdateModelGroup');
-    $endpoint->setParams($params);
-    $endpoint->setBody($body);
-    $endpoint->setId($id);
-
-    return $this->performRequest($endpoint);
-  }
-
-  /**
-   * $params['id']             = (string) The id of the model group (Required)
-   *
-   * @param array $params Associative array of parameters
-   *
-   * @return array
-   *   The response.
-   */
-  public function deleteModelGroup(array $params = []): array
-  {
-    $id = $this->extractArgument($params, 'id');
-    $endpointBuilder = $this->endpoints;
-    $endpoint = $endpointBuilder('MachineLearning\ModelGroups\DeleteModelGroup');
-    $endpoint->setParams($params);
-    $endpoint->setId($id);
-
-    return $this->performRequest($endpoint);
-  }
-
-  /**
-   * $params['body']             = (string) The body of the request (Required)
-   *
-   * @param array $params Associative array of parameters
-   *
-   * @return array
-   *   The response.
-   */
-  public function registerModel(array $params = []): array
-  {
-    $body = $this->extractArgument($params, 'body');
-    $endpointBuilder = $this->endpoints;
-    $endpoint = $endpointBuilder('MachineLearning\Models\RegisterModel');
-    $endpoint->setParams($params);
-    $endpoint->setBody($body);
-
-    return $this->performRequest($endpoint);
-  }
-
-  /**
-   * $params['id']             = (string) The id of the model (Required)
-   *
-   * @param array $params Associative array of parameters
-   *
-   * @return array
-   *   The response.
-   */
-  public function getModel(array $params = []): array
-  {
-    $id = $this->extractArgument($params, 'id');
-    $endpointBuilder = $this->endpoints;
-    $endpoint = $endpointBuilder('MachineLearning\Models\GetModel');
-    $endpoint->setParams($params);
-    $endpoint->setId($id);
-
-    return $this->performRequest($endpoint);
-  }
-
-  /**
-   * $params['body']             = (array) The body of the request
-   *
-   * @param array $params Associative array of parameters
-   *
-   * @return array
-   *   The response.
-   */
-  public function getModels(array $params = []): array
-  {
-    if (!isset($params['body'])) {
-      $params['body'] = [
-        'query' => [
-          'match_all' => new \StdClass(),
-        ],
-        'size' => 1000,
-      ];
-    }
-    $body = $this->extractArgument($params, 'body');
-    $endpointBuilder = $this->endpoints;
-    $endpoint = $endpointBuilder('MachineLearning\Models\GetModels');
-    $endpoint->setParams($params);
-    $endpoint->setBody($body);
-
-    return $this->performRequest($endpoint);
-  }
-
-  /**
-   * $params['id']             = (string) The id of the model (Required)
-   * $params['body']           = (string) The body of the request
-   *
-   * @param array $params Associative array of parameters
-   *
-   * @return array
-   *   The response.
-   */
-  public function deployModel(array $params = []): array
-  {
-    $id = $this->extractArgument($params, 'id');
-    $body = $this->extractArgument($params, 'body');
-    $endpointBuilder = $this->endpoints;
-    $endpoint = $endpointBuilder('MachineLearning\Models\DeployModel');
-    $endpoint->setParams($params);
-    $endpoint->setId($id);
-    if ($body) {
-      $endpoint->setBody($body);
+        return $this->performRequest($endpoint);
     }
 
-    return $this->performRequest($endpoint);
-  }
+    /**
+     * $params['id']             = (string) The id of the connector (Required)
+     *
+     * @param array $params Associative array of parameters
+     *
+     * @return array
+     *   The response.
+     */
+    public function getConnector(array $params = []): array
+    {
+        $id = $this->extractArgument($params, 'id');
+        $endpointBuilder = $this->endpoints;
+        $endpoint = $endpointBuilder('MachineLearning\Connectors\GetConnector');
+        $endpoint->setParams($params);
+        $endpoint->setId($id);
 
-  /**
-   * $params['id']             = (string) The id of the model (Required)
-   * $params['body']           = (string) The body of the request
-   *
-   * @param array $params Associative array of parameters
-   *
-   * @return array
-   *   The response.
-   */
-  public function undeployModel(array $params = []): array
-  {
-    $id = $this->extractArgument($params, 'id');
-    $body = $this->extractArgument($params, 'body');
-    $endpointBuilder = $this->endpoints;
-    $endpoint = $endpointBuilder('MachineLearning\Models\UndeployModel');
-    $endpoint->setParams($params);
-    $endpoint->setId($id);
-    if ($body) {
-      $endpoint->setBody($body);
+        return $this->performRequest($endpoint);
     }
 
-    return $this->performRequest($endpoint);
-  }
+    /**
+     * $params['body']             = (string) The body of the request
+     *
+     * @param array $params Associative array of parameters
+     *
+     * @return array
+     *   The response.
+     */
+    public function getConnectors(array $params = []): array
+    {
+        if (!isset($params['body'])) {
+            $params['body'] = [
+              'query' => [
+                'match_all' => new \StdClass(),
+              ],
+              'size' => 1000,
+            ];
+        }
+        $body = $this->extractArgument($params, 'body');
+        $endpointBuilder = $this->endpoints;
+        $endpoint = $endpointBuilder('MachineLearning\Connectors\GetConnectors');
+        $endpoint->setBody($body);
 
-  /**
-   * $params['id']             = (string) The id of the model (Required)
-   *
-   * @param array $params Associative array of parameters
-   *
-   * @return array
-   *   The response.
-   */
-  public function deleteModel(array $params = []): array
-  {
-    $id = $this->extractArgument($params, 'id');
-    $endpointBuilder = $this->endpoints;
-    $endpoint = $endpointBuilder('MachineLearning\Models\DeleteModel');
-    $endpoint->setParams($params);
-    $endpoint->setId($id);
+        return $this->performRequest($endpoint);
+    }
 
-    return $this->performRequest($endpoint);
-  }
+    /**
+     * $params['id']             = (string) The id of the connector (Required)
+     *
+     * @param array $params Associative array of parameters
+     *
+     * @return array
+     *   The response.
+     */
+    public function deleteConnector(array $params = []): array
+    {
+        $id = $this->extractArgument($params, 'id');
+        $endpointBuilder = $this->endpoints;
+        $endpoint = $endpointBuilder('MachineLearning\Connectors\DeleteConnector');
+        $endpoint->setParams($params);
+        $endpoint->setId($id);
 
-  /**
-   * $params['id']             = (string) The id of the model (Required)
-   * $params['body']           = (string) The body of the request
-   *
-   * @param array $params Associative array of parameters
-   *
-   * @return array
-   *   The response.
-   */
-  public function predict(array $params = []): array
-  {
-    $id = $this->extractArgument($params, 'id');
-    $body = $this->extractArgument($params, 'body');
-    $endpointBuilder = $this->endpoints;
-    $endpoint = $endpointBuilder('MachineLearning\Models\Predict');
-    $endpoint->setParams($params);
-    $endpoint->setId($id);
-    $endpoint->setBody($body);
+        return $this->performRequest($endpoint);
+    }
 
-    return $this->performRequest($endpoint);
-  }
+    /**
+     * $params['body']             = (string) The body of the request (Required)
+     *
+     * @param array $params Associative array of parameters
+     *
+     * @return array
+     *   The response.
+     */
+    public function registerModelGroup(array $params = []): array
+    {
+        $body = $this->extractArgument($params, 'body');
+        $endpointBuilder = $this->endpoints;
+        $endpoint = $endpointBuilder('MachineLearning\ModelGroups\RegisterModelGroup');
+        $endpoint->setParams($params);
+        $endpoint->setBody($body);
 
-  /**
-   * $params['id']             = (string) The id of the task (Required)
-   *
-   * @param array $params Associative array of parameters
-   *
-   * @return array
-   *   The response.
-   */
-  public function getTask(array $params = []): array
-  {
-    $id = $this->extractArgument($params, 'id');
-    $endpointBuilder = $this->endpoints;
-    $endpoint = $endpointBuilder('MachineLearning\Tasks\GetTask');
-    $endpoint->setParams($params);
-    $endpoint->setId($id);
+        return $this->performRequest($endpoint);
+    }
 
-    return $this->performRequest($endpoint);
-  }
+    /**
+     * $params['body']             = (string) The body of the request
+     *
+     * @param array $params Associative array of parameters
+     *
+     * @return array
+     *   The response.
+     */
+    public function getModelGroups(array $params = []): array
+    {
+        if (!isset($params['body'])) {
+            $params['body'] = [
+              'query' => [
+                'match_all' => new \StdClass(),
+              ],
+              'size' => 1000,
+            ];
+        }
+        $body = $this->extractArgument($params, 'body');
+        $endpointBuilder = $this->endpoints;
+        $endpoint = $endpointBuilder('MachineLearning\ModelGroups\GetModelGroups');
+        $endpoint->setBody($body);
+
+        return $this->performRequest($endpoint);
+    }
+
+    /**
+     * $params['id']             = (string) The id of the model group (Required)
+     * $params['body']           = (array) The body of the request (Required)
+     *
+     * @param array $params Associative array of parameters
+     *
+     * @return array
+     *   The response.
+     */
+    public function updateModelGroup(array $params = []): array
+    {
+        $id = $this->extractArgument($params, 'id');
+        $body = $this->extractArgument($params, 'body');
+        $endpointBuilder = $this->endpoints;
+        $endpoint = $endpointBuilder('MachineLearning\ModelGroups\UpdateModelGroup');
+        $endpoint->setParams($params);
+        $endpoint->setBody($body);
+        $endpoint->setId($id);
+
+        return $this->performRequest($endpoint);
+    }
+
+    /**
+     * $params['id']             = (string) The id of the model group (Required)
+     *
+     * @param array $params Associative array of parameters
+     *
+     * @return array
+     *   The response.
+     */
+    public function deleteModelGroup(array $params = []): array
+    {
+        $id = $this->extractArgument($params, 'id');
+        $endpointBuilder = $this->endpoints;
+        $endpoint = $endpointBuilder('MachineLearning\ModelGroups\DeleteModelGroup');
+        $endpoint->setParams($params);
+        $endpoint->setId($id);
+
+        return $this->performRequest($endpoint);
+    }
+
+    /**
+     * $params['body']             = (string) The body of the request (Required)
+     *
+     * @param array $params Associative array of parameters
+     *
+     * @return array
+     *   The response.
+     */
+    public function registerModel(array $params = []): array
+    {
+        $body = $this->extractArgument($params, 'body');
+        $endpointBuilder = $this->endpoints;
+        $endpoint = $endpointBuilder('MachineLearning\Models\RegisterModel');
+        $endpoint->setParams($params);
+        $endpoint->setBody($body);
+
+        return $this->performRequest($endpoint);
+    }
+
+    /**
+     * $params['id']             = (string) The id of the model (Required)
+     *
+     * @param array $params Associative array of parameters
+     *
+     * @return array
+     *   The response.
+     */
+    public function getModel(array $params = []): array
+    {
+        $id = $this->extractArgument($params, 'id');
+        $endpointBuilder = $this->endpoints;
+        $endpoint = $endpointBuilder('MachineLearning\Models\GetModel');
+        $endpoint->setParams($params);
+        $endpoint->setId($id);
+
+        return $this->performRequest($endpoint);
+    }
+
+    /**
+     * $params['body']             = (array) The body of the request
+     *
+     * @param array $params Associative array of parameters
+     *
+     * @return array
+     *   The response.
+     */
+    public function getModels(array $params = []): array
+    {
+        if (!isset($params['body'])) {
+            $params['body'] = [
+              'query' => [
+                'match_all' => new \StdClass(),
+              ],
+              'size' => 1000,
+            ];
+        }
+        $body = $this->extractArgument($params, 'body');
+        $endpointBuilder = $this->endpoints;
+        $endpoint = $endpointBuilder('MachineLearning\Models\GetModels');
+        $endpoint->setParams($params);
+        $endpoint->setBody($body);
+
+        return $this->performRequest($endpoint);
+    }
+
+    /**
+     * $params['id']             = (string) The id of the model (Required)
+     * $params['body']           = (string) The body of the request
+     *
+     * @param array $params Associative array of parameters
+     *
+     * @return array
+     *   The response.
+     */
+    public function deployModel(array $params = []): array
+    {
+        $id = $this->extractArgument($params, 'id');
+        $body = $this->extractArgument($params, 'body');
+        $endpointBuilder = $this->endpoints;
+        $endpoint = $endpointBuilder('MachineLearning\Models\DeployModel');
+        $endpoint->setParams($params);
+        $endpoint->setId($id);
+        if ($body) {
+            $endpoint->setBody($body);
+        }
+
+        return $this->performRequest($endpoint);
+    }
+
+    /**
+     * $params['id']             = (string) The id of the model (Required)
+     * $params['body']           = (string) The body of the request
+     *
+     * @param array $params Associative array of parameters
+     *
+     * @return array
+     *   The response.
+     */
+    public function undeployModel(array $params = []): array
+    {
+        $id = $this->extractArgument($params, 'id');
+        $body = $this->extractArgument($params, 'body');
+        $endpointBuilder = $this->endpoints;
+        $endpoint = $endpointBuilder('MachineLearning\Models\UndeployModel');
+        $endpoint->setParams($params);
+        $endpoint->setId($id);
+        if ($body) {
+            $endpoint->setBody($body);
+        }
+
+        return $this->performRequest($endpoint);
+    }
+
+    /**
+     * $params['id']             = (string) The id of the model (Required)
+     *
+     * @param array $params Associative array of parameters
+     *
+     * @return array
+     *   The response.
+     */
+    public function deleteModel(array $params = []): array
+    {
+        $id = $this->extractArgument($params, 'id');
+        $endpointBuilder = $this->endpoints;
+        $endpoint = $endpointBuilder('MachineLearning\Models\DeleteModel');
+        $endpoint->setParams($params);
+        $endpoint->setId($id);
+
+        return $this->performRequest($endpoint);
+    }
+
+    /**
+     * $params['id']             = (string) The id of the model (Required)
+     * $params['body']           = (string) The body of the request
+     *
+     * @param array $params Associative array of parameters
+     *
+     * @return array
+     *   The response.
+     */
+    public function predict(array $params = []): array
+    {
+        $id = $this->extractArgument($params, 'id');
+        $body = $this->extractArgument($params, 'body');
+        $endpointBuilder = $this->endpoints;
+        $endpoint = $endpointBuilder('MachineLearning\Models\Predict');
+        $endpoint->setParams($params);
+        $endpoint->setId($id);
+        $endpoint->setBody($body);
+
+        return $this->performRequest($endpoint);
+    }
+
+    /**
+     * $params['id']             = (string) The id of the task (Required)
+     *
+     * @param array $params Associative array of parameters
+     *
+     * @return array
+     *   The response.
+     */
+    public function getTask(array $params = []): array
+    {
+        $id = $this->extractArgument($params, 'id');
+        $endpointBuilder = $this->endpoints;
+        $endpoint = $endpointBuilder('MachineLearning\Tasks\GetTask');
+        $endpoint->setParams($params);
+        $endpoint->setId($id);
+
+        return $this->performRequest($endpoint);
+    }
 
 }

--- a/src/OpenSearch/Namespaces/MachineLearningNamespace.php
+++ b/src/OpenSearch/Namespaces/MachineLearningNamespace.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Elasticsearch PHP client
+ *
+ * @link      https://github.com/elastic/elasticsearch-php/
+ * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
+ *
+ * Licensed to Elasticsearch B.V under one or more agreements.
+ * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
+ * the GNU Lesser General Public License, Version 2.1, at your option.
+ * See the LICENSE file in the project root for more information.
+ */
+
+namespace OpenSearch\Namespaces;
+
+use OpenSearch\Namespaces\AbstractNamespace;
+
+/**
+ * Class ConnectorsNamespace
+ */
+class MachineLearningNamespace extends AbstractNamespace {
+
+  /**
+   * $params['body']             = (string) The connector configuration (Required)
+   *
+   * @param array $params Associative array of parameters
+   *
+   * @return string
+   *   The connector id.
+   */
+  public function createConnector(array $params = []): string {
+    $body = $this->extractArgument($params, 'body');
+    $endpointBuilder = $this->endpoints;
+    $endpoint = $endpointBuilder('MachineLearning\CreateConnector');
+    $endpoint->setParams($params);
+    $endpoint->setBody($body);
+
+    return $this->performRequest($endpoint);
+  }
+
+}

--- a/src/OpenSearch/Namespaces/MachineLearningNamespace.php
+++ b/src/OpenSearch/Namespaces/MachineLearningNamespace.php
@@ -197,4 +197,132 @@ class MachineLearningNamespace extends AbstractNamespace {
     return $this->performRequest($endpoint);
   }
 
+  /**
+   * $params['body']             = (string) The body of the request (Required)
+   *
+   * @param array $params Associative array of parameters
+   *
+   * @return array
+   *   The response.
+   */
+  public function registerModel(array $params = []): array
+  {
+    $body = $this->extractArgument($params, 'body');
+    $endpointBuilder = $this->endpoints;
+    $endpoint = $endpointBuilder('MachineLearning\Models\RegisterModel');
+    $endpoint->setParams($params);
+    $endpoint->setBody($body);
+
+    return $this->performRequest($endpoint);
+  }
+
+  /**
+   * $params['id']             = (string) The id of the model (Required)
+   *
+   * @param array $params Associative array of parameters
+   *
+   * @return array
+   *   The response.
+   */
+  public function getModel(array $params = []): array
+  {
+    $id = $this->extractArgument($params, 'id');
+    $endpointBuilder = $this->endpoints;
+    $endpoint = $endpointBuilder('MachineLearning\Models\GetModel');
+    $endpoint->setParams($params);
+    $endpoint->setId($id);
+
+    return $this->performRequest($endpoint);
+  }
+
+
+  /**
+   * $params['id']             = (string) The id of the model (Required)
+   * $params['body']           = (string) The body of the request
+   *
+   * @param array $params Associative array of parameters
+   *
+   * @return array
+   *   The response.
+   */
+  public function deployModel(array $params = []): array
+  {
+    $id = $this->extractArgument($params, 'id');
+    $body = $this->extractArgument($params, 'body');
+    $endpointBuilder = $this->endpoints;
+    $endpoint = $endpointBuilder('MachineLearning\Models\DeployModel');
+    $endpoint->setParams($params);
+    $endpoint->setId($id);
+    if ($body) {
+      $endpoint->setBody($body);
+    }
+
+    return $this->performRequest($endpoint);
+  }
+
+  /**
+   * $params['id']             = (string) The id of the model (Required)
+   * $params['body']           = (string) The body of the request
+   *
+   * @param array $params Associative array of parameters
+   *
+   * @return array
+   *   The response.
+   */
+  public function undeployModel(array $params = []): array
+  {
+    $id = $this->extractArgument($params, 'id');
+    $body = $this->extractArgument($params, 'body');
+    $endpointBuilder = $this->endpoints;
+    $endpoint = $endpointBuilder('MachineLearning\Models\UndeployModel');
+    $endpoint->setParams($params);
+    $endpoint->setId($id);
+    if ($body) {
+      $endpoint->setBody($body);
+    }
+
+    return $this->performRequest($endpoint);
+  }
+
+  /**
+   * $params['id']             = (string) The id of the model (Required)
+   *
+   * @param array $params Associative array of parameters
+   *
+   * @return array
+   *   The response.
+   */
+  public function deleteModel(array $params = []): array
+  {
+    $id = $this->extractArgument($params, 'id');
+    $endpointBuilder = $this->endpoints;
+    $endpoint = $endpointBuilder('MachineLearning\Models\DeleteModel');
+    $endpoint->setParams($params);
+    $endpoint->setId($id);
+
+    return $this->performRequest($endpoint);
+  }
+
+  /**
+   * $params['id']             = (string) The id of the model (Required)
+   * $params['body']           = (string) The body of the request
+   *
+   * @param array $params Associative array of parameters
+   *
+   * @return array
+   *   The response.
+   */
+  public function predict(array $params = []): array
+  {
+    $id = $this->extractArgument($params, 'id');
+    $body = $this->extractArgument($params, 'body');
+    $endpointBuilder = $this->endpoints;
+    $endpoint = $endpointBuilder('MachineLearning\Models\Predict');
+    $endpoint->setParams($params);
+    $endpoint->setId($id);
+    $endpoint->setBody($body);
+
+    return $this->performRequest($endpoint);
+  }
+
 }

--- a/src/OpenSearch/Namespaces/MachineLearningNamespace.php
+++ b/src/OpenSearch/Namespaces/MachineLearningNamespace.php
@@ -4,19 +4,11 @@ declare(strict_types=1);
 
 /**
  * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  *
- * Elasticsearch PHP client
- *
- * @link      https://github.com/elastic/elasticsearch-php/
- * @copyright Copyright (c) Elasticsearch B.V (https://www.elastic.co)
- * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
- * @license   https://www.gnu.org/licenses/lgpl-2.1.html GNU Lesser General Public License, Version 2.1
- *
- * Licensed to Elasticsearch B.V under one or more agreements.
- * Elasticsearch B.V licenses this file to you under the Apache 2.0 License or
- * the GNU Lesser General Public License, Version 2.1, at your option.
- * See the LICENSE file in the project root for more information.
+ *  The OpenSearch Contributors require contributions made to
+ *  this file be licensed under the Apache-2.0 license or a
+ *  compatible open source license.
  */
 
 namespace OpenSearch\Namespaces;

--- a/src/OpenSearch/Namespaces/MachineLearningNamespace.php
+++ b/src/OpenSearch/Namespaces/MachineLearningNamespace.php
@@ -111,4 +111,90 @@ class MachineLearningNamespace extends AbstractNamespace {
     return $this->performRequest($endpoint);
   }
 
+  /**
+   * $params['body']             = (string) The body of the request (Required)
+   *
+   * @param array $params Associative array of parameters
+   *
+   * @return array
+   *   The response.
+   */
+  public function registerModelGroup(array $params = []): array
+  {
+    $body = $this->extractArgument($params, 'body');
+    $endpointBuilder = $this->endpoints;
+    $endpoint = $endpointBuilder('MachineLearning\ModelGroups\RegisterModelGroup');
+    $endpoint->setParams($params);
+    $endpoint->setBody($body);
+
+    return $this->performRequest($endpoint);
+  }
+
+  /**
+   * $params['body']             = (string) The body of the request
+   *
+   * @param array $params Associative array of parameters
+   *
+   * @return array
+   *   The response.
+   */
+  public function getModelGroups(array $params = []): array
+  {
+    if (!isset($params['body'])) {
+      $params['body'] = [
+        'query' => [
+          'match_all' => new \StdClass(),
+        ],
+        'size' => 1000,
+      ];
+    }
+    $body = $this->extractArgument($params, 'body');
+    $endpointBuilder = $this->endpoints;
+    $endpoint = $endpointBuilder('MachineLearning\ModelGroups\GetModelGroups');
+    $endpoint->setBody($body);
+
+    return $this->performRequest($endpoint);
+  }
+
+  /**
+   * $params['id']             = (string) The id of the model group (Required)
+   * $params['body']           = (array) The body of the request (Required)
+   *
+   * @param array $params Associative array of parameters
+   *
+   * @return array
+   *   The response.
+   */
+  public function updateModelGroup(array $params = []): array
+  {
+    $id = $this->extractArgument($params, 'id');
+    $body = $this->extractArgument($params, 'body');
+    $endpointBuilder = $this->endpoints;
+    $endpoint = $endpointBuilder('MachineLearning\ModelGroups\UpdateModelGroup');
+    $endpoint->setParams($params);
+    $endpoint->setBody($body);
+    $endpoint->setId($id);
+
+    return $this->performRequest($endpoint);
+  }
+
+  /**
+   * $params['id']             = (string) The id of the model group (Required)
+   *
+   * @param array $params Associative array of parameters
+   *
+   * @return array
+   *   The response.
+   */
+  public function deleteModelGroup(array $params = []): array
+  {
+    $id = $this->extractArgument($params, 'id');
+    $endpointBuilder = $this->endpoints;
+    $endpoint = $endpointBuilder('MachineLearning\ModelGroups\DeleteModelGroup');
+    $endpoint->setParams($params);
+    $endpoint->setId($id);
+
+    return $this->performRequest($endpoint);
+  }
+
 }

--- a/src/OpenSearch/Namespaces/MachineLearningNamespace.php
+++ b/src/OpenSearch/Namespaces/MachineLearningNamespace.php
@@ -227,6 +227,32 @@ class MachineLearningNamespace extends AbstractNamespace {
     return $this->performRequest($endpoint);
   }
 
+  /**
+   * $params['body']             = (array) The body of the request
+   *
+   * @param array $params Associative array of parameters
+   *
+   * @return array
+   *   The response.
+   */
+  public function getModels(array $params = []): array
+  {
+    if (!isset($params['body'])) {
+      $params['body'] = [
+        'query' => [
+          'match_all' => new \StdClass(),
+        ],
+        'size' => 1000,
+      ];
+    }
+    $body = $this->extractArgument($params, 'body');
+    $endpointBuilder = $this->endpoints;
+    $endpoint = $endpointBuilder('MachineLearning\Models\GetModels');
+    $endpoint->setParams($params);
+    $endpoint->setBody($body);
+
+    return $this->performRequest($endpoint);
+  }
 
   /**
    * $params['id']             = (string) The id of the model (Required)

--- a/src/OpenSearch/Namespaces/MachineLearningNamespace.php
+++ b/src/OpenSearch/Namespaces/MachineLearningNamespace.php
@@ -343,4 +343,23 @@ class MachineLearningNamespace extends AbstractNamespace {
     return $this->performRequest($endpoint);
   }
 
+  /**
+   * $params['id']             = (string) The id of the task (Required)
+   *
+   * @param array $params Associative array of parameters
+   *
+   * @return array
+   *   The response.
+   */
+  public function getTask(array $params = []): array
+  {
+    $id = $this->extractArgument($params, 'id');
+    $endpointBuilder = $this->endpoints;
+    $endpoint = $endpointBuilder('MachineLearning\Tasks\GetTask');
+    $endpoint->setParams($params);
+    $endpoint->setId($id);
+
+    return $this->performRequest($endpoint);
+  }
+
 }

--- a/tests/Namespaces/MachineLearningNamespaceTest.php
+++ b/tests/Namespaces/MachineLearningNamespaceTest.php
@@ -1,0 +1,414 @@
+<?php
+
+namespace OpenSearch\Tests\Namespaces;
+
+use OpenSearch\Endpoints\MachineLearning\Connectors\CreateConnector;
+use OpenSearch\Endpoints\MachineLearning\Connectors\DeleteConnector;
+use OpenSearch\Endpoints\MachineLearning\Connectors\GetConnector;
+use OpenSearch\Endpoints\MachineLearning\Connectors\GetConnectors;
+use OpenSearch\Endpoints\MachineLearning\ModelGroups\DeleteModelGroup;
+use OpenSearch\Endpoints\MachineLearning\ModelGroups\GetModelGroups;
+use OpenSearch\Endpoints\MachineLearning\ModelGroups\RegisterModelGroup;
+use OpenSearch\Endpoints\MachineLearning\ModelGroups\UpdateModelGroup;
+use OpenSearch\Endpoints\MachineLearning\Models\DeleteModel;
+use OpenSearch\Endpoints\MachineLearning\Models\DeployModel;
+use OpenSearch\Endpoints\MachineLearning\Models\GetModel;
+use OpenSearch\Endpoints\MachineLearning\Models\GetModels;
+use OpenSearch\Endpoints\MachineLearning\Models\Predict;
+use OpenSearch\Endpoints\MachineLearning\Models\RegisterModel;
+use OpenSearch\Endpoints\MachineLearning\Models\UndeployModel;
+use OpenSearch\Endpoints\MachineLearning\Tasks\GetTask;
+use OpenSearch\Endpoints\Sql\Query;
+use OpenSearch\Namespaces\MachineLearningNamespace;
+use OpenSearch\Namespaces\SqlNamespace;
+use OpenSearch\Transport;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Copyright OpenSearch Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ *  this file be licensed under the Apache-2.0 license or a
+ *  compatible open source license.
+ */
+class MachineLearningNamespaceTest extends TestCase
+{
+    public function testCreatingConnector(): void
+    {
+
+        $func = static function () {
+            return new CreateConnector();
+        };
+
+        $transport = $this->createMock(Transport::class);
+
+        $transport->method('performRequest')
+          ->with('POST', '/_plugins/_ml/connectors/_create', [], [
+              'foo' => 'bar',
+          ]);
+
+        $transport->method('resultOrFuture')
+          ->willReturn([]);
+
+        (new MachineLearningNamespace($transport, $func))->createConnector([
+          'body' => [
+            'foo' => 'bar',
+          ],
+        ]);
+    }
+
+    public function testGetConnector(): void
+    {
+
+        $func = static function () {
+            return new GetConnector();
+        };
+
+        $transport = $this->createMock(Transport::class);
+
+        $transport->method('performRequest')
+          ->with('GET', '/_plugins/_ml/connectors/foobar', [], null);
+
+        $transport->method('resultOrFuture')
+          ->willReturn([]);
+
+        (new MachineLearningNamespace($transport, $func))->getConnector([
+          'id' => 'foobar'
+        ]);
+    }
+
+    public function testGetConnectors(): void
+    {
+
+        $func = static function () {
+            return new GetConnectors();
+        };
+
+        $transport = $this->createMock(Transport::class);
+
+        $transport->method('performRequest')
+          ->with('POST', '/_plugins/_ml/connectors/_search', [], [
+            'query' => [
+              'match_all' => new \StdClass(),
+            ],
+            'size' => 1000,
+          ]);
+
+        $transport->method('resultOrFuture')
+          ->willReturn([]);
+
+        (new MachineLearningNamespace($transport, $func))->getConnectors([
+          'body' => [
+            'query' => [
+              'match_all' => new \StdClass(),
+            ],
+            'size' => 1000,
+          ],
+        ]);
+    }
+
+    public function testDeleteConnector(): void
+    {
+
+        $func = static function () {
+            return new DeleteConnector();
+        };
+
+        $transport = $this->createMock(Transport::class);
+
+        $transport->method('performRequest')
+          ->with('DELETE', '/_plugins/_ml/connectors/foobar', [], null);
+
+        $transport->method('resultOrFuture')
+          ->willReturn([]);
+
+        (new MachineLearningNamespace($transport, $func))->deleteConnector([
+          'id' => 'foobar'
+        ]);
+    }
+
+    public function testRegisterModelGroup(): void
+    {
+
+        $func = static function () {
+            return new RegisterModelGroup();
+        };
+
+        $transport = $this->createMock(Transport::class);
+
+        $transport->method('performRequest')
+          ->with('POST', '/_plugins/_ml/model_groups/_register', [], [
+            'foo' => 'bar',
+          ]);
+
+        $transport->method('resultOrFuture')
+          ->willReturn([]);
+
+        (new MachineLearningNamespace($transport, $func))->registerModelGroup([
+          'body' => [
+            'foo' => 'bar',
+          ],
+        ]);
+    }
+
+    public function testGetModelGroups(): void
+    {
+
+        $func = static function () {
+            return new GetModelGroups();
+        };
+
+        $transport = $this->createMock(Transport::class);
+
+        $transport->method('performRequest')
+          ->with('POST', '/_plugins/_ml/model_groups/_search', [], [
+            'query' => [
+              'match_all' => new \StdClass(),
+            ],
+            'size' => 1000,
+          ]);
+
+        $transport->method('resultOrFuture')
+          ->willReturn([]);
+
+        (new MachineLearningNamespace($transport, $func))->getModelGroups([
+          'body' => [
+            'query' => [
+              'match_all' => new \StdClass(),
+            ],
+            'size' => 1000,
+          ],
+        ]);
+    }
+
+    public function testUpdateModelGroup(): void
+    {
+
+        $func = static function () {
+            return new UpdateModelGroup();
+        };
+
+        $transport = $this->createMock(Transport::class);
+
+        $transport->method('performRequest')
+          ->with('PUT', '/_plugins/_ml/model_groups/foobar', [], [
+            'query' => [
+              'match_all' => new \StdClass(),
+            ],
+            'size' => 1000,
+          ]);
+
+        $transport->method('resultOrFuture')
+          ->willReturn([]);
+
+        (new MachineLearningNamespace($transport, $func))->updateModelGroup([
+          'id' => 'foobar',
+          'body' => [
+            'query' => [
+              'match_all' => new \StdClass(),
+            ],
+            'size' => 1000,
+          ],
+        ]);
+    }
+
+    public function testDeleteModelGroup(): void
+    {
+
+        $func = static function () {
+            return new DeleteModelGroup();
+        };
+
+        $transport = $this->createMock(Transport::class);
+
+        $transport->method('performRequest')
+          ->with('DELETE', '/_plugins/_ml/model_groups/foobar', [], null);
+
+        $transport->method('resultOrFuture')
+          ->willReturn([]);
+
+        (new MachineLearningNamespace($transport, $func))->deleteModelGroup([
+          'id' => 'foobar'
+        ]);
+    }
+
+    public function testRegisterModel(): void
+    {
+
+        $func = static function () {
+            return new RegisterModel();
+        };
+
+        $transport = $this->createMock(Transport::class);
+
+        $transport->method('performRequest')
+          ->with('POST', '/_plugins/_ml/models/_register', [], [
+            'foo' => 'bar',
+          ]);
+
+        $transport->method('resultOrFuture')
+          ->willReturn([]);
+
+        (new MachineLearningNamespace($transport, $func))->registerModel([
+          'body' => [
+            'foo' => 'bar',
+          ],
+        ]);
+    }
+
+    public function testGetModel(): void
+    {
+
+        $func = static function () {
+            return new GetModel();
+        };
+
+        $transport = $this->createMock(Transport::class);
+
+        $transport->method('performRequest')
+          ->with('GET', '/_plugins/_ml/models/foobar', [], null);
+
+        $transport->method('resultOrFuture')
+          ->willReturn([]);
+
+        (new MachineLearningNamespace($transport, $func))->getModel([
+          'id' => 'foobar',
+        ]);
+    }
+
+    public function testGetModels(): void
+    {
+
+        $func = static function () {
+            return new GetModels();
+        };
+
+        $transport = $this->createMock(Transport::class);
+
+        $transport->method('performRequest')
+          ->with('POST', '/_plugins/_ml/models/_search', [], [
+            'query' => [
+              'match_all' => new \StdClass(),
+            ],
+            'size' => 1000,
+          ]);
+
+        $transport->method('resultOrFuture')
+          ->willReturn([]);
+
+        (new MachineLearningNamespace($transport, $func))->getModels([
+          'body' => [
+            'query' => [
+              'match_all' => new \StdClass(),
+            ],
+            'size' => 1000,
+          ],
+        ]);
+    }
+
+    public function testDeployModel(): void
+    {
+
+        $func = static function () {
+            return new DeployModel();
+        };
+
+        $transport = $this->createMock(Transport::class);
+
+        $transport->method('performRequest')
+          ->with('POST', '/_plugins/_ml/models/foobar/_deploy', [], null);
+
+        $transport->method('resultOrFuture')
+          ->willReturn([]);
+
+        (new MachineLearningNamespace($transport, $func))->deployModel([
+          'id' => 'foobar',
+        ]);
+    }
+
+    public function testUnDeployModel(): void
+    {
+
+        $func = static function () {
+            return new UndeployModel();
+        };
+
+        $transport = $this->createMock(Transport::class);
+
+        $transport->method('performRequest')
+          ->with('POST', '/_plugins/_ml/models/foobar/_undeploy', [], null);
+
+        $transport->method('resultOrFuture')
+          ->willReturn([]);
+
+        (new MachineLearningNamespace($transport, $func))->undeployModel([
+          'id' => 'foobar',
+        ]);
+    }
+
+    public function testDeleteModel(): void
+    {
+
+        $func = static function () {
+            return new DeleteModel();
+        };
+
+        $transport = $this->createMock(Transport::class);
+
+        $transport->method('performRequest')
+          ->with('DELETE', '/_plugins/_ml/models/foobar', [], null);
+
+        $transport->method('resultOrFuture')
+          ->willReturn([]);
+
+        (new MachineLearningNamespace($transport, $func))->deleteModel([
+          'id' => 'foobar',
+        ]);
+    }
+
+    public function testPredict(): void
+    {
+
+        $func = static function () {
+            return new Predict();
+        };
+
+        $transport = $this->createMock(Transport::class);
+
+        $transport->method('performRequest')
+          ->with('POST', '/_plugins/_ml/models/foobar/_predict', [], [
+            'foo' => 'bar',
+          ]);
+
+        $transport->method('resultOrFuture')
+          ->willReturn([]);
+
+        (new MachineLearningNamespace($transport, $func))->predict([
+          'id' => 'foobar',
+          'body' => [
+            'foo' => 'bar',
+          ]
+        ]);
+    }
+
+    public function testGetTask(): void
+    {
+
+        $func = static function () {
+            return new GetTask();
+        };
+
+        $transport = $this->createMock(Transport::class);
+
+        $transport->method('performRequest')
+          ->with('GET', '/_plugins/_ml/tasks/foobar', [], null);
+
+        $transport->method('resultOrFuture')
+          ->willReturn([]);
+
+        (new MachineLearningNamespace($transport, $func))->getTask([
+          'id' => 'foobar',
+        ]);
+    }
+}


### PR DESCRIPTION
### Description
This PR implements the model, model group and connector apis from the ML Commons API so that developers can set up connectors to 3rd party tools like OpenAI as described here: https://github.com/opensearch-project/ml-commons/blob/main/docs/remote_inference_blueprints/openai_connector_embedding_blueprint.md

### Issues Resolved
Closes #169 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
