### PR TITLE
Update deprecation message to specify version 2.4.0 not 2.3.2

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3,7 +3,7 @@ parameters:
 		-
 			message: """
 				#^Instantiation of deprecated class OpenSearch\\\\Common\\\\Exceptions\\\\InvalidArgumentException\\:
-				in 2\\.3\\.2 and will be removed in 3\\.0\\.0\\.$#
+				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\.$#
 			"""
 			count: 1
 			path: src/OpenSearch/Endpoints/Monitoring/Bulk.php
@@ -11,7 +11,7 @@ parameters:
 		-
 			message: """
 				#^Access to deprecated property \\$endpoints of class OpenSearch\\\\Namespaces\\\\AbstractNamespace\\:
-				in 2\\.3\\.2 and will be removed in 3\\.0\\.0\\. Use \\$endpointFactory property instead\\.$#
+				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\. Use \\$endpointFactory property instead\\.$#
 			"""
 			count: 3
 			path: src/OpenSearch/Namespaces/AsyncSearchNamespace.php
@@ -27,7 +27,7 @@ parameters:
 		-
 			message: """
 				#^Access to deprecated property \\$endpoints of class OpenSearch\\\\Namespaces\\\\AbstractNamespace\\:
-				in 2\\.3\\.2 and will be removed in 3\\.0\\.0\\. Use \\$endpointFactory property instead\\.$#
+				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\. Use \\$endpointFactory property instead\\.$#
 			"""
 			count: 8
 			path: src/OpenSearch/Namespaces/DataFrameTransformDeprecatedNamespace.php
@@ -75,7 +75,7 @@ parameters:
 		-
 			message: """
 				#^Access to deprecated property \\$endpoints of class OpenSearch\\\\Namespaces\\\\AbstractNamespace\\:
-				in 2\\.3\\.2 and will be removed in 3\\.0\\.0\\. Use \\$endpointFactory property instead\\.$#
+				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\. Use \\$endpointFactory property instead\\.$#
 			"""
 			count: 1
 			path: src/OpenSearch/Namespaces/MonitoringNamespace.php
@@ -83,7 +83,7 @@ parameters:
 		-
 			message: """
 				#^Access to deprecated property \\$endpoints of class OpenSearch\\\\Namespaces\\\\AbstractNamespace\\:
-				in 2\\.3\\.2 and will be removed in 3\\.0\\.0\\. Use \\$endpointFactory property instead\\.$#
+				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\. Use \\$endpointFactory property instead\\.$#
 			"""
 			count: 4
 			path: src/OpenSearch/Namespaces/SearchableSnapshotsNamespace.php
@@ -91,7 +91,7 @@ parameters:
 		-
 			message: """
 				#^Access to deprecated property \\$endpoints of class OpenSearch\\\\Namespaces\\\\AbstractNamespace\\:
-				in 2\\.3\\.2 and will be removed in 3\\.0\\.0\\. Use \\$endpointFactory property instead\\.$#
+				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\. Use \\$endpointFactory property instead\\.$#
 			"""
 			count: 1
 			path: src/OpenSearch/Namespaces/SecurityNamespace.php
@@ -99,7 +99,7 @@ parameters:
 		-
 			message: """
 				#^Access to deprecated property \\$endpoints of class OpenSearch\\\\Namespaces\\\\AbstractNamespace\\:
-				in 2\\.3\\.2 and will be removed in 3\\.0\\.0\\. Use \\$endpointFactory property instead\\.$#
+				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\. Use \\$endpointFactory property instead\\.$#
 			"""
 			count: 1
 			path: src/OpenSearch/Namespaces/SslNamespace.php

--- a/src/OpenSearch/Client.php
+++ b/src/OpenSearch/Client.php
@@ -70,7 +70,7 @@ class Client
     /**
      * @var Transport
      *
-     * @deprecated in 2.3.2 and will be removed in 3.0.0.
+     * @deprecated in 2.4.0 and will be removed in 3.0.0.
      */
     public $transport;
 
@@ -86,7 +86,7 @@ class Client
     /**
      * @var callable
      *
-     * @deprecated in 2.3.2 and will be removed in 3.0.0.
+     * @deprecated in 2.4.0 and will be removed in 3.0.0.
      */
     protected $endpoints;
 
@@ -277,7 +277,7 @@ class Client
         array $registeredNamespaces,
     ) {
         if (!$transport instanceof TransportInterface) {
-            @trigger_error('Passing an instance of \OpenSearch\Transport to ' . __METHOD__ . '() is deprecated in 2.3.2 and will be removed in 3.0.0. Pass an instance of \OpenSearch\TransportInterface instead.', E_USER_DEPRECATED);
+            @trigger_error('Passing an instance of \OpenSearch\Transport to ' . __METHOD__ . '() is deprecated in 2.4.0 and will be removed in 3.0.0. Pass an instance of \OpenSearch\TransportInterface instead.', E_USER_DEPRECATED);
             // @phpstan-ignore property.deprecated
             $this->transport = $transport;
             // @phpstan-ignore new.deprecated
@@ -286,13 +286,13 @@ class Client
             $this->httpTransport = $transport;
         }
         if (is_callable($endpointFactory)) {
-            @trigger_error('Passing a callable as the $endpointFactory param in ' . __METHOD__ . ' is deprecated in 2.3.2 and will be removed in 3.0.0. Pass an instance of \OpenSearch\EndpointFactoryInterface instead.', E_USER_DEPRECATED);
+            @trigger_error('Passing a callable as the $endpointFactory param in ' . __METHOD__ . ' is deprecated in 2.4.0 and will be removed in 3.0.0. Pass an instance of \OpenSearch\EndpointFactoryInterface instead.', E_USER_DEPRECATED);
             $endpoints = $endpointFactory;
             // @phpstan-ignore new.deprecated
             $endpointFactory = new LegacyEndpointFactory($endpointFactory);
         } else {
             $endpoints = function ($c) use ($endpointFactory) {
-                @trigger_error('The $endpoints property is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+                @trigger_error('The $endpoints property is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
                 return $endpointFactory->getEndpoint('OpenSearch\\Endpoints\\' . $c);
             };
         }

--- a/src/OpenSearch/ClientBuilder.php
+++ b/src/OpenSearch/ClientBuilder.php
@@ -46,10 +46,10 @@ use Psr\Log\NullLogger;
 use ReflectionClass;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(ClientBuilder::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(ClientBuilder::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class ClientBuilder
 {
@@ -188,11 +188,11 @@ class ClientBuilder
     /**
      * Can supply second param to Client::__construct() when invoking manually or with dependency injection
      *
-     * @deprecated in 2.3.2 and will be removed in 3.0.0. Use \OpenSearch\ClientBuilder::getEndpointFactory() instead.
+     * @deprecated in 2.4.0 and will be removed in 3.0.0. Use \OpenSearch\ClientBuilder::getEndpointFactory() instead.
      */
     public function getEndpoint(): callable
     {
-        @trigger_error(__METHOD__ . '() is deprecated in 2.3.2 and will be removed in 3.0.0. Use \OpenSearch\ClientBuilder::getEndpointFactory() instead.', E_USER_DEPRECATED);
+        @trigger_error(__METHOD__ . '() is deprecated in 2.4.0 and will be removed in 3.0.0. Use \OpenSearch\ClientBuilder::getEndpointFactory() instead.', E_USER_DEPRECATED);
         return fn ($c) => $this->endpointFactory->getEndpoint('OpenSearch\\Endpoints\\' . $c);
     }
 
@@ -336,11 +336,11 @@ class ClientBuilder
      *
      * @param callable $endpoint
      *
-     * @deprecated in 2.3.2 and will be removed in 3.0.0. Use \OpenSearch\ClientBuilder::setEndpointFactory() instead.
+     * @deprecated in 2.4.0 and will be removed in 3.0.0. Use \OpenSearch\ClientBuilder::setEndpointFactory() instead.
      */
     public function setEndpoint(callable $endpoint): ClientBuilder
     {
-        @trigger_error(__METHOD__ . '() is deprecated in 2.3.2 and will be removed in 3.0.0. Use \OpenSearch\ClientBuilder::setEndpointFactory() instead.', E_USER_DEPRECATED);
+        @trigger_error(__METHOD__ . '() is deprecated in 2.4.0 and will be removed in 3.0.0. Use \OpenSearch\ClientBuilder::setEndpointFactory() instead.', E_USER_DEPRECATED);
         $this->endpointFactory = new LegacyEndpointFactory($endpoint);
 
         return $this;

--- a/src/OpenSearch/Common/EmptyLogger.php
+++ b/src/OpenSearch/Common/EmptyLogger.php
@@ -25,7 +25,7 @@ use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(EmptyLogger::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0. Use Psr\Log\NullLogger instead', E_USER_DEPRECATED);
+@trigger_error(EmptyLogger::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0. Use Psr\Log\NullLogger instead', E_USER_DEPRECATED);
 
 /**
  * Class EmptyLogger
@@ -33,7 +33,7 @@ use Psr\Log\LoggerInterface;
  * Logger that doesn't do anything.  Similar to Monolog's NullHandler,
  * but avoids the overhead of partially loading Monolog
  *
- * @deprecated in 2.3.2 and will be removed in 3.0.0. Use Psr\Log\NullLogger instead.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0. Use Psr\Log\NullLogger instead.
  */
 class EmptyLogger extends AbstractLogger implements LoggerInterface
 {

--- a/src/OpenSearch/Common/Exceptions/AuthenticationConfigException.php
+++ b/src/OpenSearch/Common/Exceptions/AuthenticationConfigException.php
@@ -23,10 +23,10 @@ declare(strict_types=1);
 namespace OpenSearch\Common\Exceptions;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(AuthenticationConfigException::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(AuthenticationConfigException::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class AuthenticationConfigException extends \RuntimeException implements OpenSearchException
 {

--- a/src/OpenSearch/Common/Exceptions/BadMethodCallException.php
+++ b/src/OpenSearch/Common/Exceptions/BadMethodCallException.php
@@ -22,14 +22,14 @@ declare(strict_types=1);
 namespace OpenSearch\Common\Exceptions;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(BadMethodCallException::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(BadMethodCallException::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
  * BadMethodCallException
  *
  * Denote problems with a method call (e.g. incorrect number of arguments)
  *
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class BadMethodCallException extends \BadMethodCallException implements OpenSearchException
 {

--- a/src/OpenSearch/Common/Exceptions/BadRequest400Exception.php
+++ b/src/OpenSearch/Common/Exceptions/BadRequest400Exception.php
@@ -22,10 +22,10 @@ declare(strict_types=1);
 namespace OpenSearch\Common\Exceptions;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(BadRequest400Exception::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(BadRequest400Exception::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class BadRequest400Exception extends \Exception implements OpenSearchException
 {

--- a/src/OpenSearch/Common/Exceptions/ClientErrorResponseException.php
+++ b/src/OpenSearch/Common/Exceptions/ClientErrorResponseException.php
@@ -22,10 +22,10 @@ declare(strict_types=1);
 namespace OpenSearch\Common\Exceptions;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(ClientErrorResponseException::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(ClientErrorResponseException::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  *
  * @phpstan-ignore class.extendsDeprecatedClass
  */

--- a/src/OpenSearch/Common/Exceptions/Conflict409Exception.php
+++ b/src/OpenSearch/Common/Exceptions/Conflict409Exception.php
@@ -22,10 +22,10 @@ declare(strict_types=1);
 namespace OpenSearch\Common\Exceptions;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(Conflict409Exception::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(Conflict409Exception::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class Conflict409Exception extends \Exception implements OpenSearchException
 {

--- a/src/OpenSearch/Common/Exceptions/Curl/CouldNotConnectToHost.php
+++ b/src/OpenSearch/Common/Exceptions/Curl/CouldNotConnectToHost.php
@@ -26,10 +26,10 @@ use OpenSearch\Common\Exceptions\OpenSearchException;
 use OpenSearch\Common\Exceptions\TransportException;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(CouldNotConnectToHost::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(CouldNotConnectToHost::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  *
  * @phpstan-ignore class.extendsDeprecatedClass
  */

--- a/src/OpenSearch/Common/Exceptions/Curl/CouldNotResolveHostException.php
+++ b/src/OpenSearch/Common/Exceptions/Curl/CouldNotResolveHostException.php
@@ -25,10 +25,10 @@ use OpenSearch\Common\Exceptions\OpenSearchException;
 use OpenSearch\Common\Exceptions\TransportException;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(CouldNotResolveHostException::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(CouldNotResolveHostException::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  *
  * @phpstan-ignore class.extendsDeprecatedClass
  */

--- a/src/OpenSearch/Common/Exceptions/Curl/OperationTimeoutException.php
+++ b/src/OpenSearch/Common/Exceptions/Curl/OperationTimeoutException.php
@@ -25,10 +25,10 @@ use OpenSearch\Common\Exceptions\OpenSearchException;
 use OpenSearch\Common\Exceptions\TransportException;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(OperationTimeoutException::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(OperationTimeoutException::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  *
  * @phpstan-ignore class.extendsDeprecatedClass
  */

--- a/src/OpenSearch/Common/Exceptions/Forbidden403Exception.php
+++ b/src/OpenSearch/Common/Exceptions/Forbidden403Exception.php
@@ -24,10 +24,10 @@ namespace OpenSearch\Common\Exceptions;
 use OpenSearch\Exception\ForbiddenHttpException;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(Forbidden403Exception::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0. Use \OpenSearch\Exception\ForbiddenHttpException instead', E_USER_DEPRECATED);
+@trigger_error(Forbidden403Exception::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0. Use \OpenSearch\Exception\ForbiddenHttpException instead', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  *
  * @see \OpenSearch\Exception\ForbiddenHttpException
  */

--- a/src/OpenSearch/Common/Exceptions/InvalidArgumentException.php
+++ b/src/OpenSearch/Common/Exceptions/InvalidArgumentException.php
@@ -22,10 +22,10 @@ declare(strict_types=1);
 namespace OpenSearch\Common\Exceptions;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(InvalidArgumentException::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(InvalidArgumentException::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class InvalidArgumentException extends \InvalidArgumentException implements OpenSearchException
 {

--- a/src/OpenSearch/Common/Exceptions/MaxRetriesException.php
+++ b/src/OpenSearch/Common/Exceptions/MaxRetriesException.php
@@ -22,10 +22,10 @@ declare(strict_types=1);
 namespace OpenSearch\Common\Exceptions;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(MaxRetriesException::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(MaxRetriesException::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  *
  * @phpstan-ignore class.extendsDeprecatedClass
  */

--- a/src/OpenSearch/Common/Exceptions/Missing404Exception.php
+++ b/src/OpenSearch/Common/Exceptions/Missing404Exception.php
@@ -25,12 +25,12 @@ use OpenSearch\Exception\NotFoundHttpException;
 
 @trigger_error(
     // @phpstan-ignore classConstant.deprecatedClass
-    Missing404Exception::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0. Use \OpenSearch\Exception\NotFoundHttpException instead.',
+    Missing404Exception::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0. Use \OpenSearch\Exception\NotFoundHttpException instead.',
     E_USER_DEPRECATED
 );
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  *
  * @see \OpenSearch\Exception\NotFoundHttpException
  */

--- a/src/OpenSearch/Common/Exceptions/NoDocumentsToGetException.php
+++ b/src/OpenSearch/Common/Exceptions/NoDocumentsToGetException.php
@@ -23,12 +23,12 @@ namespace OpenSearch\Common\Exceptions;
 
 @trigger_error(
     // @phpstan-ignore classConstant.deprecatedClass
-    NoDocumentsToGetException::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0. Use \OpenSearch\Exception\NoDocumentsToGetException instead.',
+    NoDocumentsToGetException::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0. Use \OpenSearch\Exception\NoDocumentsToGetException instead.',
     E_USER_DEPRECATED
 );
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0. Use \OpenSearch\Exception\NoDocumentsToGetException instead.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0. Use \OpenSearch\Exception\NoDocumentsToGetException instead.
  *
  * @see \OpenSearch\Exception\ScriptLangNotSupportedException
  */

--- a/src/OpenSearch/Common/Exceptions/NoNodesAvailableException.php
+++ b/src/OpenSearch/Common/Exceptions/NoNodesAvailableException.php
@@ -22,10 +22,10 @@ declare(strict_types=1);
 namespace OpenSearch\Common\Exceptions;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(NoNodesAvailableException::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(NoNodesAvailableException::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  *
  * @phpstan-ignore class.extendsDeprecatedClass
  */

--- a/src/OpenSearch/Common/Exceptions/NoShardAvailableException.php
+++ b/src/OpenSearch/Common/Exceptions/NoShardAvailableException.php
@@ -22,10 +22,10 @@ declare(strict_types=1);
 namespace OpenSearch\Common\Exceptions;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(NoShardAvailableException::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0. Use \OpenSearch\Exception\NoShardAvailableException instead.', E_USER_DEPRECATED);
+@trigger_error(NoShardAvailableException::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0. Use \OpenSearch\Exception\NoShardAvailableException instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0. Use \OpenSearch\Exception\NoShardAvailableException instead.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0. Use \OpenSearch\Exception\NoShardAvailableException instead.
  *
  * @see \OpenSearch\Exception\NoShardAvailableException
  */

--- a/src/OpenSearch/Common/Exceptions/OpenSearchException.php
+++ b/src/OpenSearch/Common/Exceptions/OpenSearchException.php
@@ -24,10 +24,10 @@ namespace OpenSearch\Common\Exceptions;
 use OpenSearch\Exception\OpenSearchExceptionInterface;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(NoNodesAvailableException::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(NoNodesAvailableException::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 interface OpenSearchException extends OpenSearchExceptionInterface
 {

--- a/src/OpenSearch/Common/Exceptions/RequestTimeout408Exception.php
+++ b/src/OpenSearch/Common/Exceptions/RequestTimeout408Exception.php
@@ -22,10 +22,10 @@ declare(strict_types=1);
 namespace OpenSearch\Common\Exceptions;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(RequestTimeout408Exception::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(RequestTimeout408Exception::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  *
  * @phpstan-ignore class.extendsDeprecatedClass
  */

--- a/src/OpenSearch/Common/Exceptions/RoutingMissingException.php
+++ b/src/OpenSearch/Common/Exceptions/RoutingMissingException.php
@@ -22,10 +22,10 @@ declare(strict_types=1);
 namespace OpenSearch\Common\Exceptions;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(RoutingMissingException::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0. Use \OpenSearch\Exception\RoutingMissingException instead.', E_USER_DEPRECATED);
+@trigger_error(RoutingMissingException::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0. Use \OpenSearch\Exception\RoutingMissingException instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0. Use OpenSearch\Exception\UnauthorizedHttpException instead.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0. Use OpenSearch\Exception\UnauthorizedHttpException instead.
  *
  * @see \OpenSearch\Exception\ScriptLangNotSupportedException
  */

--- a/src/OpenSearch/Common/Exceptions/ScriptLangNotSupportedException.php
+++ b/src/OpenSearch/Common/Exceptions/ScriptLangNotSupportedException.php
@@ -22,10 +22,10 @@ declare(strict_types=1);
 namespace OpenSearch\Common\Exceptions;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(ScriptLangNotSupportedException::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0. Use OpenSearch\Exception\ScriptLangNotSupportedException instead.', E_USER_DEPRECATED);
+@trigger_error(ScriptLangNotSupportedException::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0. Use OpenSearch\Exception\ScriptLangNotSupportedException instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0. Use OpenSearch\Exception\UnauthorizedHttpException instead.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0. Use OpenSearch\Exception\UnauthorizedHttpException instead.
  *
  * @see \OpenSearch\Exception\ScriptLangNotSupportedException
  */

--- a/src/OpenSearch/Common/Exceptions/ServerErrorResponseException.php
+++ b/src/OpenSearch/Common/Exceptions/ServerErrorResponseException.php
@@ -22,10 +22,10 @@ declare(strict_types=1);
 namespace OpenSearch\Common\Exceptions;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(RequestTimeout408Exception::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(RequestTimeout408Exception::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  *
  * @phpstan-ignore class.extendsDeprecatedClass
  */

--- a/src/OpenSearch/Common/Exceptions/TransportException.php
+++ b/src/OpenSearch/Common/Exceptions/TransportException.php
@@ -22,10 +22,10 @@ declare(strict_types=1);
 namespace OpenSearch\Common\Exceptions;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(TransportException::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(TransportException::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class TransportException extends \Exception implements OpenSearchException
 {

--- a/src/OpenSearch/Common/Exceptions/Unauthorized401Exception.php
+++ b/src/OpenSearch/Common/Exceptions/Unauthorized401Exception.php
@@ -24,10 +24,10 @@ namespace OpenSearch\Common\Exceptions;
 use OpenSearch\Exception\UnauthorizedHttpException;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(Unauthorized401Exception::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0. Use OpenSearch\Exception\UnauthorizedHttpException instead.', E_USER_DEPRECATED);
+@trigger_error(Unauthorized401Exception::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0. Use OpenSearch\Exception\UnauthorizedHttpException instead.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0. Use OpenSearch\Exception\UnauthorizedHttpException instead.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0. Use OpenSearch\Exception\UnauthorizedHttpException instead.
  *
  * @see \OpenSearch\Exception\UnauthorizedHttpException
  */

--- a/src/OpenSearch/ConnectionPool/AbstractConnectionPool.php
+++ b/src/OpenSearch/ConnectionPool/AbstractConnectionPool.php
@@ -27,10 +27,10 @@ use OpenSearch\Connections\ConnectionFactoryInterface;
 use OpenSearch\Connections\ConnectionInterface;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(AbstractConnectionPool::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(AbstractConnectionPool::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 abstract class AbstractConnectionPool implements ConnectionPoolInterface
 {

--- a/src/OpenSearch/ConnectionPool/ConnectionPoolInterface.php
+++ b/src/OpenSearch/ConnectionPool/ConnectionPoolInterface.php
@@ -24,10 +24,10 @@ namespace OpenSearch\ConnectionPool;
 use OpenSearch\Connections\ConnectionInterface;
 
 // @phpstan-ignore classConstant.deprecatedInterface
-@trigger_error(ConnectionPoolInterface::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(ConnectionPoolInterface::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 interface ConnectionPoolInterface
 {

--- a/src/OpenSearch/ConnectionPool/Selectors/RandomSelector.php
+++ b/src/OpenSearch/ConnectionPool/Selectors/RandomSelector.php
@@ -24,10 +24,10 @@ namespace OpenSearch\ConnectionPool\Selectors;
 use OpenSearch\Connections\ConnectionInterface;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(RandomSelector::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(RandomSelector::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class RandomSelector implements SelectorInterface
 {

--- a/src/OpenSearch/ConnectionPool/Selectors/RoundRobinSelector.php
+++ b/src/OpenSearch/ConnectionPool/Selectors/RoundRobinSelector.php
@@ -24,10 +24,10 @@ namespace OpenSearch\ConnectionPool\Selectors;
 use OpenSearch\Connections\ConnectionInterface;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(RoundRobinSelector::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(RoundRobinSelector::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class RoundRobinSelector implements SelectorInterface
 {

--- a/src/OpenSearch/ConnectionPool/Selectors/SelectorInterface.php
+++ b/src/OpenSearch/ConnectionPool/Selectors/SelectorInterface.php
@@ -24,10 +24,10 @@ namespace OpenSearch\ConnectionPool\Selectors;
 use OpenSearch\Connections\ConnectionInterface;
 
 // @phpstan-ignore classConstant.deprecatedInterface
-@trigger_error(SelectorInterface::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(SelectorInterface::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 interface SelectorInterface
 {

--- a/src/OpenSearch/ConnectionPool/Selectors/StickyRoundRobinSelector.php
+++ b/src/OpenSearch/ConnectionPool/Selectors/StickyRoundRobinSelector.php
@@ -24,10 +24,10 @@ namespace OpenSearch\ConnectionPool\Selectors;
 use OpenSearch\Connections\ConnectionInterface;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(StickyRoundRobinSelector::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(StickyRoundRobinSelector::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class StickyRoundRobinSelector implements SelectorInterface
 {

--- a/src/OpenSearch/ConnectionPool/SimpleConnectionPool.php
+++ b/src/OpenSearch/ConnectionPool/SimpleConnectionPool.php
@@ -26,10 +26,10 @@ use OpenSearch\Connections\ConnectionFactoryInterface;
 use OpenSearch\Connections\ConnectionInterface;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(SimpleConnectionPool::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(SimpleConnectionPool::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  *
  * @phpstan-ignore class.extendsDeprecatedClass
  */

--- a/src/OpenSearch/ConnectionPool/SniffingConnectionPool.php
+++ b/src/OpenSearch/ConnectionPool/SniffingConnectionPool.php
@@ -29,10 +29,10 @@ use OpenSearch\Connections\ConnectionFactoryInterface;
 use OpenSearch\Connections\ConnectionInterface;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(SniffingConnectionPool::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(SniffingConnectionPool::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  *
  * @phpstan-ignore class.extendsDeprecatedClass
  */

--- a/src/OpenSearch/ConnectionPool/StaticConnectionPool.php
+++ b/src/OpenSearch/ConnectionPool/StaticConnectionPool.php
@@ -28,10 +28,10 @@ use OpenSearch\Connections\ConnectionFactoryInterface;
 use OpenSearch\Connections\ConnectionInterface;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(StaticConnectionPool::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(StaticConnectionPool::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  *
  * @phpstan-ignore class.extendsDeprecatedClass
  */

--- a/src/OpenSearch/ConnectionPool/StaticNoPingConnectionPool.php
+++ b/src/OpenSearch/ConnectionPool/StaticNoPingConnectionPool.php
@@ -28,10 +28,10 @@ use OpenSearch\Connections\ConnectionFactoryInterface;
 use OpenSearch\Connections\ConnectionInterface;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(StaticNoPingConnectionPool::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(StaticNoPingConnectionPool::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  *
  * @phpstan-ignore class.extendsDeprecatedClass
  */

--- a/src/OpenSearch/Connections/Connection.php
+++ b/src/OpenSearch/Connections/Connection.php
@@ -48,10 +48,10 @@ use OpenSearch\Transport;
 use Psr\Log\LoggerInterface;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(Connection::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(Connection::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class Connection implements ConnectionInterface
 {

--- a/src/OpenSearch/Connections/ConnectionFactory.php
+++ b/src/OpenSearch/Connections/ConnectionFactory.php
@@ -25,10 +25,10 @@ use OpenSearch\Serializers\SerializerInterface;
 use Psr\Log\LoggerInterface;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(ConnectionFactory::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(ConnectionFactory::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class ConnectionFactory implements ConnectionFactoryInterface
 {

--- a/src/OpenSearch/Connections/ConnectionFactoryInterface.php
+++ b/src/OpenSearch/Connections/ConnectionFactoryInterface.php
@@ -22,10 +22,10 @@ declare(strict_types=1);
 namespace OpenSearch\Connections;
 
 // @phpstan-ignore classConstant.deprecatedInterface
-@trigger_error(ConnectionFactoryInterface::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(ConnectionFactoryInterface::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 interface ConnectionFactoryInterface
 {

--- a/src/OpenSearch/Connections/ConnectionInterface.php
+++ b/src/OpenSearch/Connections/ConnectionInterface.php
@@ -24,10 +24,10 @@ namespace OpenSearch\Connections;
 use OpenSearch\Transport;
 
 // @phpstan-ignore classConstant.deprecatedInterface
-@trigger_error(ConnectionInterface::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(ConnectionInterface::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 interface ConnectionInterface
 {

--- a/src/OpenSearch/Handlers/SigV4Handler.php
+++ b/src/OpenSearch/Handlers/SigV4Handler.php
@@ -14,12 +14,12 @@ use Psr\Http\Message\RequestInterface;
 use RuntimeException;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(SigV4Handler::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(SigV4Handler::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
  * @phpstan-type RingPhpRequest array{http_method: string, scheme: string, uri: string, query_string?: string, version?: string, headers: array<string, list<string>>, body: string|resource|null, client?: array<string, mixed>}
  *
- * @deprecated in 2.3.2 and will be removed in 3.0.0. Use \OpenSearch\Aws\SigV4RequestFactory instead.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0. Use \OpenSearch\Aws\SigV4RequestFactory instead.
  */
 class SigV4Handler
 {

--- a/src/OpenSearch/LegacyTransportWrapper.php
+++ b/src/OpenSearch/LegacyTransportWrapper.php
@@ -10,7 +10,7 @@ use GuzzleHttp\Ring\Future\FutureArrayInterface;
 /**
  * Transport that wraps the legacy transport.
  *
- * @deprecated in 2.3.2 and will be removed in 3.0.0. Use PsrTransport instead.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0. Use PsrTransport instead.
  */
 class LegacyTransportWrapper implements TransportInterface
 {

--- a/src/OpenSearch/Namespaces/AbstractNamespace.php
+++ b/src/OpenSearch/Namespaces/AbstractNamespace.php
@@ -33,7 +33,7 @@ abstract class AbstractNamespace
     /**
      * @var \OpenSearch\Transport
      *
-     * @deprecated in 2.3.2 and will be removed in 3.0.0. Use $httpTransport property instead.
+     * @deprecated in 2.4.0 and will be removed in 3.0.0. Use $httpTransport property instead.
      */
     protected $transport;
 
@@ -44,7 +44,7 @@ abstract class AbstractNamespace
     /**
      * @var callable
      *
-     * @deprecated in 2.3.2 and will be removed in 3.0.0. Use $endpointFactory property instead.
+     * @deprecated in 2.4.0 and will be removed in 3.0.0. Use $endpointFactory property instead.
      */
     protected $endpoints;
 
@@ -54,7 +54,7 @@ abstract class AbstractNamespace
     public function __construct(TransportInterface|Transport $transport, callable|EndpointFactoryInterface $endpointFactory)
     {
         if (!$transport instanceof TransportInterface) {
-            @trigger_error('Passing an instance of \OpenSearch\Transport to ' . __METHOD__ . '() is deprecated in 2.3.2 and will be removed in 3.0.0. Pass an instance of \OpenSearch\TransportInterface instead.', E_USER_DEPRECATED);
+            @trigger_error('Passing an instance of \OpenSearch\Transport to ' . __METHOD__ . '() is deprecated in 2.4.0 and will be removed in 3.0.0. Pass an instance of \OpenSearch\TransportInterface instead.', E_USER_DEPRECATED);
             // @phpstan-ignore property.deprecated
             $this->transport = $transport;
             // @phpstan-ignore new.deprecated
@@ -63,13 +63,13 @@ abstract class AbstractNamespace
             $this->httpTransport = $transport;
         }
         if (is_callable($endpointFactory)) {
-            @trigger_error('Passing a callable as $endpointFactory param to ' . __METHOD__ . '() is deprecated in 2.3.2 and will be removed in 3.0.0. Pass an instance of \OpenSearch\EndpointFactoryInterface instead.', E_USER_DEPRECATED);
+            @trigger_error('Passing a callable as $endpointFactory param to ' . __METHOD__ . '() is deprecated in 2.4.0 and will be removed in 3.0.0. Pass an instance of \OpenSearch\EndpointFactoryInterface instead.', E_USER_DEPRECATED);
             $endpoints = $endpointFactory;
             // @phpstan-ignore new.deprecated
             $endpointFactory = new LegacyEndpointFactory($endpointFactory);
         } else {
             $endpoints = function ($c) use ($endpointFactory) {
-                @trigger_error('The $endpoints property is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+                @trigger_error('The $endpoints property is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
                 return $endpointFactory->getEndpoint('OpenSearch\\Endpoints\\' . $c);
             };
         }

--- a/src/OpenSearch/Namespaces/BooleanRequestWrapper.php
+++ b/src/OpenSearch/Namespaces/BooleanRequestWrapper.php
@@ -63,12 +63,12 @@ abstract class BooleanRequestWrapper
      * @throws Missing404Exception
      * @throws RoutingMissingException
      *
-     * @deprecated in 2.3.2 and will be removed in 3.0.0. Use \OpenSearch\Namespaces\BooleanRequestWrapper::sendRequest() instead.
+     * @deprecated in 2.4.0 and will be removed in 3.0.0. Use \OpenSearch\Namespaces\BooleanRequestWrapper::sendRequest() instead.
      */
     public static function performRequest(AbstractEndpoint $endpoint, Transport $transport)
     {
         @trigger_error(
-            __METHOD__ . '() is deprecated in 2.3.2 and will be removed in 3.0.0. Use \OpenSearch\Namespaces\BooleanRequestWrapper::sendRequest() instead.'
+            __METHOD__ . '() is deprecated in 2.4.0 and will be removed in 3.0.0. Use \OpenSearch\Namespaces\BooleanRequestWrapper::sendRequest() instead.'
         );
         try {
             $response = $transport->performRequest(

--- a/src/OpenSearch/Transport.php
+++ b/src/OpenSearch/Transport.php
@@ -28,10 +28,10 @@ use OpenSearch\Connections\ConnectionInterface;
 use Psr\Log\LoggerInterface;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(Transport::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(Transport::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class Transport
 {

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -28,12 +28,12 @@ use OpenSearch\Common\Exceptions\RuntimeException;
 use PHPUnit\Framework\TestCase;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(ClientBuilderTest::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(ClientBuilderTest::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
  * @group legacy
  *
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class ClientBuilderTest extends TestCase
 {

--- a/tests/ConnectionPool/ConnectionFactoryTest.php
+++ b/tests/ConnectionPool/ConnectionFactoryTest.php
@@ -21,10 +21,10 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(ConnectionFactoryTest::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(ConnectionFactoryTest::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class ConnectionFactoryTest extends TestCase
 {

--- a/tests/ConnectionPool/Selectors/RoundRobinSelectorTest.php
+++ b/tests/ConnectionPool/Selectors/RoundRobinSelectorTest.php
@@ -25,14 +25,14 @@ use OpenSearch;
 use OpenSearch\Connections\ConnectionInterface;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(RoundRobinSelectorTest::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(RoundRobinSelectorTest::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
  * Class SnifferTest
  *
  * @subpackage Tests\ConnectionPool\RoundRobinSelectorTest
  *
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class RoundRobinSelectorTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/ConnectionPool/Selectors/StickyRoundRobinSelectorTest.php
+++ b/tests/ConnectionPool/Selectors/StickyRoundRobinSelectorTest.php
@@ -20,14 +20,14 @@ use OpenSearch\Connections\ConnectionInterface;
 use Mockery as m;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(StickyRoundRobinSelectorTest::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(StickyRoundRobinSelectorTest::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
  * Class StickyRoundRobinSelectorTest
  *
  * @subpackage Tests\ConnectionPool\StickyRoundRobinSelectorTest
  *
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class StickyRoundRobinSelectorTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/ConnectionPool/SniffingConnectionPoolIntegrationTest.php
+++ b/tests/ConnectionPool/SniffingConnectionPoolIntegrationTest.php
@@ -28,7 +28,7 @@ use OpenSearch\Tests\Utility;
 use PHPUnit\Framework\TestCase;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(SniffingConnectionPoolIntegrationTest::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(SniffingConnectionPoolIntegrationTest::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
  * Class SniffingConnectionPoolIntegrationTest

--- a/tests/ConnectionPool/SniffingConnectionPoolTest.php
+++ b/tests/ConnectionPool/SniffingConnectionPoolTest.php
@@ -24,14 +24,14 @@ use OpenSearch\Connections\ConnectionFactoryInterface;
 use PHPUnit\Framework\TestCase;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(SniffingConnectionPoolTest::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(SniffingConnectionPoolTest::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
  * Class SniffingConnectionPoolTest
  *
  * @subpackage Tests/SniffingConnectionPoolTest
  *
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class SniffingConnectionPoolTest extends TestCase
 {

--- a/tests/ConnectionPool/StaticConnectionPoolIntegrationTest.php
+++ b/tests/ConnectionPool/StaticConnectionPoolIntegrationTest.php
@@ -25,7 +25,7 @@ use OpenSearch;
 use OpenSearch\Tests\Utility;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(StaticConnectionPoolIntegrationTest::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(StaticConnectionPoolIntegrationTest::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
  * Class StaticConnectionPoolIntegrationTest
@@ -34,7 +34,7 @@ use OpenSearch\Tests\Utility;
  * @group Integration
  * @group Integration-Min
  *
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class StaticConnectionPoolIntegrationTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/ConnectionPool/StaticConnectionPoolTest.php
+++ b/tests/ConnectionPool/StaticConnectionPoolTest.php
@@ -34,7 +34,7 @@ use OpenSearch\Connections\ConnectionFactoryInterface;
 use OpenSearch\Connections\ConnectionInterface;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(StaticConnectionPoolTest::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(StaticConnectionPoolTest::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
  * Class StaticConnectionPoolTest
@@ -42,7 +42,7 @@ use OpenSearch\Connections\ConnectionInterface;
  * @subpackage Tests/StaticConnectionPoolTest
  * @group legacy
  *
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class StaticConnectionPoolTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Connections/ConnectionTest.php
+++ b/tests/Connections/ConnectionTest.php
@@ -36,14 +36,14 @@ use function base64_encode;
 use function random_bytes;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(ConnectionTest::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(ConnectionTest::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 
 /**
  * @covers \OpenSearch\Connections\Connection
  * @group legacy
  *
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class ConnectionTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/Handlers/SigV4HandlerTest.php
+++ b/tests/Handlers/SigV4HandlerTest.php
@@ -12,11 +12,11 @@ use OpenSearch\Handlers\SigV4Handler;
 use PHPUnit\Framework\TestCase;
 
 // @phpstan-ignore classConstant.deprecatedClass
-@trigger_error(SigV4HandlerTest::class . ' is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+@trigger_error(SigV4HandlerTest::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
  * @group legacy
- * @deprecated in 2.3.2 and will be removed in 3.0.0. Use \OpenSearch\Aws\SigV4RequestFactory instead.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0. Use \OpenSearch\Aws\SigV4RequestFactory instead.
  */
 class SigV4HandlerTest extends TestCase
 {

--- a/tests/LegacyRegisteredNamespaceTest.php
+++ b/tests/LegacyRegisteredNamespaceTest.php
@@ -32,7 +32,7 @@ use Mockery as m;
  * Class RegisteredNamespaceTest
  *
  * @subpackage Tests
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class LegacyRegisteredNamespaceTest extends \PHPUnit\Framework\TestCase
 {
@@ -65,7 +65,7 @@ class LegacyRegisteredNamespaceTest extends \PHPUnit\Framework\TestCase
 
 /**
  * @codingStandardsIgnoreStart "Each class must be in a file by itself" - not worth the extra work here
- * @deprecated in 2.3.2 and will be removed in 3.0.0.
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class FooNamespaceBuilder implements OpenSearch\Namespaces\NamespaceBuilderInterface
 {

--- a/util/template/client-class
+++ b/util/template/client-class
@@ -39,7 +39,7 @@ class Client
     /**
      * @var Transport
      *
-     * @deprecated in 2.3.2 and will be removed in 3.0.0.
+     * @deprecated in 2.4.0 and will be removed in 3.0.0.
      */
     public $transport;
 
@@ -55,7 +55,7 @@ class Client
     /**
      * @var callable
      *
-     * @deprecated in 2.3.2 and will be removed in 3.0.0.
+     * @deprecated in 2.4.0 and will be removed in 3.0.0.
      */
     protected $endpoints;
 
@@ -81,7 +81,7 @@ class Client
         array $registeredNamespaces,
     ) {
         if (!$transport instanceof TransportInterface) {
-            @trigger_error('Passing an instance of \OpenSearch\Transport to ' . __METHOD__ . '() is deprecated in 2.3.2 and will be removed in 3.0.0. Pass an instance of \OpenSearch\TransportInterface instead.', E_USER_DEPRECATED);
+            @trigger_error('Passing an instance of \OpenSearch\Transport to ' . __METHOD__ . '() is deprecated in 2.4.0 and will be removed in 3.0.0. Pass an instance of \OpenSearch\TransportInterface instead.', E_USER_DEPRECATED);
             // @phpstan-ignore property.deprecated
             $this->transport = $transport;
             // @phpstan-ignore new.deprecated
@@ -90,13 +90,13 @@ class Client
             $this->httpTransport = $transport;
         }
         if (is_callable($endpointFactory)) {
-            @trigger_error('Passing a callable as the $endpointFactory param in ' . __METHOD__ . ' is deprecated in 2.3.2 and will be removed in 3.0.0. Pass an instance of \OpenSearch\EndpointFactoryInterface instead.', E_USER_DEPRECATED);
+            @trigger_error('Passing a callable as the $endpointFactory param in ' . __METHOD__ . ' is deprecated in 2.4.0 and will be removed in 3.0.0. Pass an instance of \OpenSearch\EndpointFactoryInterface instead.', E_USER_DEPRECATED);
             $endpoints = $endpointFactory;
             // @phpstan-ignore new.deprecated
             $endpointFactory = new LegacyEndpointFactory($endpointFactory);
         } else {
             $endpoints = function ($c) use ($endpointFactory) {
-                @trigger_error('The $endpoints property is deprecated in 2.3.2 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+                @trigger_error('The $endpoints property is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
                 return $endpointFactory->getEndpoint('OpenSearch\\Endpoints\\' . $c);
             };
         }


### PR DESCRIPTION
### Description
We specified the deprecation version as 2.3.2 in all the recent PRs, however the correct version is 2.4.0.

This PR updates all the deprecation messages.

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
