### PR TITLE
Fix example in USER_GUIDE.md

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -217,7 +217,7 @@ class MyOpenSearchClass
     public function searchUsingSQL()
     {
         $docs = $this->client->sql()->query([
-          'query' => "SELECT * FROM INDEX_NAME WHERE name = 'wrecking'",
+          'query' => "SELECT * FROM " . INDEX_NAME . " WHERE name = 'wrecking'",
           'format' => 'json'
         ]);
         var_dump($docs['hits']['total']['value'] > 0);


### PR DESCRIPTION
### Description

In the SQL example the `INDEX_NAME` constant was interpreted as a string literal.

### Issues Resolved

None, this is a trivial change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
