### PR TITLE
Deprecate namespaces no longer in API spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Passing a callable to \OpenSearch\ClientBuilder::setEndpoint() is deprecated and replaced with passing an EndpointFactory to \OpenSearch\ClientBuilder::setEndpointFactory() ([#237](https://github.com/opensearch-project/opensearch-php/pull/237))
 - Connections, Connection pools and Selectors are deprecated. Use a PSR HTTP Client that supports retries instead.
 - Throwing exceptions for different HTTP status codes is deprecated. Use the response object to check the status code instead.
-- The following namespaces have been deprecated and will be removed in 3.0.0: 'async_search', 'searchable_snapshots', 'ssl', 'data_frame_transform_deprecated', 'monitoring'
+- The following namespaces have been deprecated and will be removed in 3.0.0: 'async_search', 'searchable_snapshots', 'ssl', 'data_frame_transform_deprecated', 'monitoring'.
 ### Removed
 - Removed support for PHP 7.3, 7.4 and 8.0.
 - Removed support for async requests which were never actually working.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Passing a callable to \OpenSearch\ClientBuilder::setEndpoint() is deprecated and replaced with passing an EndpointFactory to \OpenSearch\ClientBuilder::setEndpointFactory() ([#237](https://github.com/opensearch-project/opensearch-php/pull/237))
 - Connections, Connection pools and Selectors are deprecated. Use a PSR HTTP Client that supports retries instead.
 - Throwing exceptions for different HTTP status codes is deprecated. Use the response object to check the status code instead.
+- The following namespaces have been deprecated and will be removed in 3.0.0: 'async_search', 'searchable_snapshots', 'ssl', 'data_frame_transform_deprecated', 'monitoring'
 ### Removed
 - Removed support for PHP 7.3, 7.4 and 8.0.
 - Removed support for async requests which were never actually working.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2,6 +2,86 @@ parameters:
 	ignoreErrors:
 		-
 			message: """
+				#^Instantiation of deprecated class OpenSearch\\\\Namespaces\\\\AsyncSearchNamespace\\:
+				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\. Use AsynchronousSearchNamespace instead\\.$#
+			"""
+			count: 1
+			path: src/OpenSearch/Client.php
+
+		-
+			message: """
+				#^Instantiation of deprecated class OpenSearch\\\\Namespaces\\\\DataFrameTransformDeprecatedNamespace\\:
+				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\.$#
+			"""
+			count: 1
+			path: src/OpenSearch/Client.php
+
+		-
+			message: """
+				#^Instantiation of deprecated class OpenSearch\\\\Namespaces\\\\MonitoringNamespace\\:
+				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\.$#
+			"""
+			count: 1
+			path: src/OpenSearch/Client.php
+
+		-
+			message: """
+				#^Instantiation of deprecated class OpenSearch\\\\Namespaces\\\\SearchableSnapshotsNamespace\\:
+				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\.$#
+			"""
+			count: 1
+			path: src/OpenSearch/Client.php
+
+		-
+			message: """
+				#^Instantiation of deprecated class OpenSearch\\\\Namespaces\\\\SslNamespace\\:
+				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\. Use SslNamespace instead\\.$#
+			"""
+			count: 1
+			path: src/OpenSearch/Client.php
+
+		-
+			message: """
+				#^Return type of method OpenSearch\\\\Client\\:\\:asyncSearch\\(\\) has typehint with deprecated class OpenSearch\\\\Namespaces\\\\AsyncSearchNamespace\\:
+				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\. Use AsynchronousSearchNamespace instead\\.$#
+			"""
+			count: 1
+			path: src/OpenSearch/Client.php
+
+		-
+			message: """
+				#^Return type of method OpenSearch\\\\Client\\:\\:dataFrameTransformDeprecated\\(\\) has typehint with deprecated class OpenSearch\\\\Namespaces\\\\DataFrameTransformDeprecatedNamespace\\:
+				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\.$#
+			"""
+			count: 1
+			path: src/OpenSearch/Client.php
+
+		-
+			message: """
+				#^Return type of method OpenSearch\\\\Client\\:\\:monitoring\\(\\) has typehint with deprecated class OpenSearch\\\\Namespaces\\\\MonitoringNamespace\\:
+				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\.$#
+			"""
+			count: 1
+			path: src/OpenSearch/Client.php
+
+		-
+			message: """
+				#^Return type of method OpenSearch\\\\Client\\:\\:searchableSnapshots\\(\\) has typehint with deprecated class OpenSearch\\\\Namespaces\\\\SearchableSnapshotsNamespace\\:
+				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\.$#
+			"""
+			count: 1
+			path: src/OpenSearch/Client.php
+
+		-
+			message: """
+				#^Return type of method OpenSearch\\\\Client\\:\\:ssl\\(\\) has typehint with deprecated class OpenSearch\\\\Namespaces\\\\SslNamespace\\:
+				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\. Use SslNamespace instead\\.$#
+			"""
+			count: 1
+			path: src/OpenSearch/Client.php
+
+		-
+			message: """
 				#^Instantiation of deprecated class OpenSearch\\\\Common\\\\Exceptions\\\\InvalidArgumentException\\:
 				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\.$#
 			"""
@@ -10,27 +90,11 @@ parameters:
 
 		-
 			message: """
-				#^Access to deprecated property \\$endpoints of class OpenSearch\\\\Namespaces\\\\AbstractNamespace\\:
-				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\. Use \\$endpointFactory property instead\\.$#
-			"""
-			count: 3
-			path: src/OpenSearch/Namespaces/AsyncSearchNamespace.php
-
-		-
-			message: """
 				#^Fetching class constant class of deprecated class OpenSearch\\\\Endpoints\\\\Cat\\\\Master\\:
 				To promote inclusive language, use '/_cat/cluster_manager' instead\\.$#
 			"""
 			count: 1
 			path: src/OpenSearch/Namespaces/CatNamespace.php
-
-		-
-			message: """
-				#^Access to deprecated property \\$endpoints of class OpenSearch\\\\Namespaces\\\\AbstractNamespace\\:
-				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\. Use \\$endpointFactory property instead\\.$#
-			"""
-			count: 8
-			path: src/OpenSearch/Namespaces/DataFrameTransformDeprecatedNamespace.php
 
 		-
 			message: """
@@ -78,31 +142,7 @@ parameters:
 				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\. Use \\$endpointFactory property instead\\.$#
 			"""
 			count: 1
-			path: src/OpenSearch/Namespaces/MonitoringNamespace.php
-
-		-
-			message: """
-				#^Access to deprecated property \\$endpoints of class OpenSearch\\\\Namespaces\\\\AbstractNamespace\\:
-				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\. Use \\$endpointFactory property instead\\.$#
-			"""
-			count: 4
-			path: src/OpenSearch/Namespaces/SearchableSnapshotsNamespace.php
-
-		-
-			message: """
-				#^Access to deprecated property \\$endpoints of class OpenSearch\\\\Namespaces\\\\AbstractNamespace\\:
-				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\. Use \\$endpointFactory property instead\\.$#
-			"""
-			count: 1
 			path: src/OpenSearch/Namespaces/SecurityNamespace.php
-
-		-
-			message: """
-				#^Access to deprecated property \\$endpoints of class OpenSearch\\\\Namespaces\\\\AbstractNamespace\\:
-				in 2\\.4\\.0 and will be removed in 3\\.0\\.0\\. Use \\$endpointFactory property instead\\.$#
-			"""
-			count: 1
-			path: src/OpenSearch/Namespaces/SslNamespace.php
 
 		-
 			message: "#^Call to an undefined method OpenSearch\\\\Client\\:\\:slm\\(\\)\\.$#"

--- a/src/OpenSearch/Namespaces/AsyncSearchNamespace.php
+++ b/src/OpenSearch/Namespaces/AsyncSearchNamespace.php
@@ -21,110 +21,14 @@ declare(strict_types=1);
 
 namespace OpenSearch\Namespaces;
 
-use OpenSearch\Namespaces\AbstractNamespace;
+// @phpstan-ignore classConstant.deprecatedClass
+@trigger_error(AsyncSearchNamespace::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0. Use AsynchronousSearchNamespace instead.', E_USER_DEPRECATED);
 
 /**
  * Class AsyncSearchNamespace
  *
+ * @deprecated in 2.4.0 and will be removed in 3.0.0. Use AsynchronousSearchNamespace instead.
  */
-class AsyncSearchNamespace extends AbstractNamespace
+class AsyncSearchNamespace extends AsynchronousSearchNamespace
 {
-    /**
-     * $params['id'] = (string) The async search ID
-     *
-     * @param array $params Associative array of parameters
-     * @return array
-     */
-    public function delete(array $params = [])
-    {
-        $id = $this->extractArgument($params, 'id');
-
-        $endpointBuilder = $this->endpoints;
-        $endpoint = $endpointBuilder('AsyncSearch\Delete');
-        $endpoint->setParams($params);
-        $endpoint->setId($id);
-
-        return $this->performRequest($endpoint);
-    }
-    /**
-     * $params['id']                          = (string) The async search ID
-     * $params['wait_for_completion_timeout'] = (time) Specify the time that the request should block waiting for the final response
-     * $params['keep_alive']                  = (time) Specify the time interval in which the results (partial or final) for this search will be available
-     * $params['typed_keys']                  = (boolean) Specify whether aggregation and suggester names should be prefixed by their respective types in the response
-     *
-     * @param array $params Associative array of parameters
-     * @return array
-     */
-    public function get(array $params = [])
-    {
-        $id = $this->extractArgument($params, 'id');
-
-        $endpointBuilder = $this->endpoints;
-        $endpoint = $endpointBuilder('AsyncSearch\Get');
-        $endpoint->setParams($params);
-        $endpoint->setId($id);
-
-        return $this->performRequest($endpoint);
-    }
-    /**
-     * $params['index']                         = (list) A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices
-     * $params['wait_for_completion_timeout']   = (time) Specify the time that the request should block waiting for the final response (Default = 1s)
-     * $params['keep_on_completion']            = (boolean) Control whether the response should be stored in the cluster if it completed within the provided [wait_for_completion] time (default: false) (Default = false)
-     * $params['keep_alive']                    = (time) Update the time interval in which the results (partial or final) for this search will be available (Default = 5d)
-     * $params['batched_reduce_size']           = (number) The number of shard results that should be reduced at once on the coordinating node. This value should be used as the granularity at which progress results will be made available. (Default = 5)
-     * $params['request_cache']                 = (boolean) Specify if request cache should be used for this request or not, defaults to true
-     * $params['analyzer']                      = (string) The analyzer to use for the query string
-     * $params['analyze_wildcard']              = (boolean) Specify whether wildcard and prefix queries should be analyzed (default: false)
-     * $params['default_operator']              = (enum) The default operator for query string query (AND or OR) (Options = AND,OR) (Default = OR)
-     * $params['df']                            = (string) The field to use as default where no field prefix is given in the query string
-     * $params['explain']                       = (boolean) Specify whether to return detailed information about score computation as part of a hit
-     * $params['stored_fields']                 = (list) A comma-separated list of stored fields to return as part of a hit
-     * $params['docvalue_fields']               = (list) A comma-separated list of fields to return as the docvalue representation of a field for each hit
-     * $params['from']                          = (number) Starting offset (default: 0)
-     * $params['ignore_unavailable']            = (boolean) Whether specified concrete indices should be ignored when unavailable (missing or closed)
-     * $params['ignore_throttled']              = (boolean) Whether specified concrete, expanded or aliased indices should be ignored when throttled
-     * $params['allow_no_indices']              = (boolean) Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)
-     * $params['expand_wildcards']              = (enum) Whether to expand wildcard expression to concrete indices that are open, closed or both. (Options = open,closed,hidden,none,all) (Default = open)
-     * $params['lenient']                       = (boolean) Specify whether format-based query failures (such as providing text to a numeric field) should be ignored
-     * $params['preference']                    = (string) Specify the node or shard the operation should be performed on (default: random)
-     * $params['q']                             = (string) Query in the Lucene query string syntax
-     * $params['routing']                       = (list) A comma-separated list of specific routing values
-     * $params['search_type']                   = (enum) Search operation type (Options = query_then_fetch,dfs_query_then_fetch)
-     * $params['size']                          = (number) Number of hits to return (default: 10)
-     * $params['sort']                          = (list) A comma-separated list of <field>:<direction> pairs
-     * $params['_source']                       = (list) True or false to return the _source field or not, or a list of fields to return
-     * $params['_source_excludes']              = (list) A list of fields to exclude from the returned _source field
-     * $params['_source_includes']              = (list) A list of fields to extract and return from the _source field
-     * $params['terminate_after']               = (number) The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.
-     * $params['stats']                         = (list) Specific 'tag' of the request for logging and statistical purposes
-     * $params['suggest_field']                 = (string) Specify which field to use for suggestions
-     * $params['suggest_mode']                  = (enum) Specify suggest mode (Options = missing,popular,always) (Default = missing)
-     * $params['suggest_size']                  = (number) How many suggestions to return in response
-     * $params['suggest_text']                  = (string) The source text for which the suggestions should be returned
-     * $params['timeout']                       = (time) Explicit operation timeout
-     * $params['track_scores']                  = (boolean) Whether to calculate and return scores even if they are not used for sorting
-     * $params['track_total_hits']              = (boolean) Indicate if the number of documents that match the query should be tracked
-     * $params['allow_partial_search_results']  = (boolean) Indicate if an error should be returned if there is a partial search failure or timeout (Default = true)
-     * $params['typed_keys']                    = (boolean) Specify whether aggregation and suggester names should be prefixed by their respective types in the response
-     * $params['version']                       = (boolean) Specify whether to return document version as part of a hit
-     * $params['seq_no_primary_term']           = (boolean) Specify whether to return sequence number and primary term of the last modification of each hit
-     * $params['max_concurrent_shard_requests'] = (number) The number of concurrent shard requests per node this search executes concurrently. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests (Default = 5)
-     * $params['body']                          = (array) The search definition using the Query DSL
-     *
-     * @param array $params Associative array of parameters
-     * @return array
-     */
-    public function submit(array $params = [])
-    {
-        $index = $this->extractArgument($params, 'index');
-        $body = $this->extractArgument($params, 'body');
-
-        $endpointBuilder = $this->endpoints;
-        $endpoint = $endpointBuilder('AsyncSearch\Submit');
-        $endpoint->setParams($params);
-        $endpoint->setIndex($index);
-        $endpoint->setBody($body);
-
-        return $this->performRequest($endpoint);
-    }
 }

--- a/src/OpenSearch/Namespaces/DataFrameTransformDeprecatedNamespace.php
+++ b/src/OpenSearch/Namespaces/DataFrameTransformDeprecatedNamespace.php
@@ -21,11 +21,13 @@ declare(strict_types=1);
 
 namespace OpenSearch\Namespaces;
 
-use OpenSearch\Namespaces\AbstractNamespace;
+// @phpstan-ignore classConstant.deprecatedClass
+@trigger_error(DataFrameTransformDeprecatedNamespace::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
  * Class DataFrameTransformDeprecatedNamespace
  *
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class DataFrameTransformDeprecatedNamespace extends AbstractNamespace
 {

--- a/src/OpenSearch/Namespaces/MonitoringNamespace.php
+++ b/src/OpenSearch/Namespaces/MonitoringNamespace.php
@@ -23,9 +23,13 @@ namespace OpenSearch\Namespaces;
 
 use OpenSearch\Namespaces\AbstractNamespace;
 
+// @phpstan-ignore classConstant.deprecatedClass
+@trigger_error(MonitoringNamespace::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
+
 /**
  * Class MonitoringNamespace
  *
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class MonitoringNamespace extends AbstractNamespace
 {

--- a/src/OpenSearch/Namespaces/SearchableSnapshotsNamespace.php
+++ b/src/OpenSearch/Namespaces/SearchableSnapshotsNamespace.php
@@ -21,11 +21,13 @@ declare(strict_types=1);
 
 namespace OpenSearch\Namespaces;
 
-use OpenSearch\Namespaces\AbstractNamespace;
+// @phpstan-ignore classConstant.deprecatedClass
+@trigger_error(SearchableSnapshotsNamespace::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
 
 /**
  * Class SearchableSnapshotsNamespace
  *
+ * @deprecated in 2.4.0 and will be removed in 3.0.0.
  */
 class SearchableSnapshotsNamespace extends AbstractNamespace
 {

--- a/src/OpenSearch/Namespaces/SslNamespace.php
+++ b/src/OpenSearch/Namespaces/SslNamespace.php
@@ -21,13 +21,15 @@ declare(strict_types=1);
 
 namespace OpenSearch\Namespaces;
 
-use OpenSearch\Namespaces\AbstractNamespace;
+// @phpstan-ignore classConstant.deprecatedClass
+@trigger_error(SslNamespace::class . ' is deprecated in 2.4.0 and will be removed in 3.0.0. Use SslNamespace instead.', E_USER_DEPRECATED);
 
 /**
  * Class SslNamespace
  *
+ * @deprecated in 2.4.0 and will be removed in 3.0.0. Use SslNamespace instead.
  */
-class SslNamespace extends AbstractNamespace
+class SslNamespace extends SecurityNamespace
 {
     /**
      *
@@ -36,10 +38,6 @@ class SslNamespace extends AbstractNamespace
      */
     public function certificates(array $params = [])
     {
-        $endpointBuilder = $this->endpoints;
-        $endpoint = $endpointBuilder('Ssl\Certificates');
-        $endpoint->setParams($params);
-
-        return $this->performRequest($endpoint);
+        return $this->getCertificates($params);
     }
 }

--- a/util/ClientEndpoint.php
+++ b/util/ClientEndpoint.php
@@ -50,6 +50,7 @@ class ClientEndpoint extends NamespaceEndpoint
         $useNamespace = '';
 
         // The following namespaces do not have OpenSearch API specifications
+        // @todo Remove these namespaces in 3.0.0
         $patchnamespaces = ['async_search', 'searchable_snapshots', 'ssl', 'data_frame_transform_deprecated', 'monitoring'];
         $this->namespace = array_unique(array_merge($this->namespace, $patchnamespaces));
         sort($this->namespace);


### PR DESCRIPTION
### Description
Deprecates namespaces no longer in the API spec.

Unfortunately there is no way to deprecate the corresponding methods in the `Client` as the template doesn't support this.

### Issues Resolved
#262 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
