### PR TITLE
Require minimum PHP 8.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,8 +102,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - '7.3'
-          - '7.4'
           - '8.0'
           - '8.1'
           - '8.2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Changed fluent setters to return static
 ### Deprecated
 ### Removed
+- Removed support for PHP 7.3 and 7.4
 ### Fixed
 - Fixed PHP 8.4 deprecations
 ### Updated APIs

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     }
   ],
   "require": {
-    "php": "^7.3 || ^8.0",
+    "php": "^8.0",
     "ext-json": ">=1.3.7",
     "ext-curl": "*",
     "ezimuel/ringphp": "^1.2.2",


### PR DESCRIPTION
### Description
PHP 7.4 was EOL 2 years ago (Nov 2022). We want to use modern PHP features such as static return types. This requires PHP 8.0+

### Issues Resolved
Fixes build failure in #238 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
