### PR TITLE
Deprecate unused classes

### DIFF
--- a/src/OpenSearch/Helper/Iterators/SearchHitIterator.php
+++ b/src/OpenSearch/Helper/Iterators/SearchHitIterator.php
@@ -23,6 +23,12 @@ namespace OpenSearch\Helper\Iterators;
 
 use Iterator;
 
+// @phpstan-ignore classConstant.deprecatedClass
+@trigger_error(SearchHitIterator::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
+ */
 class SearchHitIterator implements Iterator, \Countable
 {
     /**

--- a/src/OpenSearch/Helper/Iterators/SearchResponseIterator.php
+++ b/src/OpenSearch/Helper/Iterators/SearchResponseIterator.php
@@ -24,6 +24,12 @@ namespace OpenSearch\Helper\Iterators;
 use OpenSearch\Client;
 use Iterator;
 
+// @phpstan-ignore classConstant.deprecatedClass
+@trigger_error(SearchResponseIterator::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
+ */
 class SearchResponseIterator implements Iterator
 {
     /**

--- a/src/OpenSearch/Serializers/ArrayToJSONSerializer.php
+++ b/src/OpenSearch/Serializers/ArrayToJSONSerializer.php
@@ -23,11 +23,17 @@ namespace OpenSearch\Serializers;
 
 use OpenSearch\Common\Exceptions\RuntimeException;
 
+// @phpstan-ignore classConstant.deprecatedClass
+@trigger_error(ArrayToJSONSerializer::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+
 if (!defined('JSON_INVALID_UTF8_SUBSTITUTE')) {
     //PHP < 7.2 Define it as 0 so it does nothing
     define('JSON_INVALID_UTF8_SUBSTITUTE', 0);
 }
 
+/**
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
+ */
 class ArrayToJSONSerializer implements SerializerInterface
 {
     /**

--- a/src/OpenSearch/Serializers/EverythingToJSONSerializer.php
+++ b/src/OpenSearch/Serializers/EverythingToJSONSerializer.php
@@ -23,11 +23,17 @@ namespace OpenSearch\Serializers;
 
 use OpenSearch\Common\Exceptions\RuntimeException;
 
+// @phpstan-ignore classConstant.deprecatedClass
+@trigger_error(EverythingToJSONSerializer::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+
 if (!defined('JSON_INVALID_UTF8_SUBSTITUTE')) {
     //PHP < 7.2 Define it as 0 so it does nothing
     define('JSON_INVALID_UTF8_SUBSTITUTE', 0);
 }
 
+/**
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
+ */
 class EverythingToJSONSerializer implements SerializerInterface
 {
     /**

--- a/tests/ClientBuilder/ArrayLogger.php
+++ b/tests/ClientBuilder/ArrayLogger.php
@@ -25,6 +25,12 @@ namespace OpenSearch\Tests\ClientBuilder;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
+// @phpstan-ignore classConstant.deprecatedClass
+@trigger_error(ArrayLogger::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+
+/**
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
+ */
 class ArrayLogger implements LoggerInterface
 {
     /**

--- a/tests/Helper/Iterators/SearchHitIteratorTest.php
+++ b/tests/Helper/Iterators/SearchHitIteratorTest.php
@@ -28,6 +28,7 @@ use Mockery;
 /**
  * Class SearchResponseIteratorTest
  *
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class SearchHitIteratorTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Helper/Iterators/SearchResponseIteratorTest.php
+++ b/tests/Helper/Iterators/SearchResponseIteratorTest.php
@@ -28,6 +28,7 @@ use Mockery as m;
 /**
  * Class SearchResponseIteratorTest
  *
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class SearchResponseIteratorTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Serializers/ArrayToJSONSerializerTest.php
+++ b/tests/Serializers/ArrayToJSONSerializerTest.php
@@ -27,6 +27,7 @@ use Mockery as m;
 /**
  * Class ArrayToJSONSerializerTest
  *
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class ArrayToJSONSerializerTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Serializers/EverythingToJSONSerializerTest.php
+++ b/tests/Serializers/EverythingToJSONSerializerTest.php
@@ -27,6 +27,7 @@ use Mockery as m;
 /**
  * Class EverythingToJSONSerializerTest
  *
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class EverythingToJSONSerializerTest extends \PHPUnit\Framework\TestCase
 {


### PR DESCRIPTION
### Description

There are a number of unused classes related to the legacy connection pools.  This PR marks them deprecated so they can be removed in 3.x

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
