### PR TITLE
Change registered namespaces to an optional Client constructor param

### DIFF
--- a/src/OpenSearch/Client.php
+++ b/src/OpenSearch/Client.php
@@ -315,7 +315,7 @@ class Client
     public function __construct(
         TransportInterface|Transport $transport,
         callable|EndpointFactoryInterface $endpointFactory,
-        array $registeredNamespaces,
+        array $registeredNamespaces = [],
     ) {
         if (!$transport instanceof TransportInterface) {
             @trigger_error('Passing an instance of \OpenSearch\Transport to ' . __METHOD__ . '() is deprecated in 2.4.0 and will be removed in 3.0.0. Pass an instance of \OpenSearch\TransportInterface instead.', E_USER_DEPRECATED);

--- a/util/template/client-class
+++ b/util/template/client-class
@@ -78,7 +78,7 @@ class Client
     public function __construct(
         TransportInterface|Transport $transport,
         callable|EndpointFactoryInterface $endpointFactory,
-        array $registeredNamespaces,
+        array $registeredNamespaces = [],
     ) {
         if (!$transport instanceof TransportInterface) {
             @trigger_error('Passing an instance of \OpenSearch\Transport to ' . __METHOD__ . '() is deprecated in 2.4.0 and will be removed in 3.0.0. Pass an instance of \OpenSearch\TransportInterface instead.', E_USER_DEPRECATED);


### PR DESCRIPTION
### Description

The `$registeredNamespaces` `Client` constructor param is often set as an empty array. Let's make this an optional param.

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
