### PR TITLE
Add phpstan deprecation rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,9 @@
     "friendsofphp/php-cs-fixer": "^v3.64",
     "guzzlehttp/psr7": "^2.7",
     "mockery/mockery": "^1.6",
+    "phpstan/extension-installer": "^1.4",
     "phpstan/phpstan": "^1.12",
+    "phpstan/phpstan-deprecation-rules": "^1.2",
     "phpstan/phpstan-mockery": "^1.1",
     "phpunit/phpunit": "^9.6",
     "symfony/finder": "^6.4|^7.0",
@@ -66,7 +68,8 @@
   "config": {
     "sort-packages": true,
     "allow-plugins": {
-      "php-http/discovery": true
+      "php-http/discovery": true,
+      "phpstan/extension-installer": true
     }
   },
   "scripts": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,3 @@
-includes:
-    - vendor/phpstan/phpstan-mockery/extension.neon
 parameters:
     level: 5
     paths:


### PR DESCRIPTION
### Description
Adds PHPStan deprecation rules to see where we are using deprecated code. This is important when we want to remove deprecated code in 3.x.

This also moves to using `phpstan/extension-installer` to make it easier to configure multiple phpstan extensions.

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
