### PR TITLE
Add a proxy for closeCursor for backwards-compatibility.

### DIFF
--- a/util/ClientEndpoint.php
+++ b/util/ClientEndpoint.php
@@ -50,7 +50,7 @@ class ClientEndpoint extends NamespaceEndpoint
         $useNamespace = '';
 
         // The following namespaces do not have OpenSearch API specifications
-        $patchnamespaces = ['async_search', 'searchable_snapshots', 'ssl', 'sql', 'data_frame_transform_deprecated', 'monitoring'];
+        $patchnamespaces = ['async_search', 'searchable_snapshots', 'ssl', 'data_frame_transform_deprecated', 'monitoring'];
         $this->namespace = array_unique(array_merge($this->namespace, $patchnamespaces));
         sort($this->namespace);
 

--- a/util/EndpointProxies/sql/closeCursorProxy.php
+++ b/util/EndpointProxies/sql/closeCursorProxy.php
@@ -1,0 +1,24 @@
+<?php
+
+return <<<'EOD'
+    /**
+     * This API will be removed in a future version. Use 'close' API instead.
+     * 
+     * $params['cursor'] = (string) The cursor given by the server
+     *
+     * @param array{'cursor': string} $params Associative array of parameters
+     * @return array
+     */
+    public function closeCursor(array $params): array
+    {
+        $endpointBuilder = $this->endpoints;
+
+        $endpoint = $endpointBuilder('Sql\Close');
+        $endpoint->setBody(array_filter([
+            'cursor' => $this->extractArgument($params, 'cursor'),
+        ]));
+        $endpoint->setParams($params);
+
+        return $this->performRequest($endpoint);
+    }
+EOD;

--- a/util/EndpointProxies/sql/explainProxy.php
+++ b/util/EndpointProxies/sql/explainProxy.php
@@ -1,0 +1,27 @@
+<?php
+
+return <<<'EOD'
+    /**
+     * $params['query'] = (string) The SQL Query
+     *
+     * @param array{'query': string} $params Associative array of parameters
+     * @return array
+     *
+     * Note: Use of query parameter is deprecated. Pass it in `body` instead.
+     */
+    public function explain(array $params): array
+    {
+        $endpointBuilder = $this->endpoints;
+
+        $body = $this->extractArgument($params, 'body') ?? [];
+        $query = $this->extractArgument($params, 'query');
+
+        $endpoint = $endpointBuilder('Sql\Explain');
+        $endpoint->setBody(array_merge($body, [
+            'query' => $query,
+        ]));
+        $endpoint->setParams($params);
+
+        return $this->performRequest($endpoint);
+    }
+EOD;

--- a/util/EndpointProxies/sql/queryProxy.php
+++ b/util/EndpointProxies/sql/queryProxy.php
@@ -1,0 +1,31 @@
+<?php
+
+return <<<'EOD'
+    /**
+     * $params['query'] = (string) The SQL Query
+     * $params['format'] = (string) The response format
+     * $params['cursor'] = (string) The cursor given by the server
+     * $params['fetch_size'] = (int) The fetch size
+     *
+     * @param array{'query'?: string, 'cursor'?: string, 'fetch_size'?: int} $params Associative array of parameters
+     * @return array
+     *
+     * Note: Use of `query`, `cursor` and `fetch_size` parameters is deprecated. Pass them in `body` instead.
+     * 
+     */
+    public function query(array $params): array
+    {
+        $endpointBuilder = $this->endpoints;
+
+        $endpoint = $endpointBuilder('Sql\Query');
+        $body = $this->extractArgument($params, 'body') ?? [];
+        $endpoint->setBody(array_merge($body, array_filter([
+            'query' => $this->extractArgument($params, 'query'),
+            'cursor' => $this->extractArgument($params, 'cursor'),
+            'fetch_size' => $this->extractArgument($params, 'fetch_size'),
+        ])));
+        $endpoint->setParams($params);
+
+        return $this->performRequest($endpoint);
+    }
+EOD;


### PR DESCRIPTION
### Description

In the next round of code generation in https://github.com/opensearch-project/opensearch-php/pull/213 we are loosing a method and changing the behavior of two others wrt `body` parameters being copied from query to body, as the SQL API has been added to the spec and can now be auto-generated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
