### PR TITLE
Fix changelog updater

### DIFF
--- a/util/changelog_updater.php
+++ b/util/changelog_updater.php
@@ -52,13 +52,14 @@ function main()
                 throw new \RuntimeException('Failed to read CHANGELOG.md');
             }
 
-            if (strpos($content, $commitUrl) === false) {
-                if (strpos($content, "### Updated APIs") !== false) {
-                    $fileContent = str_replace(
-                        "### Updated APIs",
-                        "### Updated APIs\n- Updated opensearch-php APIs to reflect [opensearch-api-specification@" . substr($latestCommitSha, 0, 7) . "]($commitUrl)",
-                        $content
-                    );
+            if (!str_contains($content, $commitUrl)) {
+                $search = "### Updated APIs";
+                $pos = strpos($content, $search);
+                if ($pos !== false) {
+                    $shortHash = substr($latestCommitSha, 0, 7);
+                    $replace = "### Updated APIs\n- Updated opensearch-php APIs to reflect [opensearch-api-specification@$shortHash]($commitUrl)";
+                    // Only replace first occurrence of 'Updated APIs' section.
+                    $fileContent = substr_replace($content, $replace, $pos, strlen($search));
 
                     $result = file_put_contents($changelogPath, $fileContent);
                     if ($result === false) {


### PR DESCRIPTION
### Description

The changelog updater should only update the first occurance of the `### Updated APIs` section.

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
