### PR TITLE
Add php cs fixer rule to remove unused imports

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
 This document has been generated with
 https://mlocati.github.io/php-cs-fixer-configurator/#version:3.0.0-rc.1|configurator
@@ -9,10 +10,12 @@ return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
         '@PSR12' => true,
+        'no_unused_imports' => true,
     ])
-    ->setFinder(PhpCsFixer\Finder::create()
+    ->setFinder(
+        PhpCsFixer\Finder::create()
         ->exclude('vendor')
         ->exclude('util/cache')
         ->in(__DIR__)
     )
-    ;
+;


### PR DESCRIPTION
### Description

Cleans up unused imports with a php-cs fixer rule.

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
