### PR TITLE
Add release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release to packagist
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+        id-token: write
+        issues: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - id: get_data
+        run: echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
+
+      - uses: trstringer/manual-approval@v1
+        with:
+          secret: ${{ github.TOKEN }}
+          approvers: ${{ steps.get_data.outputs.approvers }}
+          minimum-approvals: 2
+          issue-title: 'Release opensearch-PHP'
+          issue-body: "Please approve or deny the release of opensearch-PHP client on packagist. **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }}"
+          exclude-workflow-initiator-as-approver: true
+
+      - name: Release to Packagist
+        run: curl -XPOST -f -H 'content-type:application/json' 'https://packagist.org/api/update-package?username=opensearch&apiToken=${{secrets.PACKAGIST_PUBLISHING_API_TOKEN}}' -d'{"repository":{"url":"https://github.com/opensearch-project/opensearch-php"}}'
+
+      - name: Release on GitHub
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added code coverage reporting ([#100](https://github.com/opensearch-project/opensearch-php/pull/100))
 - Added support for a custom signing service name for AWS SigV4 ([#117](https://github.com/opensearch-project/opensearch-php/pull/117))
 - Added support for OpenSearch 2.12 and 2.13 ([#180](https://github.com/opensearch-project/opensearch-php/pull/180))
+- Added release automation to publish to packagist ([#183](https://github.com/opensearch-project/opensearch-php/pull/183))
 
 ### Changed
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -53,6 +53,8 @@ Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v
 
 The release process is standard across repositories in this org and is run by a release manager volunteering from amongst [MAINTAINERS](MAINTAINERS.md).
 
+Push a tag to this repository aganist the right commit. This triggers [release.yml](.github/workflows/release.yml) workflow which is responsible to get approval from the maintainers in the form of comments on the GitHub issue, release the client to packagist using manual webhook and finally publishing a release on the GitHub.
+
 ## Backporting
 
 This project follows [semantic versioning](https://semver.org/spec/v2.0.0.html). Backwards-incompatible changes always result in a new major version and will __never__ be backported. Small improvements and features will be backported to a new minor version (e.g. `1.1`). Security fixes will be backported to a new patch version (e.g. `1.0.1`).


### PR DESCRIPTION
### Description
Adds workflow that publishes the package to packagist using manual webook. Since we only want to publish when a tag is pushed and GitHub webhooks does not allow to specify what exact trigger we want, a manual webhook is used here. See https://packagist.org/about#how-to-update-packages
The flow would be:
push a tag -> runs the workflow -> creates issue asking for approval from codeowners -> once approved publish to packagist using manual webhook -> Publish a release on GH

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3146

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
