### PR TITLE
Ensure Async mode is still working on last version, Fix #297

### DIFF
--- a/src/OpenSearch/Client.php
+++ b/src/OpenSearch/Client.php
@@ -2155,7 +2155,7 @@ class Client
         string $method,
         string $uri,
         array $attributes = []
-    ): array|string|null {
+    ): \Traversable|array|string|null {
         $params = $attributes['params'] ?? [];
         $body = $attributes['body'] ?? null;
         $options = $attributes['options'] ?? [];
@@ -2169,7 +2169,7 @@ class Client
      * @throws \Psr\Http\Client\ClientExceptionInterface
      * @throws \OpenSearch\Exception\HttpExceptionInterface
      */
-    private function performRequest(AbstractEndpoint $endpoint): array|string|null
+    private function performRequest(AbstractEndpoint $endpoint): \Traversable|array|string|null
     {
         return $this->httpTransport->sendRequest(
             $endpoint->getMethod(),

--- a/src/OpenSearch/HttpTransport.php
+++ b/src/OpenSearch/HttpTransport.php
@@ -36,7 +36,7 @@ final class HttpTransport implements TransportInterface
         array $params = [],
         mixed $body = null,
         array $headers = [],
-    ): array|string|null {
+    ): \Traversable|array|string|null {
         $request = $this->createRequest($method, $uri, $params, $body, $headers);
         $response = $this->client->sendRequest($request);
         $statusCode = $response->getStatusCode();

--- a/src/OpenSearch/LegacyTransportWrapper.php
+++ b/src/OpenSearch/LegacyTransportWrapper.php
@@ -28,13 +28,10 @@ class LegacyTransportWrapper implements TransportInterface
         array $params = [],
         mixed $body = null,
         array $headers = [],
-    ): array|string|null {
-        $promise = $this->transport->performRequest($method, $uri, $params, $body);
-        $futureArray = $this->transport->resultOrFuture($promise);
-        if ($futureArray instanceof FutureArrayInterface) {
-            return $futureArray->wait();
-        }
-        return $futureArray;
+    ): \Traversable|array|string|null {
+        $promise = $this->transport->performRequest($method, $uri, $params, $body, $headers);
+
+        return $this->transport->resultOrFuture($promise, $headers);
     }
 
 }

--- a/src/OpenSearch/TransportInterface.php
+++ b/src/OpenSearch/TransportInterface.php
@@ -23,6 +23,6 @@ interface TransportInterface
         array $params = [],
         string|array|null $body = null,
         array $headers = [],
-    ): array|string|null;
+    ): \Traversable|array|string|null;
 
 }


### PR DESCRIPTION
### Description
The explicit call to `wait()` in LegacyTransportWrapper was causing all the existing promises to resolve even if we plan to let them run async.

The missing parameter for `performRequest` and `resultOrFuture` was also preventing the correct detection that we are using the async mode.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

#297 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
