### PR TITLE
Add decorator tests for guzzle and symfony

### DIFF
--- a/tests/Aws/SigningClientDecoratorGuzzleTest.php
+++ b/tests/Aws/SigningClientDecoratorGuzzleTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace OpenSearch\Tests\Aws;
+
+use Aws\Credentials\CredentialsInterface;
+use Aws\Signature\SignatureV4;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\HttpFactory;
+use GuzzleHttp\Psr7\Response;
+use OpenSearch\Aws\SigningClientDecorator;
+use OpenSearch\Client;
+use OpenSearch\EndpointFactory;
+use OpenSearch\RequestFactory;
+use OpenSearch\Serializers\SmartSerializer;
+use OpenSearch\TransportFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the signing client decorator.
+ */
+class SigningClientDecoratorGuzzleTest extends TestCase
+{
+    public function testGuzzleRequestIsSigned(): void
+    {
+        // Mock out the Guzzle handler so we can test the client without making a real HTTP request.
+        $mockHandler = new MockHandler([
+            new Response(200, [], '{"foo":"bar"}'),
+        ]);
+
+        $handlerStack = HandlerStack::create($mockHandler);
+
+        $guzzleClient = new \GuzzleHttp\Client([
+            'base_uri' => 'http://localhost:9200',
+            'headers' => [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+            ],
+            'handler' => $handlerStack,
+        ]);
+
+        $guzzleHttpFactory = new HttpFactory();
+
+        $serializer = new SmartSerializer();
+
+        $requestFactory = new RequestFactory(
+            $guzzleHttpFactory,
+            $guzzleHttpFactory,
+            $guzzleHttpFactory,
+            $serializer,
+        );
+        $credentials = $this->createMock(CredentialsInterface::class);
+        $signer = new SignatureV4('es', 'us-east-1');
+
+        $decorator = new SigningClientDecorator($guzzleClient, $credentials, $signer);
+
+        $transport = (new TransportFactory())
+            ->setHttpClient($decorator)
+            ->setRequestFactory($requestFactory)
+            ->create();
+
+        $endpointFactory = new EndpointFactory();
+        $client = new Client($transport, $endpointFactory, []);
+
+        $client->request('GET', '/_cat/indices');
+
+        // Check the last request to ensure it was signed and has a host header.
+        $lastRequest = $mockHandler->getLastRequest();
+        $this->assertEquals('localhost:9200', $lastRequest->getHeader('Host')[0]);
+        $this->assertNotEmpty($lastRequest->getHeader('x-amz-content-sha256'));
+        $this->assertNotEmpty($lastRequest->getHeader('x-amz-date'));
+        $this->assertNotEmpty($lastRequest->getHeader('Authorization'));
+    }
+
+}

--- a/tests/Aws/SigningClientDecoratorSymfonyTest.php
+++ b/tests/Aws/SigningClientDecoratorSymfonyTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Tests\Aws;
+
+use Aws\Credentials\CredentialsInterface;
+use Aws\Signature\SignatureV4;
+use OpenSearch\Aws\SigningClientDecorator;
+use OpenSearch\Client;
+use OpenSearch\EndpointFactory;
+use OpenSearch\RequestFactory;
+use OpenSearch\Serializers\SmartSerializer;
+use OpenSearch\TransportFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Psr18Client;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+
+/**
+ * Tests the signing client decorator with the Symfony HTTP client.
+ */
+class SigningClientDecoratorSymfonyTest extends TestCase
+{
+    public function testSymfonyRequestIsSigned(): void
+    {
+        $response = new JsonMockResponse([
+            'foo' => 'bar',
+        ]);
+
+        $mockHttpClient = (new MockHttpClient([$response]))->withOptions([
+            'base_uri' => 'http://localhost:9200',
+            'headers' => [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+                'Host' => 'localhost:9200',
+            ],
+        ]);
+
+        $symfonyPsr18Client = (new Psr18Client($mockHttpClient));
+
+        $serializer = new SmartSerializer();
+
+        $requestFactory = new RequestFactory(
+            $symfonyPsr18Client,
+            $symfonyPsr18Client,
+            $symfonyPsr18Client,
+            $serializer,
+        );
+
+        $credentials = $this->createMock(CredentialsInterface::class);
+        $signer = new SignatureV4('es', 'us-east-1');
+
+        $decorator = new SigningClientDecorator($symfonyPsr18Client, $credentials, $signer);
+
+        $transport = (new TransportFactory())
+            ->setHttpClient($decorator)
+            ->setRequestFactory($requestFactory)
+            ->create();
+
+        $endpointFactory = new EndpointFactory();
+
+        $client = new Client($transport, $endpointFactory, []);
+
+        // Send a request to the 'info' endpoint.
+        $client->request('GET', '/');
+
+        $this->assertNotEmpty($response->getRequestUrl());
+        $requestHeaders = $response->getRequestOptions()['normalized_headers'];
+        $this->assertArrayHasKey('authorization', $requestHeaders);
+        $this->assertArrayHasKey('x-amz-content-sha256', $requestHeaders);
+        $this->assertArrayHasKey('x-amz-date', $requestHeaders);
+        $this->assertArrayHasKey('host', $requestHeaders);
+
+    }
+
+
+}

--- a/tests/Aws/SigningClientDecoratorTest.php
+++ b/tests/Aws/SigningClientDecoratorTest.php
@@ -19,7 +19,6 @@ use Psr\Http\Message\ResponseInterface;
  */
 class SigningClientDecoratorTest extends TestCase
 {
-
     /**
      * Test that the decorator signs the request.
      *
@@ -44,7 +43,6 @@ class SigningClientDecoratorTest extends TestCase
                 })
             )
             ->willReturn($this->createMock(ResponseInterface::class));
-
 
         $decorator = new SigningClientDecorator($client, $credentials, $signer);
         $request = new Request('GET', 'http://localhost:9200/_search');


### PR DESCRIPTION
### Description
Adds tests for Guzzle and Symfony to test if the host header is passed in the request.

This shows that Guzzle passes the host from the `base_uri` default option while the Symfony HTTP Client does not.

You need to manually set the default 'Host' header in the Symfony HTTP Client for it to be sent in the request.

### Issues Resolved
#248 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
