### PR TITLE
Bump java version to 21 for unreleased opensearch tests

### DIFF
--- a/.github/workflows/test_unreleased.yml
+++ b/.github/workflows/test_unreleased.yml
@@ -15,9 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         entry:
-          - { opensearch_ref: "1.x", java: 11 }
-          - { opensearch_ref: "2.x", java: 11, gradle-runtime: 17 }
-          - { opensearch_ref: "main", java: 11, gradle-runtime: 17 }
+          - { opensearch_ref: "1.x", java: 21 }
+          - { opensearch_ref: "2.x", java: 21, gradle-runtime: 21 }
+          - { opensearch_ref: "main", java: 21, gradle-runtime: 21 }
     steps:
       - name: Checkout PHP Client
         uses: actions/checkout@v4


### PR DESCRIPTION
### Description

Bumps the Java version to `21` for building the latest unrelease opensearch version.

### Issues Resolved

Fixes #261 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
