### PR TITLE
Serialize boolean query string params as strings

### DIFF
--- a/src/OpenSearch/RequestFactory.php
+++ b/src/OpenSearch/RequestFactory.php
@@ -32,7 +32,7 @@ final class RequestFactory implements RequestFactoryInterface
         array $headers = [],
     ): RequestInterface {
         $uri = $this->uriFactory->createUri($uri);
-        $uri = $uri->withQuery(http_build_query($params));
+        $uri = $uri->withQuery($this->createQuery($params));
         $request = $this->psrRequestFactory->createRequest($method, $uri);
         if ($body !== null) {
             $bodyJson = $this->serializer->serialize($body);
@@ -43,6 +43,25 @@ final class RequestFactory implements RequestFactoryInterface
             $request = $request->withHeader($name, $value);
         }
         return $request;
+    }
+
+    /**
+     * Create a query string from an array of parameters.
+     */
+    private function createQuery(array $params): string
+    {
+        ksort($params);
+
+        return http_build_query(array_map(function ($value) {
+            // Ensure boolean values are serialized as strings.
+            if ($value === true) {
+                return 'true';
+            }
+            if ($value === false) {
+                return 'false';
+            }
+            return $value;
+        }, $params));
     }
 
 }

--- a/tests/RequestFactoryTest.php
+++ b/tests/RequestFactoryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Tests;
+
+use GuzzleHttp\Psr7\HttpFactory;
+use OpenSearch\RequestFactory;
+use OpenSearch\Serializers\SerializerInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the request factory.
+ *
+ * @coversDefaultClass \OpenSearch\RequestFactory
+ */
+class RequestFactoryTest extends TestCase
+{
+    public function testBoolean(): void
+    {
+        $httpFactory = new HttpFactory();
+        $serializer = $this->createMock(SerializerInterface::class);
+
+        $factory = new RequestFactory($httpFactory, $httpFactory, $httpFactory, $serializer);
+
+        $params = ['foo' => true, 'bar' => false];
+        $request = $factory->createRequest('GET', 'http://localhost:9200/_search', $params);
+
+        $this->assertEquals('bar=false&foo=true', $request->getUri()->getQuery());
+    }
+}


### PR DESCRIPTION
### Description

Boolean query string parameters should be `"true"` or `"false"` strings, `http_build_query()` serializes them as `1` and `0`.

In 2.3.1 they were strings, but this got missed in 2.4.0. This PR changes them back to strings.

### Issues Resolved
Fixes #246 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
