### PR TITLE
Moved Endpoint Proxies in Namespace Generator to Separate Folder

### DIFF
--- a/util/EndpointProxies/indices/getAliasesProxy.php
+++ b/util/EndpointProxies/indices/getAliasesProxy.php
@@ -1,0 +1,15 @@
+<?php
+
+return <<<'EOD'
+    
+/**
+ * Alias function to getAlias()
+ *
+ * @deprecated added to prevent BC break introduced in 7.2.0
+ * @see https://github.com/elastic/elasticsearch-php/issues/940
+ */
+public function getAliases(array $params = [])
+{
+    return $this->getAlias($params);
+}
+EOD;

--- a/util/EndpointProxies/tasks/tasksListProxy.php
+++ b/util/EndpointProxies/tasks/tasksListProxy.php
@@ -1,0 +1,12 @@
+<?php
+
+return <<<'EOD'
+
+/**
+ * Proxy function to list() to prevent BC break since 7.4.0
+ */
+public function tasksList(array $params = [])
+{
+    return $this->list($params);
+}
+EOD;


### PR DESCRIPTION
### Description
Moved endpoint proxies from within the namespace generator code to a separate endpointproxies folder. This refactor improves code organization and allows for easier future additions.

### Issues Resolved
Related to #97 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
