### PR TITLE
Add `--warning-mode none` when assembling OpenSearch in CI

### DIFF
--- a/.github/workflows/test_unreleased.yml
+++ b/.github/workflows/test_unreleased.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Assemble OpenSearch
         if: steps.cache-restore.outputs.cache-hit != 'true'
         working-directory: opensearch
-        run: ./gradlew :distribution:archives:linux-tar:assemble
+        run: ./gradlew :distribution:archives:linux-tar:assemble --warning-mode none
 
       - name: Save cached build
         if: steps.cache-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/test_unreleased.yml
+++ b/.github/workflows/test_unreleased.yml
@@ -50,6 +50,12 @@ jobs:
           path: opensearch/distribution/archives/linux-tar/build/distributions
           key: ${{ steps.get-key.outputs.key }}
 
+      - uses: actions/setup-java@v4
+        if: steps.cache-restore.outputs.cache-hit != 'true'
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
       - name: Assemble OpenSearch
         if: steps.cache-restore.outputs.cache-hit != 'true'
         working-directory: opensearch


### PR DESCRIPTION
### Description

This should hopefully fix the integration test with unreleased OpenSearch versions, as per:

https://github.com/opensearch-project/opensearch-php/pull/229#pullrequestreview-2382054150

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
