### PR TITLE
Added optional headers to the AWS SigningDecorator.

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -101,6 +101,7 @@ $transport = (new \OpenSearch\TransportFactory())
     ->setRequestFactory($requestFactory)
     ->create();
 
+$endpointFactory = new \OpenSearch\EndpointFactory();
 $client = new \OpenSearch\Client($transport, $endpointFactory, []);
 
 // Send a request to the 'info' endpoint.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -504,4 +504,6 @@ $client = \OpenSearch\ClientBuilder::fromConfig($config);
 
 ## Advanced Features
 
+* [Authentication](guides/auth.md)
 * [ML Commons](guides/ml-commons.md)
+* [Sending Raw JSON Requests](guides/raw-request.md)

--- a/guides/auth.md
+++ b/guides/auth.md
@@ -1,0 +1,124 @@
+- [Authentication](#authentication)
+  - [Basic Auth](#basic-auth)
+    - [Using `\OpenSearch\ClientBuilder`](#using-opensearchclientbuilder)
+    - [Using a Psr Client](#using-a-psr-client)
+  - [IAM Authentication](#iam-authentication)
+    - [Using `\OpenSearch\ClientBuilder`](#using-opensearchclientbuilder-1)
+    - [Using a Psr Client](#using-a-psr-client-1)
+
+# Authentication
+
+OpenSearch allows you to use different methods for the authentication.
+
+## Basic Auth
+
+```php
+$endpoint = "https://localhost:9200"
+$username = "admin"
+$password = "..."
+```
+
+### Using `\OpenSearch\ClientBuilder`
+
+```php
+$client = (new \OpenSearch\ClientBuilder())
+    ->setBasicAuthentication($username, $password) 
+    ->setHosts([$endpoint])
+    ->setSSLVerification(false) // for testing only
+    ->build();
+```
+
+### Using a Psr Client
+
+```php
+$symfonyPsr18Client = (new \Symfony\Component\HttpClient\Psr18Client())->withOptions([
+    'base_uri' => $endpoint,
+    'auth_basic' => [$username, $password],
+    'verify_peer' => false, // for testing only
+    'headers' => [
+        'Accept' => 'application/json',
+        'Content-Type' => 'application/json',
+    ],
+]);
+```
+
+## IAM Authentication
+
+This library supports IAM-based authentication when communicating with OpenSearch clusters running in Amazon Managed OpenSearch and OpenSearch Serverless.
+
+```php
+$endpoint = "https://search-....us-west-2.es.amazonaws.com"
+$region = "us-west-2"
+$service = "es"
+$aws_access_key_id = ...
+$aws_secret_access_key = ...
+$aws_session_token = ...
+```
+
+### Using `\OpenSearch\ClientBuilder`
+
+```php
+$client = (new \OpenSearch\ClientBuilder())
+  ->setHosts([$endpoint])
+  ->setSigV4Region($region)    
+  ->setSigV4Service('es')
+  ->setSigV4CredentialProvider([
+      'key' => $aws_access_key_id,
+      'secret' => $aws_secret_access_key,
+      'token' => $aws_session_token
+    ])
+  ->build();
+```
+
+### Using a Psr Client
+
+```php
+$symfonyPsr18Client = (new \Symfony\Component\HttpClient\Psr18Client())->withOptions([
+    'base_uri' => $endpoint,
+    'headers' => [
+        'Accept' => 'application/json',
+        'Content-Type' => 'application/json',
+    ],
+]);
+
+$serializer = new \OpenSearch\Serializers\SmartSerializer();
+$endpointFactory = new \OpenSearch\EndpointFactory();
+
+$signer = new Aws\Signature\SignatureV4(
+    $service,
+    $region
+);
+
+$credentials = new Aws\Credentials\Credentials(
+    $aws_access_key_id,
+    $aws_secret_access_key,
+    $aws_session_token
+);
+
+$signingClient = new \OpenSearch\Aws\SigningClientDecorator(
+    $symfonyPsr18Client,
+    $credentials,
+    $signer, 
+    [
+        'Host' => parse_url(getenv("ENDPOINT"))['host']
+    ]
+);
+
+$requestFactory = new \OpenSearch\RequestFactory(
+    $symfonyPsr18Client,
+    $symfonyPsr18Client,
+    $symfonyPsr18Client,
+    $serializer,
+);
+
+$transport = (new \OpenSearch\TransportFactory())
+    ->setHttpClient($signingClient)
+    ->setRequestFactory($requestFactory)
+    ->create();
+
+$client = new \OpenSearch\Client(
+    $transport,
+    $endpointFactory,
+    []
+);
+```

--- a/guides/raw-request.md
+++ b/guides/raw-request.md
@@ -1,12 +1,12 @@
-# Raw JSON Requests
+# Sending Raw JSON Requests
 
-Opensearch client implements many high-level APIs out of the box. However, there are times when you need to send a raw
+OpenSearch client implements many high-level APIs out of the box. However, there are times when you need to send a raw
 JSON request to the server. This can be done using the `request()` method of the client.
 
 The `request()` method expects the following parameters:
 
 | Parameter     | Description                                                                  |
-|---------------|------------------------------------------------------------------------------|
+| ------------- | ---------------------------------------------------------------------------- |
 | `$method`     | The HTTP method to use for the request, `GET`, `POST`, `PUT`, `DELETE`, etc. |
 | `$uri`        | The URI to send the request to, e.g. `/_search`.                             |
 | `$attributes` | An array of request options. `body`, `params` & `options`                    |

--- a/src/OpenSearch/Aws/SigningClientDecorator.php
+++ b/src/OpenSearch/Aws/SigningClientDecorator.php
@@ -13,15 +13,27 @@ use Psr\Http\Message\ResponseInterface;
  */
 class SigningClientDecorator implements ClientInterface
 {
+    /**
+     * @param ClientInterface $inner The client to decorate.
+     * @param CredentialsInterface $credentials The AWS credentials to use for signing requests.
+     * @param SignatureInterface $signer The AWS signer to use for signing requests.
+     * @param array $headers Additional headers to add to the request, usually `Host` is required.
+     * @return void
+     */
     public function __construct(
         protected ClientInterface $inner,
         protected CredentialsInterface $credentials,
         protected SignatureInterface $signer,
+        protected array $headers = []
     ) {
     }
 
     public function sendRequest(RequestInterface $request): ResponseInterface
     {
+        foreach ($this->headers as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+
         $request = $request->withHeader('x-amz-content-sha256', hash('sha256', (string) $request->getBody()));
         $request = $this->signer->signRequest($request, $this->credentials);
         return $this->inner->sendRequest($request);

--- a/src/OpenSearch/Aws/SigningClientDecorator.php
+++ b/src/OpenSearch/Aws/SigningClientDecorator.php
@@ -17,7 +17,7 @@ class SigningClientDecorator implements ClientInterface
      * @param ClientInterface $inner The client to decorate.
      * @param CredentialsInterface $credentials The AWS credentials to use for signing requests.
      * @param SignatureInterface $signer The AWS signer to use for signing requests.
-     * @param array $headers Additional headers to add to the request, usually `Host` is required.
+     * @param array $headers Additional headers to add to the request. `Host` is required.
      * @return void
      */
     public function __construct(

--- a/src/OpenSearch/Aws/SigningClientDecorator.php
+++ b/src/OpenSearch/Aws/SigningClientDecorator.php
@@ -34,6 +34,10 @@ class SigningClientDecorator implements ClientInterface
             $request = $request->withHeader($name, $value);
         }
 
+        if (empty($request->getHeaderLine('Host'))) {
+            throw new \RuntimeException('Missing Host header.');
+        }
+
         $request = $request->withHeader('x-amz-content-sha256', hash('sha256', (string) $request->getBody()));
         $request = $this->signer->signRequest($request, $this->credentials);
         return $this->inner->sendRequest($request);

--- a/tests/Aws/SigningClientDecoratorGuzzleTest.php
+++ b/tests/Aws/SigningClientDecoratorGuzzleTest.php
@@ -52,7 +52,14 @@ class SigningClientDecoratorGuzzleTest extends TestCase
         $credentials = $this->createMock(CredentialsInterface::class);
         $signer = new SignatureV4('es', 'us-east-1');
 
-        $decorator = new SigningClientDecorator($guzzleClient, $credentials, $signer);
+        $decorator = new SigningClientDecorator(
+            $guzzleClient,
+            $credentials,
+            $signer,
+            [
+                'Host' => 'search.host'
+            ]
+        );
 
         $transport = (new TransportFactory())
             ->setHttpClient($decorator)
@@ -66,7 +73,7 @@ class SigningClientDecoratorGuzzleTest extends TestCase
 
         // Check the last request to ensure it was signed and has a host header.
         $lastRequest = $mockHandler->getLastRequest();
-        $this->assertEquals('localhost:9200', $lastRequest->getHeader('Host')[0]);
+        $this->assertEquals('search.host', $lastRequest->getHeader('Host')[0]);
         $this->assertNotEmpty($lastRequest->getHeader('x-amz-content-sha256'));
         $this->assertNotEmpty($lastRequest->getHeader('x-amz-date'));
         $this->assertNotEmpty($lastRequest->getHeader('Authorization'));

--- a/tests/Aws/SigningClientDecoratorSymfonyTest.php
+++ b/tests/Aws/SigningClientDecoratorSymfonyTest.php
@@ -51,7 +51,14 @@ class SigningClientDecoratorSymfonyTest extends TestCase
         $credentials = $this->createMock(CredentialsInterface::class);
         $signer = new SignatureV4('es', 'us-east-1');
 
-        $decorator = new SigningClientDecorator($symfonyPsr18Client, $credentials, $signer);
+        $decorator = new SigningClientDecorator(
+            $symfonyPsr18Client,
+            $credentials,
+            $signer,
+            [
+                'Host' => 'search.host'
+            ]
+        );
 
         $transport = (new TransportFactory())
             ->setHttpClient($decorator)
@@ -71,8 +78,5 @@ class SigningClientDecoratorSymfonyTest extends TestCase
         $this->assertArrayHasKey('x-amz-content-sha256', $requestHeaders);
         $this->assertArrayHasKey('x-amz-date', $requestHeaders);
         $this->assertArrayHasKey('host', $requestHeaders);
-
     }
-
-
 }

--- a/tests/Aws/SigningClientDecoratorTest.php
+++ b/tests/Aws/SigningClientDecoratorTest.php
@@ -49,4 +49,16 @@ class SigningClientDecoratorTest extends TestCase
         $request = new Request('GET', 'http://localhost:9200/_search');
         $decorator->sendRequest($request);
     }
+
+    public function testSendRequestWithEmptyHostHeader(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Missing Host header.');
+        $client = $this->createMock(ClientInterface::class);
+        $credentials = $this->createMock(CredentialsInterface::class);
+        $signer = $this->createMock(SignatureV4::class);
+        $decorator = new SigningClientDecorator($client, $credentials, $signer, []);
+        $request = new Request('GET', 'http://localhost:9200/_search', ['Host' => '']);
+        $decorator->sendRequest($request);
+    }
 }

--- a/tests/Aws/SigningClientDecoratorTest.php
+++ b/tests/Aws/SigningClientDecoratorTest.php
@@ -34,8 +34,9 @@ class SigningClientDecoratorTest extends TestCase
             ->method('sendRequest')
             ->with(
                 $this->callback(function (Request $req): bool {
-                    $this->assertEquals('localhost:9200', $req->getHeaderLine('Host'));
+                    $this->assertEquals('server:443', $req->getHeaderLine('Host'));
                     $this->assertEquals('GET', $req->getMethod());
+                    $this->assertTrue($req->hasHeader('Host'));
                     $this->assertTrue($req->hasHeader('Authorization'));
                     $this->assertTrue($req->hasHeader('x-amz-content-sha256'));
                     $this->assertTrue($req->hasHeader('x-amz-date'));
@@ -44,7 +45,7 @@ class SigningClientDecoratorTest extends TestCase
             )
             ->willReturn($this->createMock(ResponseInterface::class));
 
-        $decorator = new SigningClientDecorator($client, $credentials, $signer);
+        $decorator = new SigningClientDecorator($client, $credentials, $signer, ['Host' => 'server:443']);
         $request = new Request('GET', 'http://localhost:9200/_search');
         $decorator->sendRequest($request);
     }


### PR DESCRIPTION
### Description

- Added an optional `headers` to the signing decorator to pass `Host`.
- Added docs on auth.

### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-php/issues/248.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
