### PR TITLE
Add more precise types

### DIFF
--- a/src/OpenSearch/Common/Exceptions/Serializer/JsonErrorException.php
+++ b/src/OpenSearch/Common/Exceptions/Serializer/JsonErrorException.php
@@ -56,7 +56,11 @@ class JsonErrorException extends \Exception implements OpenSearchException
         10 => 'Attempted to decode nonexistent UTF-16 code-point' //JSON_ERROR_UTF16
     );
 
-    public function __construct($code, $input, $result, $previous = null)
+    /**
+     * @param mixed $input
+     * @param mixed $result
+     */
+    public function __construct(int $code, $input, $result, \Throwable $previous = null)
     {
         if (isset(self::$messages[$code]) !== true) {
             throw new \InvalidArgumentException(sprintf('Encountered unknown JSON error code: [%d]', $code));

--- a/src/OpenSearch/ConnectionPool/AbstractConnectionPool.php
+++ b/src/OpenSearch/ConnectionPool/AbstractConnectionPool.php
@@ -50,7 +50,7 @@ abstract class AbstractConnectionPool implements ConnectionPoolInterface
     protected $selector;
 
     /**
-     * @var array
+     * @var array<string, mixed>
      */
     protected $connectionPoolParams;
 
@@ -65,7 +65,7 @@ abstract class AbstractConnectionPool implements ConnectionPoolInterface
      * @param ConnectionInterface[]      $connections          The Connections to choose from
      * @param SelectorInterface          $selector             A Selector instance to perform the selection logic for the available connections
      * @param ConnectionFactoryInterface $factory              ConnectionFactory instance
-     * @param array                      $connectionPoolParams
+     * @param array<string, mixed>       $connectionPoolParams
      */
     public function __construct(array $connections, SelectorInterface $selector, ConnectionFactoryInterface $factory, array $connectionPoolParams)
     {

--- a/src/OpenSearch/ConnectionPool/SimpleConnectionPool.php
+++ b/src/OpenSearch/ConnectionPool/SimpleConnectionPool.php
@@ -29,7 +29,8 @@ use OpenSearch\Connections\ConnectionInterface;
 class SimpleConnectionPool extends AbstractConnectionPool implements ConnectionPoolInterface
 {
     /**
-     * {@inheritdoc}
+     * @param ConnectionInterface[] $connections
+     * @param array<string, mixed>  $connectionPoolParams
      */
     public function __construct($connections, SelectorInterface $selector, ConnectionFactoryInterface $factory, $connectionPoolParams)
     {

--- a/src/OpenSearch/ConnectionPool/SniffingConnectionPool.php
+++ b/src/OpenSearch/ConnectionPool/SniffingConnectionPool.php
@@ -41,7 +41,8 @@ class SniffingConnectionPool extends AbstractConnectionPool
     private $nextSniff;
 
     /**
-     * {@inheritdoc}
+     * @param ConnectionInterface[] $connections
+     * @param array<string, mixed>  $connectionPoolParams
      */
     public function __construct(
         $connections,
@@ -148,6 +149,9 @@ class SniffingConnectionPool extends AbstractConnectionPool
         return true;
     }
 
+    /**
+     * @return list<array{host: string, port: int}>
+     */
     private function parseClusterState($nodeInfo): array
     {
         $pattern = '/([^:]*):(\d+)/';
@@ -167,6 +171,9 @@ class SniffingConnectionPool extends AbstractConnectionPool
         return $hosts;
     }
 
+    /**
+     * @param array<string, mixed> $connectionPoolParams
+     */
     private function setConnectionPoolParams(array $connectionPoolParams): void
     {
         $this->sniffingInterval = (int)($connectionPoolParams['sniffingInterval'] ?? 300);

--- a/src/OpenSearch/ConnectionPool/StaticConnectionPool.php
+++ b/src/OpenSearch/ConnectionPool/StaticConnectionPool.php
@@ -40,7 +40,8 @@ class StaticConnectionPool extends AbstractConnectionPool implements ConnectionP
     private $maxPingTimeout = 3600;
 
     /**
-     * {@inheritdoc}
+     * @param ConnectionInterface[] $connections
+     * @param array<string, mixed>  $connectionPoolParams
      */
     public function __construct($connections, SelectorInterface $selector, ConnectionFactoryInterface $factory, $connectionPoolParams)
     {

--- a/src/OpenSearch/ConnectionPool/StaticNoPingConnectionPool.php
+++ b/src/OpenSearch/ConnectionPool/StaticNoPingConnectionPool.php
@@ -40,7 +40,8 @@ class StaticNoPingConnectionPool extends AbstractConnectionPool implements Conne
     private $maxPingTimeout = 3600;
 
     /**
-     * {@inheritdoc}
+     * @param ConnectionInterface[] $connections
+     * @param array<string, mixed>  $connectionPoolParams
      */
     public function __construct($connections, SelectorInterface $selector, ConnectionFactoryInterface $factory, $connectionPoolParams)
     {

--- a/src/OpenSearch/Connections/Connection.php
+++ b/src/OpenSearch/Connections/Connection.php
@@ -95,7 +95,7 @@ class Connection implements ConnectionInterface
     protected $connectionParams;
 
     /**
-     * @var array
+     * @var array<string, list<string>>
      */
     protected $headers = [];
 
@@ -129,6 +129,10 @@ class Connection implements ConnectionInterface
      */
     private $OSVersion = null;
 
+    /**
+     * @param array{host: string, port?: int, scheme?: string, user?: string, pass?: string, path?: string} $hostDetails
+     * @param array{client?: array{headers?: array<string, list<string>>, curl?: array<int, mixed>}} $connectionParams
+     */
     public function __construct(
         callable $handler,
         array $hostDetails,
@@ -192,10 +196,10 @@ class Connection implements ConnectionInterface
     /**
      * @param  string    $method
      * @param  string    $uri
-     * @param  null|array   $params
-     * @param  null|mixed   $body
+     * @param  null|array<string, mixed> $params
+     * @param  mixed     $body
      * @param  array     $options
-     * @param  Transport $transport
+     * @param  Transport|null $transport
      * @return mixed
      */
     public function performRequest(string $method, string $uri, ?array $params = [], $body = null, array $options = [], Transport $transport = null)
@@ -344,6 +348,9 @@ class Connection implements ConnectionInterface
         };
     }
 
+    /**
+     * @param array<string, string|int|bool>|null $params
+     */
     private function getURI(string $uri, ?array $params): string
     {
         if (isset($params) === true && !empty($params)) {
@@ -370,6 +377,9 @@ class Connection implements ConnectionInterface
         return $uri;
     }
 
+    /**
+     * @return array<string, list<string>>
+     */
     public function getHeaders(): array
     {
         return $this->headers;

--- a/src/OpenSearch/Connections/ConnectionFactory.php
+++ b/src/OpenSearch/Connections/ConnectionFactory.php
@@ -51,6 +51,9 @@ class ConnectionFactory implements ConnectionFactoryInterface
      */
     private $handler;
 
+    /**
+     * @param array{client?: array{headers?: array<string, list<string>>, curl?: array<int, mixed>}} $connectionParams
+     */
     public function __construct(callable $handler, array $connectionParams, SerializerInterface $serializer, LoggerInterface $logger, LoggerInterface $tracer)
     {
         $this->handler          = $handler;

--- a/src/OpenSearch/Connections/ConnectionFactoryInterface.php
+++ b/src/OpenSearch/Connections/ConnectionFactoryInterface.php
@@ -23,5 +23,8 @@ namespace OpenSearch\Connections;
 
 interface ConnectionFactoryInterface
 {
+    /**
+     * @param array{host: string, port?: int, scheme?: string, user?: string, pass?: string, path?: string} $hostDetails
+     */
     public function create(array $hostDetails): ConnectionInterface;
 }

--- a/src/OpenSearch/Connections/ConnectionInterface.php
+++ b/src/OpenSearch/Connections/ConnectionInterface.php
@@ -75,7 +75,8 @@ interface ConnectionInterface
     public function getLastRequestInfo(): array;
 
     /**
-     * @param  null $body
+     * @param array<string, mixed>|null $params
+     * @param  mixed $body
      * @return mixed
      */
     public function performRequest(string $method, string $uri, ?array $params = [], $body = null, array $options = [], Transport $transport = null);

--- a/src/OpenSearch/Endpoints/AbstractEndpoint.php
+++ b/src/OpenSearch/Endpoints/AbstractEndpoint.php
@@ -113,6 +113,8 @@ abstract class AbstractEndpoint
     }
 
     /**
+     * @param string|string[]|null $index
+     *
      * @return $this
      */
     public function setIndex($index)
@@ -188,7 +190,7 @@ abstract class AbstractEndpoint
     }
 
     /**
-     * @param array $params
+     * @param array<string, mixed> $params
      *
      * @throws UnexpectedValueException
      */
@@ -218,7 +220,7 @@ abstract class AbstractEndpoint
     }
 
     /**
-     * @param array $params Note: this is passed by-reference!
+     * @param array<string, mixed> $params Note: this is passed by-reference!
      */
     private function extractOptions(&$params)
     {
@@ -248,6 +250,11 @@ abstract class AbstractEndpoint
         }
     }
 
+    /**
+     * @param array<string, mixed> $params
+     *
+     * @return array<string, mixed>
+     */
     private function convertCustom(array $params): array
     {
         if (isset($params['custom']) === true) {
@@ -285,7 +292,7 @@ abstract class AbstractEndpoint
     }
 
     /**
-     * This function returns all param deprecations also optional with an replacement field
+     * This function returns all param deprecations also optional with a replacement field
      *
      * @return array<string, string|null>
      */

--- a/src/OpenSearch/Handlers/SigV4Handler.php
+++ b/src/OpenSearch/Handlers/SigV4Handler.php
@@ -13,10 +13,22 @@ use OpenSearch\ClientBuilder;
 use Psr\Http\Message\RequestInterface;
 use RuntimeException;
 
+/**
+ * @phpstan-type RingPhpRequest array{http_method: string, scheme: string, uri: string, query_string?: string, version?: string, headers: array<string, list<string>>, body: string|resource|null, client?: array<string, mixed>}
+ */
 class SigV4Handler
 {
+    /**
+     * @var SignatureV4
+     */
     private $signer;
+    /**
+     * @var callable
+     */
     private $credentialProvider;
+    /**
+     * @var callable
+     */
     private $wrappedHandler;
 
     /**
@@ -46,6 +58,9 @@ class SigV4Handler
             ?: CredentialProvider::defaultProvider();
     }
 
+    /**
+     * @phpstan-param RingPhpRequest $request
+     */
     public function __invoke(array $request)
     {
         $creds = call_user_func($this->credentialProvider)->wait();
@@ -66,6 +81,9 @@ class SigV4Handler
         }
     }
 
+    /**
+     * @phpstan-param RingPhpRequest $ringPhpRequest
+     */
     private function createPsr7Request(array $ringPhpRequest): Request
     {
         // fix for uppercase 'Host' array key in elasticsearch-php 5.3.1 and backward compatible
@@ -96,6 +114,11 @@ class SigV4Handler
         );
     }
 
+    /**
+     * @phpstan-param RingPhpRequest $originalRequest
+     *
+     * @phpstan-return RingPhpRequest
+     */
     private function createRingRequest(RequestInterface $request, array $originalRequest): array
     {
         $uri = $request->getUri();

--- a/src/OpenSearch/Transport.php
+++ b/src/OpenSearch/Transport.php
@@ -90,7 +90,7 @@ class Transport
      *
      * @param string     $method  HTTP method to use
      * @param string     $uri     HTTP URI to send request to
-     * @param array      $params  Optional query parameters
+     * @param array<string, mixed> $params  Optional query parameters
      * @param mixed|null $body    Optional query body
      * @param array      $options
      *

--- a/tests/ClientIntegrationTest.php
+++ b/tests/ClientIntegrationTest.php
@@ -37,7 +37,7 @@ use Psr\Log\LogLevel;
 class ClientIntegrationTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * ArrayLogger
+     * @var ArrayLogger
      */
     private $logger;
 

--- a/tests/Handlers/SigV4HandlerTest.php
+++ b/tests/Handlers/SigV4HandlerTest.php
@@ -15,6 +15,9 @@ class SigV4HandlerTest extends TestCase
 {
     private const ENV_KEYS_USED = [CredentialProvider::ENV_KEY, CredentialProvider::ENV_SECRET];
 
+    /**
+     * @var array<string, string|false>
+     */
     private $envTemp = [];
 
     protected function setUp(): void

--- a/tests/Utility.php
+++ b/tests/Utility.php
@@ -29,7 +29,7 @@ use OpenSearch\Common\Exceptions\OpenSearchException;
 class Utility
 {
     /**
-     * @var array|null
+     * @var array{number: string, distribution?: string, build_flavor: string, build_date: string, build_hash: string, build_snapshot: bool, build_type: string, lucene_version: string, minimum_index_compatibility_version: string, minimum_wire_compatibility_version: string}|null
      */
     private static $version;
 
@@ -110,6 +110,9 @@ class Utility
         return version_compare($versionNumber, $version) >= 0;
     }
 
+    /**
+     * @return array{number: string, distribution?: string, build_flavor: string, build_date: string, build_hash: string, build_snapshot: bool, build_type: string, lucene_version: string, minimum_index_compatibility_version: string, minimum_wire_compatibility_version: string}
+     */
     private static function getVersion(Client $client): array
     {
         if (!isset(self::$version)) {


### PR DESCRIPTION
### Description
This adds more precise types for some parts of the package. This PR specifically targets only places that are *not* generated by the `GenerateEndpoints` script (this will be covered by a separate PR solving #217).
I found those by running phpstan at level 6 (instead of the existing config using level 5). This PR does not solve all non-endpoints errors of level 6:
- I excluded most of the errors reported in tests (more precise types in tests don't bring benefits to consumers of the package, especially when the missing types are the `void` return types on test methods themselves)
- I haven't added the more precise type for `SerializerInterface::deserialize` as I'm not sure about the correct type:
    - `$body` has a native type `?string` but the phpdoc type says `string` and implementations don't seem to account for `null` (so maybe `string` is the expected type
    - I'm not sure about the expected type for `$headers` as callers are passing `$response['transfer_stats']` there (while ringphp documents that response headers are in `$response['headers']`)
 - I haven't solve all errors in `Connection` because dealing with RingPhp responses is complex.

Those can be solved later (before enabling level 6)

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
