### PR TITLE
fix: reusage of parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Added Guzzle and Symfony client factories ([#287](https://github.com/opensearch-project/opensearch-php/pull/287))
 ### Changed
+- Changed EndpointFactory to return new objects on each call to fix issues with parameter reusage ([#292](https://github.com/opensearch-project/opensearch-php/pull/292))
 ### Deprecated
 ### Removed
 ### Fixed

--- a/src/OpenSearch/EndpointFactory.php
+++ b/src/OpenSearch/EndpointFactory.php
@@ -12,11 +12,6 @@ use ReflectionClass;
  */
 class EndpointFactory implements EndpointFactoryInterface
 {
-    /**
-     * @var array<string, AbstractEndpoint>
-     */
-    private array $endpoints = [];
-
     private ?SerializerInterface $serializer;
 
     public function __construct(?SerializerInterface $serializer = null)
@@ -29,11 +24,7 @@ class EndpointFactory implements EndpointFactoryInterface
      */
     public function getEndpoint(string $class): AbstractEndpoint
     {
-        if (!isset($this->endpoints[$class])) {
-            $this->endpoints[$class] = $this->createEndpoint($class);
-        }
-
-        return $this->endpoints[$class];
+        return $this->createEndpoint($class);
     }
 
     private function getSerializer(): SerializerInterface

--- a/tests/Endpoints/MlNamespaceIntegrationTest.php
+++ b/tests/Endpoints/MlNamespaceIntegrationTest.php
@@ -41,6 +41,12 @@ class MlNamespaceIntegrationTest extends TestCase
             ],
         ]);
         $this->assertNotEmpty($modelGroupResponse['model_group_id']);
+
+        if (Utility::isOpenSearchVersionAtLeast($client, '2.11.0')) {
+            $client->ml()->deleteModelGroup([
+                 'id' => $modelGroupResponse['model_group_id'],
+             ]);
+        }
     }
 
     public function testgetModels()

--- a/tests/Namespaces/SearchTest.php
+++ b/tests/Namespaces/SearchTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Tests\Namespaces;
+
+use OpenSearch\Client;
+use OpenSearch\EndpointFactory;
+use OpenSearch\TransportInterface;
+use PHPUnit\Framework\TestCase;
+
+class SearchTest extends TestCase
+{
+    public function testSearchDoesNotInhereitPreviousParameters(): void
+    {
+        $transport = $this->createMock(TransportInterface::class);
+
+        $calledUrls = [];
+
+        $transport->method('sendRequest')
+            ->willReturnCallback(function ($method, $uri, $params, $body) use (&$calledUrls) {
+                $calledUrls[] = $uri;
+                return [];
+            });
+
+        $client = new Client($transport, new EndpointFactory());
+
+        $client->search([
+            'index' => 'test',
+            'body' => [
+                'query' => [
+                    'match_all' => new \stdClass(),
+                ],
+            ],
+        ]);
+
+        $client->search([
+            'body' => [
+                'query' => [
+                    'match_all' => new \stdClass(),
+                ],
+            ],
+        ]);
+
+        static::assertSame([
+            '/test/_search',
+            '/_search',
+        ], $calledUrls);
+    }
+}


### PR DESCRIPTION
### Description

Since we don't clone endpoints anymore. we keep some set variables between multiple calls. I restored the previous behaviour and added a test. I think we should refactor it out in future PRs


### Issues Resolved
Closes #289 , #284 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
