### PR TITLE
Add phpstan/phpstan-phpunit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added support for PHP 8.3 and 8.4 ([#229](https://github.com/opensearch-project/opensearch-php/pull/229))
 - Added a Docker Compose config file for local development.
 - Added a test for the AWS signing client decorator
-- Added PHPStan deprecation rules and baseline
+- Added PHPStan Deprecation rules and baseline
+- Added PHPStan PHPUnit extensions and rules
 ### Changed
 - Switched to PSR Interfaces
 - Increased PHP min version to 8.1

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
     "phpstan/phpstan": "^1.12",
     "phpstan/phpstan-deprecation-rules": "^1.2",
     "phpstan/phpstan-mockery": "^1.1",
+    "phpstan/phpstan-phpunit": "^1.4",
     "phpunit/phpunit": "^9.6",
     "symfony/finder": "^6.4|^7.0",
     "symfony/http-client": "^6.4|^7.0",

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -213,7 +213,7 @@ class ClientBuilderTest extends TestCase
 
         try {
             $client->info();
-            $this->assertTrue(false, 'Exception was not thrown!');
+            $this->fail('Exception was not thrown!');
         } catch (OpenSearchException $e) {
             $request = $client->transport->getLastConnection()->getLastRequestInfo();
             $this->assertTrue(isset($request['request']['headers']['Host'][0]));


### PR DESCRIPTION
### Description

Adds [phpstan/phpstan-phpunit](https://github.com/phpstan/phpstan-phpunit) PHPUnit extensions and rules. See the link for the full list of features.

As evidenced by this PR it can pick up errors in tests.

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
