### PR TITLE
Replace array by iterable in return type. Fix #307

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed mismatch in return types between `Client::performRequest()` and `Transport::sendRequest()` ([#307](https://github.com/opensearch-project/opensearch-php/issues/307))
 ### Security
 ### Updated APIs
 - Updated opensearch-php APIs to reflect [opensearch-api-specification@5ed668d](https://github.com/opensearch-project/opensearch-api-specification/commit/5ed668d81b34ae90c22a605755fe1c340f38c27d)

--- a/src/OpenSearch/Client.php
+++ b/src/OpenSearch/Client.php
@@ -2169,7 +2169,7 @@ class Client
      * @throws \Psr\Http\Client\ClientExceptionInterface
      * @throws \OpenSearch\Exception\HttpExceptionInterface
      */
-    private function performRequest(AbstractEndpoint $endpoint): array|string|null
+    private function performRequest(AbstractEndpoint $endpoint): iterable|string|null
     {
         return $this->httpTransport->sendRequest(
             $endpoint->getMethod(),


### PR DESCRIPTION
### Description
_Describe what this change achieves._

This ensures that `Client::performRequest()` has the same return type than the `Transport::sendRequest()` since it was changed in #300 

### Issues Resolved
Fixes #307 