### PR TITLE
Run unit tests with PHP 8.3 and 8.4 on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Use PHP 8.2
+      - name: Use PHP 8.3
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.3
           extensions: yaml, zip, curl
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -37,10 +37,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Use PHP 8.2
+      - name: Use PHP 8.3
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.3
           extensions: yaml, zip, curl
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -70,10 +70,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Use PHP 8.2
+      - name: Use PHP 8.3
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.3
           extensions: yaml, zip, curl, pcov
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -155,10 +155,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Use PHP 8.2
+    - name: Use PHP 8.3
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.2
+        php-version: 8.3
         extensions: yaml, zip, curl
       env:
         COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -214,10 +214,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Use PHP 8.2
+    - name: Use PHP 8.3
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.2
+        php-version: 8.3
         extensions: yaml, zip, curl
       env:
         COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -262,10 +262,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Use PHP 8.2
+    - name: Use PHP 8.3
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.2
+        php-version: 8.3
         extensions: yaml, zip, curl
       env:
         COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,8 @@ jobs:
           - '8.0'
           - '8.1'
           - '8.2'
+          - '8.3'
+          - '8.4'
         os:
           - ubuntu-latest
           - macos-latest

--- a/.github/workflows/test_unreleased.yml
+++ b/.github/workflows/test_unreleased.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Checkout PHP Client
         uses: actions/checkout@v2
 
-      - name: Use PHP 8.2
+      - name: Use PHP 8.3
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.3
           extensions: yaml, zip, curl
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -19,10 +19,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Use PHP 8.2
+      - name: Use PHP 8.3
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.3
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Generate endpoints from OpenSearch API Specification ([#194](https://github.com/opensearch-project/opensearch-php/pull/194))
 - Added workflow for automated API update using OpenSearch API specification ([#209](https://github.com/opensearch-project/opensearch-php/pull/209))
 - Added samples ([#218](https://github.com/opensearch-project/opensearch-php/pull/218))
+- Added support for PHP 8.3 and 8.4 ([#229](https://github.com/opensearch-project/opensearch-php/pull/229))
 ### Changed
 - Increased min version of `ezimuel/ringphp` to `^1.2.2`
 ### Deprecated
 ### Removed
 ### Fixed
-- Fixed upcomming PHP 8.4 deprecations
+- Fixed PHP 8.4 deprecations
 ### Updated APIs
 - Updated opensearch-php APIs to reflect [opensearch-api-specification@cb320b5](https://github.com/opensearch-project/opensearch-api-specification/commit/cb320b5482551c4f28afa26ff0d1653332699722)
 ### Security


### PR DESCRIPTION
### Description

This PR runs `composer run unit` with PHP 8.3 and 8.4 in CI. Previously only PHP 7.3 - 8.2 were tested.

### Issues Resolved

n/a 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
