### PR TITLE
Added @saimedhi to opensearch-php maintainers.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the team set up in https://github.com/orgs/opensearch-project/teams and include any additional contributors
-*   @VachaShah @dblock @harshavamsi @shyim
+*   @VachaShah @dblock @harshavamsi @shyim @saimedhi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added support for a custom signing service name for AWS SigV4 ([#117](https://github.com/opensearch-project/opensearch-php/pull/117))
 - Added support for OpenSearch 2.12 and 2.13 ([#180](https://github.com/opensearch-project/opensearch-php/pull/180))
 - Added release automation to publish to packagist ([#183](https://github.com/opensearch-project/opensearch-php/pull/183))
+- Added @saimedhi to opensearch-php maintainers ([#215](https://github.com/opensearch-project/opensearch-php/pull/215))
 
 ### Fixed
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,17 +4,16 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer           | GitHub ID                                     | Affiliation |
-| -------------------- | --------------------------------------------- | ----------- |
-| Soner Sayakci        | [shyim](https://github.com/shyim)             | shopware AG |
-| Vacha Shah           | [VachaShah](https://github.com/VachaShah)     | Amazon      |
-| Daniel Doubrovkine   | [dblock](https://github.com/dblock)           | Amazon      |
-| Harsha Vamsi Kalluri | [harshavamsi](https://github.com/harshavamsi) | Amazon      |
+| Maintainer                | GitHub ID                                     | Affiliation |
+| ------------------------- | --------------------------------------------- | ----------- |
+| Daniel Doubrovkine        | [dblock](https://github.com/dblock)           | Amazon      |
+| Harsha Vamsi Kalluri      | [harshavamsi](https://github.com/harshavamsi) | Amazon      |
+| Sai Medhini Reddy Maryada | [saimedhi](https://github.com/saimedhi)       | Amazon      |
+| Soner Sayakci             | [shyim](https://github.com/shyim)             | shopware AG |
+| Vacha Shah                | [VachaShah](https://github.com/VachaShah)     | Amazon      |
 
 ## Emeritus
 
 | Maintainer      | GitHub ID                                           | Affiliation |
 | --------------- | --------------------------------------------------- | ----------- |
 | Paul Borgermans | [paulborgermans](https://github.com/paulborgermans) | External    |
-
-


### PR DESCRIPTION
### Description

Following a unanimous maintainer vote, adding @saimedhi to opensearch-php maintainers. Welcome!

Sai recently took on her to significantly update the API generator and automate it end-to-end, https://github.com/opensearch-project/opensearch-php/pull/209. There’s a dozen other PRs in https://github.com/opensearch-project/opensearch-php/pulls?q=is%3Apr+is%3Aclosed+author%3Asaimedhi.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
