### PR TITLE
Reduce the number of approvers for release to 1.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-        id-token: write
-        issues: write
-        contents: write
+      id-token: write
+      issues: write
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -22,8 +22,8 @@ jobs:
         with:
           secret: ${{ github.TOKEN }}
           approvers: ${{ steps.get_data.outputs.approvers }}
-          minimum-approvals: 2
-          issue-title: 'Release opensearch-PHP'
+          minimum-approvals: 1
+          issue-title: "Release opensearch-PHP"
           issue-body: "Please approve or deny the release of opensearch-PHP client on packagist. **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }}"
           exclude-workflow-initiator-as-approver: true
 


### PR DESCRIPTION
### Description

There are too few maintainers here, let's reduce the number of release approvers to 1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
