### PR TITLE
Fix permissions to release on GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
         id-token: write
         issues: write
+        contents: write
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
### Description
Should fix the workflow failure to release on GH

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
