### PR TITLE
Handle HTTP exceptions in HttpTransport

### DIFF
--- a/src/OpenSearch/Client.php
+++ b/src/OpenSearch/Client.php
@@ -21,17 +21,6 @@ declare(strict_types=1);
 
 namespace OpenSearch;
 
-use OpenSearch\Common\Exceptions\BadRequest400Exception;
-use OpenSearch\Common\Exceptions\Conflict409Exception;
-use OpenSearch\Common\Exceptions\Forbidden403Exception;
-use OpenSearch\Common\Exceptions\Missing404Exception;
-use OpenSearch\Common\Exceptions\NoDocumentsToGetException;
-use OpenSearch\Common\Exceptions\NoShardAvailableException;
-use OpenSearch\Common\Exceptions\RequestTimeout408Exception;
-use OpenSearch\Common\Exceptions\RoutingMissingException;
-use OpenSearch\Common\Exceptions\ScriptLangNotSupportedException;
-use OpenSearch\Common\Exceptions\ServerErrorResponseException;
-use OpenSearch\Common\Exceptions\Unauthorized401Exception;
 use OpenSearch\Endpoints\AbstractEndpoint;
 use OpenSearch\Namespaces\BooleanRequestWrapper;
 use OpenSearch\Namespaces\NamespaceBuilderInterface;
@@ -105,11 +94,6 @@ class Client
      * @var NamespaceBuilderInterface[]
      */
     protected $registeredNamespaces = [];
-
-    /**
-     * @deprecated in 2.3.2 and will be removed in 3.0.0.
-     */
-    private bool $throwExceptions = false;
 
     /**
      * @var AsyncSearchNamespace
@@ -284,13 +268,11 @@ class Client
      * @param TransportInterface|Transport $transport
      * @param callable|EndpointFactoryInterface $endpointFactory
      * @param NamespaceBuilderInterface[] $registeredNamespaces
-     * @param bool $throwExceptions
      */
     public function __construct(
         TransportInterface|Transport $transport,
         callable|EndpointFactoryInterface $endpointFactory,
         array $registeredNamespaces,
-        bool $throwExceptions = false,
     ) {
         if (!$transport instanceof TransportInterface) {
             @trigger_error('Passing an instance of \OpenSearch\Transport to ' . __METHOD__ . '() is deprecated in 2.3.2 and will be removed in 3.0.0. Pass an instance of \OpenSearch\TransportInterface instead.', E_USER_DEPRECATED);
@@ -311,13 +293,6 @@ class Client
         }
         $this->endpoints = $endpoints;
         $this->endpointFactory = $endpointFactory;
-        if ($throwExceptions === true) {
-            @trigger_error(
-                'The $throwExceptions parameter is deprecated in 2.4.0 and will be removed in 3.0.0. Check the response \'status_code\' instead',
-                E_USER_DEPRECATED
-            );
-            $this->throwExceptions = true;
-        }
         $this->asyncSearch = new AsyncSearchNamespace($transport, $this->endpointFactory);
         $this->asynchronousSearch = new AsynchronousSearchNamespace($transport, $this->endpointFactory);
         $this->cat = new CatNamespace($transport, $this->endpointFactory);
@@ -2098,7 +2073,7 @@ class Client
      * Send a raw request to the cluster.
      *
      * @throws \Psr\Http\Client\ClientExceptionInterface
-     * @throws \OpenSearch\Common\Exceptions\OpenSearchException
+     * @throws \OpenSearch\Exception\HttpExceptionInterface
      */
     public function request(
         string $method,
@@ -2109,117 +2084,24 @@ class Client
         $body = $attributes['body'] ?? null;
         $options = $attributes['options'] ?? [];
 
-        $response = $this->httpTransport->sendRequest($method, $uri, $params, $body, $options['headers'] ?? []);
-
-        // @todo: Remove this in the next major release.
-        // Throw legacy exceptions.
-        if ($this->throwExceptions) {
-            if (isset($response['status']) && $response['status'] >= 400) {
-                $this->throwLegacyException($response);
-            }
-        }
-
-        return $response;
+        return $this->httpTransport->sendRequest($method, $uri, $params, $body, $options['headers'] ?? []);
     }
 
     /**
      * Send a request for an endpoint.
      *
      * @throws \Psr\Http\Client\ClientExceptionInterface
-     * @throws \OpenSearch\Common\Exceptions\OpenSearchException
+     * @throws \OpenSearch\Exception\HttpExceptionInterface
      */
     private function performRequest(AbstractEndpoint $endpoint): array|string|null
     {
-        $response = $this->httpTransport->sendRequest(
+        return $this->httpTransport->sendRequest(
             $endpoint->getMethod(),
             $endpoint->getURI(),
             $endpoint->getParams(),
             $endpoint->getBody(),
             $endpoint->getOptions()
         );
-
-        // @todo: Remove this in the next major release.
-        // Throw legacy exceptions.
-        if ($this->throwExceptions) {
-            if (isset($response['status']) && $response['status'] >= 400) {
-                $this->throwLegacyException($response);
-            }
-        }
-
-        return $response;
-    }
-
-    /**
-     * Throw legacy exceptions.
-     *
-     * @param array<string,mixed> $response
-     *
-     * @throws \OpenSearch\Common\Exceptions\OpenSearchException
-     */
-    private function throwLegacyException(array $response): void
-    {
-        if ($response['status'] >= 400 && $response['status'] < 500) {
-            $this->throwLegacyClientException($response);
-        }
-        if ($response['status'] >= 500) {
-            $this->throwLegacyServerException($response);
-        }
-    }
-
-    /**
-     * Throw legacy client exceptions based on status code.
-     *
-     * @throws \OpenSearch\Common\Exceptions\OpenSearchException
-     */
-    private function throwLegacyClientException($response): void
-    {
-        $statusCode = $response['status_code'];
-        $responseBody = $this->convertBodyToString($response['body'], $statusCode);
-        throw match ($statusCode) {
-            401 => new Unauthorized401Exception($responseBody, $statusCode),
-            403 => new Forbidden403Exception($responseBody, $statusCode),
-            404 => new Missing404Exception($responseBody, $statusCode),
-            409 => new Conflict409Exception($responseBody, $statusCode),
-            400 => (str_contains($responseBody, 'script_lang not supported'))
-                ? new ScriptLangNotSupportedException($responseBody . $statusCode)
-                : new BadRequest400Exception($responseBody, $statusCode),
-            408 => new RequestTimeout408Exception($responseBody, $statusCode),
-            default => new BadRequest400Exception($responseBody, $statusCode),
-        };
-    }
-
-    /**
-     * Throw legacy server exceptions based on status code.
-     *
-     * @throws \OpenSearch\Common\Exceptions\OpenSearchException
-     */
-    private function throwLegacyServerException($response): void
-    {
-        $statusCode = $response['status_code'];
-        $error = $response['body']['error'] ?? [];
-        $reason = $error['reason'] ?? 'undefined reason';
-        $type = $error['type'] ?? 'undefined type';
-        $errorMessage = "$type: $reason";
-        $responseBody = $this->convertBodyToString($response['body'], $statusCode);
-
-        $exception = new ServerErrorResponseException($responseBody, $statusCode);
-        if ($statusCode === 500) {
-            if (str_contains($responseBody, "RoutingMissingException")) {
-                $exception = new RoutingMissingException($errorMessage, $statusCode);
-            } elseif (preg_match('/ActionRequestValidationException.+ no documents to get/', $responseBody) === 1) {
-                $exception = new NoDocumentsToGetException($errorMessage, $statusCode);
-            } elseif (str_contains($responseBody, 'NoShardAvailableActionException')) {
-                $exception = new NoShardAvailableException($errorMessage, $statusCode);
-            }
-        }
-        throw $exception;
-    }
-
-    private function convertBodyToString(mixed $body, int $statusCode): string
-    {
-        return empty($body)
-            ? "Unknown $statusCode error from OpenSearch"
-            : (is_string($body) ? $body : json_encode($body));
     }
 
 }

--- a/src/OpenSearch/Common/Exceptions/Forbidden403Exception.php
+++ b/src/OpenSearch/Common/Exceptions/Forbidden403Exception.php
@@ -21,11 +21,15 @@ declare(strict_types=1);
 
 namespace OpenSearch\Common\Exceptions;
 
-@trigger_error(Forbidden403Exception::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+use OpenSearch\Exception\ForbiddenHttpException;
+
+@trigger_error(Forbidden403Exception::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0. Use \OpenSearch\Exception\ForbiddenHttpException instead', E_USER_DEPRECATED);
 
 /**
  * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ *
+ * @see \OpenSearch\Exception\ForbiddenHttpException
  */
-class Forbidden403Exception extends \Exception implements OpenSearchException
+class Forbidden403Exception extends ForbiddenHttpException
 {
 }

--- a/src/OpenSearch/Common/Exceptions/Missing404Exception.php
+++ b/src/OpenSearch/Common/Exceptions/Missing404Exception.php
@@ -21,11 +21,18 @@ declare(strict_types=1);
 
 namespace OpenSearch\Common\Exceptions;
 
-@trigger_error(Missing404Exception::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+use OpenSearch\Exception\NotFoundHttpException;
+
+@trigger_error(
+    Missing404Exception::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0. Use \OpenSearch\Exception\NotFoundHttpException instead.',
+    E_USER_DEPRECATED
+);
 
 /**
  * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ *
+ * @see \OpenSearch\Exception\NotFoundHttpException
  */
-class Missing404Exception extends \Exception implements OpenSearchException
+class Missing404Exception extends NotFoundHttpException
 {
 }

--- a/src/OpenSearch/Common/Exceptions/NoDocumentsToGetException.php
+++ b/src/OpenSearch/Common/Exceptions/NoDocumentsToGetException.php
@@ -21,11 +21,16 @@ declare(strict_types=1);
 
 namespace OpenSearch\Common\Exceptions;
 
-@trigger_error(NoDocumentsToGetException::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(
+    NoDocumentsToGetException::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0. Use \OpenSearch\Exception\NoDocumentsToGetException instead.',
+    E_USER_DEPRECATED
+);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.3.2 and will be removed in 3.0.0. Use \OpenSearch\Exception\NoDocumentsToGetException instead.
+ *
+ * @see \OpenSearch\Exception\ScriptLangNotSupportedException
  */
-class NoDocumentsToGetException extends ServerErrorResponseException implements OpenSearchException
+class NoDocumentsToGetException extends \OpenSearch\Exception\NoDocumentsToGetException
 {
 }

--- a/src/OpenSearch/Common/Exceptions/NoNodesAvailableException.php
+++ b/src/OpenSearch/Common/Exceptions/NoNodesAvailableException.php
@@ -21,6 +21,14 @@ declare(strict_types=1);
 
 namespace OpenSearch\Common\Exceptions;
 
+@trigger_error(
+    NoNodesAvailableException::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.',
+    E_USER_DEPRECATED
+);
+
+/**
+ * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ */
 class NoNodesAvailableException extends ServerErrorResponseException implements OpenSearchException
 {
 }

--- a/src/OpenSearch/Common/Exceptions/NoShardAvailableException.php
+++ b/src/OpenSearch/Common/Exceptions/NoShardAvailableException.php
@@ -21,6 +21,16 @@ declare(strict_types=1);
 
 namespace OpenSearch\Common\Exceptions;
 
-class NoShardAvailableException extends ServerErrorResponseException implements OpenSearchException
+@trigger_error(
+    NoShardAvailableException::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0. Use \OpenSearch\Exception\NoShardAvailableException instead.',
+    E_USER_DEPRECATED
+);
+
+/**
+ * @deprecated in 2.3.2 and will be removed in 3.0.0. Use \OpenSearch\Exception\NoShardAvailableException instead.
+ *
+ * @see \OpenSearch\Exception\NoShardAvailableException
+ */
+class NoShardAvailableException extends \OpenSearch\Exception\NoShardAvailableException
 {
 }

--- a/src/OpenSearch/Common/Exceptions/OpenSearchException.php
+++ b/src/OpenSearch/Common/Exceptions/OpenSearchException.php
@@ -21,8 +21,16 @@ declare(strict_types=1);
 
 namespace OpenSearch\Common\Exceptions;
 
-use Throwable;
+use OpenSearch\Exception\OpenSearchExceptionInterface;
 
-interface OpenSearchException extends Throwable
+@trigger_error(
+    NoNodesAvailableException::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.',
+    E_USER_DEPRECATED
+);
+
+/**
+ * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ */
+interface OpenSearchException extends OpenSearchExceptionInterface
 {
 }

--- a/src/OpenSearch/Common/Exceptions/RoutingMissingException.php
+++ b/src/OpenSearch/Common/Exceptions/RoutingMissingException.php
@@ -21,6 +21,16 @@ declare(strict_types=1);
 
 namespace OpenSearch\Common\Exceptions;
 
-class RoutingMissingException extends ServerErrorResponseException implements OpenSearchException
+@trigger_error(
+    RoutingMissingException::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0. Use \OpenSearch\Exception\RoutingMissingException instead.',
+    E_USER_DEPRECATED
+);
+
+/**
+ * @deprecated in 2.3.2 and will be removed in 3.0.0. Use OpenSearch\Exception\UnauthorizedHttpException instead.
+ *
+ * @see \OpenSearch\Exception\ScriptLangNotSupportedException
+ */
+class RoutingMissingException extends \OpenSearch\Exception\RoutingMissingException
 {
 }

--- a/src/OpenSearch/Common/Exceptions/RuntimeException.php
+++ b/src/OpenSearch/Common/Exceptions/RuntimeException.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace OpenSearch\Common\Exceptions;
 
-class RuntimeException extends \RuntimeException implements OpenSearchException
+use OpenSearch\Exception\OpenSearchExceptionInterface;
+
+class RuntimeException extends \RuntimeException implements OpenSearchExceptionInterface
 {
 }

--- a/src/OpenSearch/Common/Exceptions/ScriptLangNotSupportedException.php
+++ b/src/OpenSearch/Common/Exceptions/ScriptLangNotSupportedException.php
@@ -21,6 +21,16 @@ declare(strict_types=1);
 
 namespace OpenSearch\Common\Exceptions;
 
-class ScriptLangNotSupportedException extends BadRequest400Exception implements OpenSearchException
+@trigger_error(
+    ScriptLangNotSupportedException::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0. Use OpenSearch\Exception\ScriptLangNotSupportedException instead.',
+    E_USER_DEPRECATED
+);
+
+/**
+ * @deprecated in 2.3.2 and will be removed in 3.0.0. Use OpenSearch\Exception\UnauthorizedHttpException instead.
+ *
+ * @see \OpenSearch\Exception\ScriptLangNotSupportedException
+ */
+class ScriptLangNotSupportedException extends \OpenSearch\Exception\ScriptLangNotSupportedException
 {
 }

--- a/src/OpenSearch/Common/Exceptions/ServerErrorResponseException.php
+++ b/src/OpenSearch/Common/Exceptions/ServerErrorResponseException.php
@@ -21,6 +21,11 @@ declare(strict_types=1);
 
 namespace OpenSearch\Common\Exceptions;
 
+@trigger_error(RequestTimeout408Exception::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ */
 class ServerErrorResponseException extends TransportException implements OpenSearchException
 {
 }

--- a/src/OpenSearch/Common/Exceptions/Unauthorized401Exception.php
+++ b/src/OpenSearch/Common/Exceptions/Unauthorized401Exception.php
@@ -21,6 +21,18 @@ declare(strict_types=1);
 
 namespace OpenSearch\Common\Exceptions;
 
-class Unauthorized401Exception extends \Exception implements OpenSearchException
+use OpenSearch\Exception\UnauthorizedHttpException;
+
+@trigger_error(
+    Unauthorized401Exception::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0. Use OpenSearch\Exception\UnauthorizedHttpException instead.',
+    E_USER_DEPRECATED
+);
+
+/**
+ * @deprecated in 2.3.2 and will be removed in 3.0.0. Use OpenSearch\Exception\UnauthorizedHttpException instead.
+ *
+ * @see \OpenSearch\Exception\UnauthorizedHttpException
+ */
+class Unauthorized401Exception extends UnauthorizedHttpException
 {
 }

--- a/src/OpenSearch/Common/Exceptions/UnexpectedValueException.php
+++ b/src/OpenSearch/Common/Exceptions/UnexpectedValueException.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace OpenSearch\Common\Exceptions;
 
-class UnexpectedValueException extends \UnexpectedValueException implements OpenSearchException
+use OpenSearch\Exception\OpenSearchExceptionInterface;
+
+class UnexpectedValueException extends \UnexpectedValueException implements OpenSearchExceptionInterface
 {
 }

--- a/src/OpenSearch/Connections/Connection.php
+++ b/src/OpenSearch/Connections/Connection.php
@@ -664,19 +664,19 @@ class Connection implements ConnectionInterface
 
         $responseBody = $this->convertBodyToString($response['body'], $statusCode, $exception);
         if ($statusCode === 401) {
-            $exception = new Unauthorized401Exception($responseBody, $statusCode);
+            $exception = new Unauthorized401Exception($responseBody);
         } elseif ($statusCode === 403) {
-            $exception = new Forbidden403Exception($responseBody, $statusCode);
+            $exception = new Forbidden403Exception($responseBody);
         } elseif ($statusCode === 404) {
-            $exception = new Missing404Exception($responseBody, $statusCode);
+            $exception = new Missing404Exception($responseBody);
         } elseif ($statusCode === 409) {
             $exception = new Conflict409Exception($responseBody, $statusCode);
         } elseif ($statusCode === 400 && strpos($responseBody, 'script_lang not supported') !== false) {
-            $exception = new ScriptLangNotSupportedException($responseBody. $statusCode);
+            $exception = new ScriptLangNotSupportedException($responseBody);
         } elseif ($statusCode === 408) {
-            $exception = new RequestTimeout408Exception($responseBody, $statusCode);
+            $exception = new RequestTimeout408Exception($responseBody);
         } else {
-            $exception = new BadRequest400Exception($responseBody, $statusCode);
+            $exception = new BadRequest400Exception($responseBody);
         }
 
         $this->logRequestFail($request, $response, $exception);
@@ -706,15 +706,14 @@ class Connection implements ConnectionInterface
         }
 
         if ($statusCode === 500 && strpos($responseBody, "RoutingMissingException") !== false) {
-            $exception = new RoutingMissingException($exception->getMessage(), $statusCode, $exception);
+            $exception = new RoutingMissingException($exception->getMessage(), [], 0, $exception);
         } elseif ($statusCode === 500 && preg_match('/ActionRequestValidationException.+ no documents to get/', $responseBody) === 1) {
-            $exception = new NoDocumentsToGetException($exception->getMessage(), $statusCode, $exception);
+            $exception = new NoDocumentsToGetException($exception->getMessage(), [], 0, $exception);
         } elseif ($statusCode === 500 && strpos($responseBody, 'NoShardAvailableActionException') !== false) {
-            $exception = new NoShardAvailableException($exception->getMessage(), $statusCode, $exception);
+            $exception = new NoShardAvailableException($exception->getMessage(), [], 0, $exception);
         } else {
             $exception = new ServerErrorResponseException(
                 $this->convertBodyToString($responseBody, $statusCode, $exception),
-                $statusCode
             );
         }
 

--- a/src/OpenSearch/Exception/BadRequestHttpException.php
+++ b/src/OpenSearch/Exception/BadRequestHttpException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Exception;
+
+/**
+ * Exception thrown when a 400 Bad Request HTTP error occurs.
+ */
+class BadRequestHttpException extends HttpException
+{
+    public function __construct(string $message = '', array $headers = [], int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct(400, $message, $headers, $code, $previous);
+    }
+
+}

--- a/src/OpenSearch/Exception/ConflictHttpException.php
+++ b/src/OpenSearch/Exception/ConflictHttpException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Exception;
+
+/**
+ * Exception thrown when a 409 Conflict HTTP error occurs.
+ */
+class ConflictHttpException extends HttpException
+{
+    public function __construct(string $message = '', array $headers = [], int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct(409, $message, $headers, $code, $previous);
+    }
+}

--- a/src/OpenSearch/Exception/ErrorMessageExtractor.php
+++ b/src/OpenSearch/Exception/ErrorMessageExtractor.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Exception;
+
+/**
+ * Extracts an error message from the response body.
+ */
+class ErrorMessageExtractor
+{
+    public static function extractErrorMessage(string|array|null $data): ?string
+    {
+        if (is_string($data) || is_null($data)) {
+            return $data;
+        }
+
+        // Must be an array now.
+        if (!isset($data['error'])) {
+            // <2.0 "i just blew up" non-structured exception.
+            // $error is an array, but we don't know the format, so we reuse the response body instead
+            // added json_encode to convert into a string
+            return json_encode($data);
+        }
+
+        // 2.0 structured exceptions
+        if (is_array($data['error']) && array_key_exists('reason', $data['error'])) {
+            // Try to use root cause first (only grabs the first root cause)
+            $info = $data['error']['root_cause'][0] ?? $data['error'];
+            $cause = $info['reason'];
+            $type = $info['type'];
+
+            return "$type: $cause";
+        }
+
+        // <2.0 semi-structured exceptions
+        $legacyError = $data['error'];
+        if (is_array($legacyError)) {
+            return json_encode($legacyError);
+        }
+        return $legacyError;
+    }
+}

--- a/src/OpenSearch/Exception/ForbiddenHttpException.php
+++ b/src/OpenSearch/Exception/ForbiddenHttpException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Exception;
+
+/**
+ * Exception thrown when a 403 Forbidden HTTP error occurs.
+ */
+class ForbiddenHttpException extends HttpException
+{
+    public function __construct(string $message = '', array $headers = [], int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct(403, $message, $headers, $code, $previous);
+    }
+}

--- a/src/OpenSearch/Exception/HttpException.php
+++ b/src/OpenSearch/Exception/HttpException.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Exception;
+
+/**
+ * Exception thrown when an HTTP error occurs.
+ *
+ * @phpstan-consistent-constructor
+ */
+class HttpException extends \RuntimeException implements HttpExceptionInterface
+{
+    public function __construct(
+        protected readonly int $statusCode,
+        string $message = '',
+        protected readonly array $headers = [],
+        int $code = 0,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+}

--- a/src/OpenSearch/Exception/HttpExceptionFactory.php
+++ b/src/OpenSearch/Exception/HttpExceptionFactory.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Exception;
+
+use OpenSearch\Serializers\SmartSerializer;
+
+/**
+ * Factory for creating HTTP exceptions.
+ */
+class HttpExceptionFactory
+{
+    public static function create(
+        int $statusCode,
+        string|array|null $data,
+        array $headers = [],
+        int $code = 0,
+        ?\Throwable $previous = null
+    ): HttpExceptionInterface {
+
+        $errorMessage = ErrorMessageExtractor::extractErrorMessage($data);
+
+        return match ($statusCode) {
+            400 => self::createBadRequestException($errorMessage, $previous, $code, $headers),
+            401 => new UnauthorizedHttpException($errorMessage, $headers, $code, $previous),
+            403 => new ForbiddenHttpException($errorMessage, $headers, $code, $previous),
+            404 => new NotFoundHttpException($errorMessage, $headers, $code, $previous),
+            406 => new NotAcceptableHttpException($errorMessage, $headers, $code, $previous),
+            409 => new ConflictHttpException($errorMessage, $headers, $code, $previous),
+            429 => new TooManyRequestsHttpException($errorMessage, $headers, $code, $previous),
+            500 => self::createInternalServerErrorException($errorMessage, $previous, $code, $headers),
+            503 => new ServiceUnavailableHttpException($errorMessage, $headers, $code, $previous),
+            default => new HttpException($statusCode, $errorMessage, $headers, $code, $previous),
+        };
+    }
+
+    private static function createBadRequestException(
+        string $message = '',
+        ?\Throwable $previous = null,
+        int $code = 0,
+        array $headers = []
+    ): HttpExceptionInterface {
+        if (str_contains($message, 'script_lang not supported')) {
+            return new ScriptLangNotSupportedException($message);
+        }
+        return new BadRequestHttpException($message, $headers, $code, $previous);
+    }
+
+    /**
+     * Create an InternalServerErrorHttpException from the given parameters.
+     */
+    private static function createInternalServerErrorException(
+        string $message = '',
+        ?\Throwable $previous = null,
+        int $code = 0,
+        array $headers = []
+    ): HttpExceptionInterface {
+        if (str_contains($message, "RoutingMissingException")) {
+            return new RoutingMissingException($message);
+        }
+        if (preg_match('/ActionRequestValidationException.+ no documents to get/', $message) === 1) {
+            return new NoDocumentsToGetException($message);
+        }
+        if (str_contains($message, 'NoShardAvailableActionException')) {
+            return new NoShardAvailableException($message);
+        }
+        return new InternalServerErrorHttpException($message, $headers, $code, $previous);
+    }
+
+}

--- a/src/OpenSearch/Exception/HttpExceptionInterface.php
+++ b/src/OpenSearch/Exception/HttpExceptionInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Exception;
+
+/**
+ * Interface for HTTP error exceptions.
+ */
+interface HttpExceptionInterface extends OpenSearchExceptionInterface
+{
+    /**
+     * Returns the status code.
+     */
+    public function getStatusCode(): int;
+
+    /**
+     * Returns response headers.
+     */
+    public function getHeaders(): array;
+}

--- a/src/OpenSearch/Exception/InternalServerErrorHttpException.php
+++ b/src/OpenSearch/Exception/InternalServerErrorHttpException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Exception;
+
+/**
+ * Exception thrown when a 500 Internal Server Error HTTP error occurs.
+ */
+class InternalServerErrorHttpException extends HttpException
+{
+    public function __construct(string $message = '', array $headers = [], int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct(500, $message, $headers, $code, $previous);
+    }
+}

--- a/src/OpenSearch/Exception/NoDocumentsToGetException.php
+++ b/src/OpenSearch/Exception/NoDocumentsToGetException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Exception;
+
+/**
+ * Exception thrown when a 500 Internal Server Error HTTP error occurs for No Documents To Get.
+ */
+class NoDocumentsToGetException extends InternalServerErrorHttpException
+{
+}

--- a/src/OpenSearch/Exception/NoShardAvailableException.php
+++ b/src/OpenSearch/Exception/NoShardAvailableException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Exception;
+
+/**
+ * Exception thrown when a 500 Internal Server Error HTTP error occurs for No Shard Available.
+ */
+class NoShardAvailableException extends InternalServerErrorHttpException
+{
+}

--- a/src/OpenSearch/Exception/NotAcceptableHttpException.php
+++ b/src/OpenSearch/Exception/NotAcceptableHttpException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace OpenSearch\Exception;
+
+class NotAcceptableHttpException extends HttpException
+{
+    public function __construct(string $message = '', array $headers = [], int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct(406, $message, $headers, $code, $previous);
+    }
+}

--- a/src/OpenSearch/Exception/NotFoundHttpException.php
+++ b/src/OpenSearch/Exception/NotFoundHttpException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Exception;
+
+/**
+ * Exception thrown when a 404 Not Found HTTP error occurs.
+ */
+class NotFoundHttpException extends HttpException
+{
+    public function __construct(string $message = '', array $headers = [], int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct(404, $message, $headers, $code, $previous);
+    }
+}

--- a/src/OpenSearch/Exception/OpenSearchExceptionInterface.php
+++ b/src/OpenSearch/Exception/OpenSearchExceptionInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Exception;
+
+/**
+ * Interface for OpenSearch exceptions.
+ */
+interface OpenSearchExceptionInterface extends \Throwable
+{
+}

--- a/src/OpenSearch/Exception/RequestTimeoutHttpException.php
+++ b/src/OpenSearch/Exception/RequestTimeoutHttpException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Exception;
+
+/**
+ * Exception thrown when a 408 Request Timeout HTTP error occurs.
+ */
+class RequestTimeoutHttpException extends HttpException
+{
+    public function __construct(string $message = '', array $headers = [], int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct(408, $message, $headers, $code, $previous);
+    }
+}

--- a/src/OpenSearch/Exception/RoutingMissingException.php
+++ b/src/OpenSearch/Exception/RoutingMissingException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Exception;
+
+/**
+ * Exception thrown when a 500 Internal Server Error HTTP error occurs for Routing Missing.
+ */
+class RoutingMissingException extends InternalServerErrorHttpException
+{
+}

--- a/src/OpenSearch/Exception/ScriptLangNotSupportedException.php
+++ b/src/OpenSearch/Exception/ScriptLangNotSupportedException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Exception;
+
+/**
+ * Exception thrown when a 400 Bad Request HTTP error occurs for a Script Language Not Supported error.
+ */
+class ScriptLangNotSupportedException extends BadRequestHttpException
+{
+}

--- a/src/OpenSearch/Exception/ServiceUnavailableHttpException.php
+++ b/src/OpenSearch/Exception/ServiceUnavailableHttpException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Exception;
+
+/**
+ * Exception thrown when a 503 Service Unavailable HTTP error occurs.
+ */
+class ServiceUnavailableHttpException extends HttpException
+{
+    public function __construct(string $message = '', array $headers = [], int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct(503, $message, $headers, $code, $previous);
+    }
+}

--- a/src/OpenSearch/Exception/TooManyRequestsHttpException.php
+++ b/src/OpenSearch/Exception/TooManyRequestsHttpException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace OpenSearch\Exception;
+
+/**
+ * Exception thrown when a 429 Too Many Requests HTTP error occurs.
+ */
+class TooManyRequestsHttpException extends HttpException
+{
+    public function __construct(string $message = '', array $headers = [], int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct(429, $message, $headers, $code, $previous);
+    }
+
+}

--- a/src/OpenSearch/Exception/UnauthorizedHttpException.php
+++ b/src/OpenSearch/Exception/UnauthorizedHttpException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Exception;
+
+/**
+ * Exception thrown when a 401 Unauthorized HTTP error occurs.
+ */
+class UnauthorizedHttpException extends HttpException
+{
+    public function __construct(string $message = '', array $headers = [], int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct(401, $message, $headers, $code, $previous);
+    }
+
+}

--- a/src/OpenSearch/Namespaces/BooleanRequestWrapper.php
+++ b/src/OpenSearch/Namespaces/BooleanRequestWrapper.php
@@ -25,6 +25,7 @@ use GuzzleHttp\Ring\Future\FutureArrayInterface;
 use OpenSearch\Common\Exceptions\Missing404Exception;
 use OpenSearch\Common\Exceptions\RoutingMissingException;
 use OpenSearch\Endpoints\AbstractEndpoint;
+use OpenSearch\Exception\NotFoundHttpException;
 use OpenSearch\Transport;
 use OpenSearch\TransportInterface;
 
@@ -41,7 +42,7 @@ abstract class BooleanRequestWrapper
     public static function sendRequest(AbstractEndpoint $endpoint, TransportInterface $transport): bool
     {
         try {
-            $response = $transport->sendRequest(
+            $transport->sendRequest(
                 $endpoint->getMethod(),
                 $endpoint->getURI(),
                 $endpoint->getParams(),
@@ -49,14 +50,11 @@ abstract class BooleanRequestWrapper
                 $endpoint->getOptions()
             );
 
-            return match ($response['status_code'] ?? null) {
-                404 => false,
-                default => true,
-            };
-        } catch (Missing404Exception|RoutingMissingException $e) {
-            // Handle legacy exceptions.
+        } catch (NotFoundHttpException|RoutingMissingException $e) {
+            // Return false for 404 errors.
             return false;
         }
+        return true;
     }
 
     /**

--- a/src/OpenSearch/TransportInterface.php
+++ b/src/OpenSearch/TransportInterface.php
@@ -15,6 +15,7 @@ interface TransportInterface
      * @param array<string, string> $headers
      *
      * @throws \Psr\Http\Client\ClientExceptionInterface
+     * @throws \OpenSearch\Exception\HttpExceptionInterface
      */
     public function sendRequest(
         string $method,

--- a/tests/ClientIntegrationTest.php
+++ b/tests/ClientIntegrationTest.php
@@ -26,6 +26,7 @@ use GuzzleHttp\Psr7\HttpFactory;
 use OpenSearch\Client;
 use OpenSearch\Common\Exceptions\RuntimeException;
 use OpenSearch\EndpointFactory;
+use OpenSearch\Exception\NotFoundHttpException;
 use OpenSearch\RequestFactory;
 use OpenSearch\Serializers\SmartSerializer;
 use OpenSearch\TransportFactory;
@@ -63,15 +64,12 @@ class ClientIntegrationTest extends TestCase
 
     public function testNotFoundError()
     {
-        $result = $this->client->get([
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage("index_not_found_exception: no such index [foo]");
+        $this->client->get([
             'index' => 'foo',
             'id' => 'bar',
         ]);
-        $this->assertEquals(404, $result['status']);
-        $error = $result['error'];
-        $this->assertEquals('index_not_found_exception', $error['type']);
-        $this->assertEquals('no such index [foo]', $error['reason']);
-        $this->assertEquals('foo', $error['index']);
     }
 
     public function testIndexCannotBeEmptyStringForDelete()

--- a/tests/ConnectionPool/StaticConnectionPoolIntegrationTest.php
+++ b/tests/ConnectionPool/StaticConnectionPoolIntegrationTest.php
@@ -61,6 +61,7 @@ class StaticConnectionPoolIntegrationTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($client->indices()->exists(['index' => 'not_existing_index']));
 
         // But the node should be marked as alive since the server responded
+        $connection = $client->transport->getConnection();
         $this->assertTrue($connection->isAlive());
     }
 }

--- a/tests/Exception/ErrorMessageExtractorTest.php
+++ b/tests/Exception/ErrorMessageExtractorTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Tests\Exception;
+
+use OpenSearch\Exception\ErrorMessageExtractor;
+use OpenSearch\Serializers\SmartSerializer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the error message extractor.
+ *
+ * @coversDefaultClass \OpenSearch\Exception\ErrorMessageExtractor
+ */
+class ErrorMessageExtractorTest extends TestCase
+{
+    public function testUnstructured(): void
+    {
+        $data = ['foo' => 'error message'];
+        $message = ErrorMessageExtractor::extractErrorMessage($data);
+        $this->assertEquals('{"foo":"error message"}', $message);
+    }
+
+    public function testStringData(): void
+    {
+        $data = 'error message';
+        $message = ErrorMessageExtractor::extractErrorMessage($data);
+        $this->assertEquals('error message', $message);
+    }
+
+    public function testNullData(): void
+    {
+        $data = null;
+        $message = ErrorMessageExtractor::extractErrorMessage($data);
+        $this->assertNull($message);
+    }
+
+    public function testLegacyErrorAsArray(): void
+    {
+        $data = [
+            'error' => [
+                'foo' => 'error message'
+            ]
+        ];
+        $message = ErrorMessageExtractor::extractErrorMessage($data);
+        $this->assertEquals('{"foo":"error message"}', $message);
+    }
+
+    public function testLegacyErrorAsString(): void
+    {
+        $data = [
+            'error' => 'error message'
+        ];
+        $message = ErrorMessageExtractor::extractErrorMessage($data);
+        $this->assertEquals('error message', $message);
+    }
+
+    public function testExtractMessageRootCause(): void
+    {
+        $data = [
+            'error' => [
+                'root_cause' => [
+                    [
+                        'type' => 'root_cause_type',
+                        'reason' => 'root_cause_reason'
+                    ]
+                ],
+                'type' => 'type',
+                'reason' => 'reason'
+            ],
+            'status' => 400
+        ];
+
+        $message = ErrorMessageExtractor::extractErrorMessage($data);
+
+        $this->assertEquals('root_cause_type: root_cause_reason', $message);
+    }
+
+
+}

--- a/tests/Exception/HttpExceptionFactoryTest.php
+++ b/tests/Exception/HttpExceptionFactoryTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Tests\Exception;
+
+use OpenSearch\Exception\BadRequestHttpException;
+use OpenSearch\Exception\HttpExceptionFactory;
+use OpenSearch\Exception\InternalServerErrorHttpException;
+use OpenSearch\Exception\NoDocumentsToGetException;
+use OpenSearch\Exception\NoShardAvailableException;
+use OpenSearch\Exception\RoutingMissingException;
+use OpenSearch\Exception\ScriptLangNotSupportedException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the HTTP exception factory.
+ *
+ * @coversDefaultClass \OpenSearch\Exception\HttpExceptionFactory
+ */
+class HttpExceptionFactoryTest extends TestCase
+{
+    public function testBadRequest(): void
+    {
+        $exception = HttpExceptionFactory::create(400, 'error message', ['foo' => 'bar']);
+        $this->assertInstanceOf(BadRequestHttpException::class, $exception);
+        $this->assertEquals('error message', $exception->getMessage());
+        $this->assertEquals(['foo' => 'bar'], $exception->getHeaders());
+    }
+
+    public function testScriptLangNotSupportedException(): void
+    {
+        $exception = HttpExceptionFactory::create(400, 'script_lang not supported');
+        $this->assertInstanceOf(ScriptLangNotSupportedException::class, $exception);
+        $this->assertEquals('script_lang not supported', $exception->getMessage());
+    }
+
+    public function testInternalServerError()
+    {
+        $exception = HttpExceptionFactory::create(500, 'error message', ['foo' => 'bar']);
+        $this->assertInstanceOf(InternalServerErrorHttpException::class, $exception);
+        $this->assertEquals('error message', $exception->getMessage());
+        $this->assertEquals(['foo' => 'bar'], $exception->getHeaders());
+    }
+
+    public function testRoutingMissingException()
+    {
+        $exception = HttpExceptionFactory::create(500, 'RoutingMissingException');
+        $this->assertInstanceOf(RoutingMissingException::class, $exception);
+        $this->assertEquals('RoutingMissingException', $exception->getMessage());
+    }
+
+    public function testNoDocumentsToGetException()
+    {
+        $exception = HttpExceptionFactory::create(500, 'ActionRequestValidationException foo bar no documents to get');
+        $this->assertInstanceOf(NoDocumentsToGetException::class, $exception);
+        $this->assertEquals('ActionRequestValidationException foo bar no documents to get', $exception->getMessage());
+    }
+
+    public function testNoShardAvailableActionException()
+    {
+        $exception = HttpExceptionFactory::create(500, 'NoShardAvailableActionException foo bar');
+        $this->assertInstanceOf(NoShardAvailableException::class, $exception);
+        $this->assertEquals('NoShardAvailableActionException foo bar', $exception->getMessage());
+    }
+
+}

--- a/util/template/client-class
+++ b/util/template/client-class
@@ -21,17 +21,6 @@ declare(strict_types=1);
 
 namespace OpenSearch;
 
-use OpenSearch\Common\Exceptions\BadRequest400Exception;
-use OpenSearch\Common\Exceptions\Conflict409Exception;
-use OpenSearch\Common\Exceptions\Forbidden403Exception;
-use OpenSearch\Common\Exceptions\Missing404Exception;
-use OpenSearch\Common\Exceptions\NoDocumentsToGetException;
-use OpenSearch\Common\Exceptions\NoShardAvailableException;
-use OpenSearch\Common\Exceptions\RequestTimeout408Exception;
-use OpenSearch\Common\Exceptions\RoutingMissingException;
-use OpenSearch\Common\Exceptions\ScriptLangNotSupportedException;
-use OpenSearch\Common\Exceptions\ServerErrorResponseException;
-use OpenSearch\Common\Exceptions\Unauthorized401Exception;
 use OpenSearch\Endpoints\AbstractEndpoint;
 use OpenSearch\Namespaces\BooleanRequestWrapper;
 use OpenSearch\Namespaces\NamespaceBuilderInterface;
@@ -75,11 +64,6 @@ class Client
      */
     protected $registeredNamespaces = [];
 
-    /**
-     * @deprecated in 2.3.2 and will be removed in 3.0.0.
-     */
-    private bool $throwExceptions = false;
-
 :namespace_properties
 
     /**
@@ -88,13 +72,11 @@ class Client
      * @param TransportInterface|Transport $transport
      * @param callable|EndpointFactoryInterface $endpointFactory
      * @param NamespaceBuilderInterface[] $registeredNamespaces
-     * @param bool $throwExceptions
      */
     public function __construct(
         TransportInterface|Transport $transport,
         callable|EndpointFactoryInterface $endpointFactory,
         array $registeredNamespaces,
-        bool $throwExceptions = false,
     ) {
         if (!$transport instanceof TransportInterface) {
             @trigger_error('Passing an instance of \OpenSearch\Transport to ' . __METHOD__ . '() is deprecated in 2.3.2 and will be removed in 3.0.0. Pass an instance of \OpenSearch\TransportInterface instead.', E_USER_DEPRECATED);
@@ -115,13 +97,6 @@ class Client
         }
         $this->endpoints = $endpoints;
         $this->endpointFactory = $endpointFactory;
-        if ($throwExceptions === true) {
-            @trigger_error(
-                'The $throwExceptions parameter is deprecated in 2.4.0 and will be removed in 3.0.0. Check the response \'status_code\' instead',
-                E_USER_DEPRECATED
-            );
-            $this->throwExceptions = true;
-        }
 :new-namespaces
         $this->registeredNamespaces = $registeredNamespaces;
     }
@@ -172,7 +147,7 @@ class Client
      * Send a raw request to the cluster.
      *
      * @throws \Psr\Http\Client\ClientExceptionInterface
-     * @throws \OpenSearch\Common\Exceptions\OpenSearchException
+     * @throws \OpenSearch\Exception\HttpExceptionInterface
      */
     public function request(
         string $method,
@@ -183,117 +158,24 @@ class Client
         $body = $attributes['body'] ?? null;
         $options = $attributes['options'] ?? [];
 
-        $response = $this->httpTransport->sendRequest($method, $uri, $params, $body, $options['headers'] ?? []);
-
-        // @todo: Remove this in the next major release.
-        // Throw legacy exceptions.
-        if ($this->throwExceptions) {
-            if (isset($response['status']) && $response['status'] >= 400) {
-                $this->throwLegacyException($response);
-            }
-        }
-
-        return $response;
+        return $this->httpTransport->sendRequest($method, $uri, $params, $body, $options['headers'] ?? []);
     }
 
     /**
      * Send a request for an endpoint.
      *
      * @throws \Psr\Http\Client\ClientExceptionInterface
-     * @throws \OpenSearch\Common\Exceptions\OpenSearchException
+     * @throws \OpenSearch\Exception\HttpExceptionInterface
      */
     private function performRequest(AbstractEndpoint $endpoint): array|string|null
     {
-        $response = $this->httpTransport->sendRequest(
+        return $this->httpTransport->sendRequest(
             $endpoint->getMethod(),
             $endpoint->getURI(),
             $endpoint->getParams(),
             $endpoint->getBody(),
             $endpoint->getOptions()
         );
-
-        // @todo: Remove this in the next major release.
-        // Throw legacy exceptions.
-        if ($this->throwExceptions) {
-            if (isset($response['status']) && $response['status'] >= 400) {
-                $this->throwLegacyException($response);
-            }
-        }
-
-        return $response;
-    }
-
-    /**
-     * Throw legacy exceptions.
-     *
-     * @param array<string,mixed> $response
-     *
-     * @throws \OpenSearch\Common\Exceptions\OpenSearchException
-     */
-    private function throwLegacyException(array $response): void
-    {
-        if ($response['status'] >= 400 && $response['status'] < 500) {
-            $this->throwLegacyClientException($response);
-        }
-        if ($response['status'] >= 500) {
-            $this->throwLegacyServerException($response);
-        }
-    }
-
-    /**
-     * Throw legacy client exceptions based on status code.
-     *
-     * @throws \OpenSearch\Common\Exceptions\OpenSearchException
-     */
-    private function throwLegacyClientException($response): void
-    {
-        $statusCode = $response['status_code'];
-        $responseBody = $this->convertBodyToString($response['body'], $statusCode);
-        throw match ($statusCode) {
-            401 => new Unauthorized401Exception($responseBody, $statusCode),
-            403 => new Forbidden403Exception($responseBody, $statusCode),
-            404 => new Missing404Exception($responseBody, $statusCode),
-            409 => new Conflict409Exception($responseBody, $statusCode),
-            400 => (str_contains($responseBody, 'script_lang not supported'))
-                ? new ScriptLangNotSupportedException($responseBody . $statusCode)
-                : new BadRequest400Exception($responseBody, $statusCode),
-            408 => new RequestTimeout408Exception($responseBody, $statusCode),
-            default => new BadRequest400Exception($responseBody, $statusCode),
-        };
-    }
-
-    /**
-     * Throw legacy server exceptions based on status code.
-     *
-     * @throws \OpenSearch\Common\Exceptions\OpenSearchException
-     */
-    private function throwLegacyServerException($response): void
-    {
-        $statusCode = $response['status_code'];
-        $error = $response['body']['error'] ?? [];
-        $reason = $error['reason'] ?? 'undefined reason';
-        $type = $error['type'] ?? 'undefined type';
-        $errorMessage = "$type: $reason";
-        $responseBody = $this->convertBodyToString($response['body'], $statusCode);
-
-        $exception = new ServerErrorResponseException($responseBody, $statusCode);
-        if ($statusCode === 500) {
-            if (str_contains($responseBody, "RoutingMissingException")) {
-                $exception = new RoutingMissingException($errorMessage, $statusCode);
-            } elseif (preg_match('/ActionRequestValidationException.+ no documents to get/', $responseBody) === 1) {
-                $exception = new NoDocumentsToGetException($errorMessage, $statusCode);
-            } elseif (str_contains($responseBody, 'NoShardAvailableActionException')) {
-                $exception = new NoShardAvailableException($errorMessage, $statusCode);
-            }
-        }
-        throw $exception;
-    }
-
-    private function convertBodyToString(mixed $body, int $statusCode): string
-    {
-        return empty($body)
-            ? "Unknown $statusCode error from OpenSearch"
-            : (is_string($body) ? $body : json_encode($body));
     }
 
 }


### PR DESCRIPTION
### Description

As discussed in https://github.com/opensearch-project/opensearch-php/pull/251#issuecomment-2584784965 we agreed that we should keep the existing behaviour of throwing exceptions.

This PR:

- Reverts the opt-in flag for throwing exceptions
- Creates an interface for HTTP Exceptions that can return a status code and headers for client debugging
- Creates a hierarchy of Exceptions for HTTP Status Codes that implement the interface
- Creates an HTTP Exception Factory for creating the exceptions based on status code and errors in the response body
- Creates an Error Message Extractor which copies the logic from the deprecated Connection class for extracting a useful error message from the response body
- Adds tests

### Issues Resolved

#250 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
