### PR TITLE
Update performRequest return type to iterable

### DIFF
--- a/src/OpenSearch/Client.php
+++ b/src/OpenSearch/Client.php
@@ -2155,7 +2155,7 @@ class Client
         string $method,
         string $uri,
         array $attributes = []
-    ): array|string|null {
+    ): iterable|string|null {
         $params = $attributes['params'] ?? [];
         $body = $attributes['body'] ?? null;
         $options = $attributes['options'] ?? [];

--- a/util/template/client-class
+++ b/util/template/client-class
@@ -159,7 +159,7 @@ class Client
         string $method,
         string $uri,
         array $attributes = []
-    ): array|string|null {
+    ): iterable|string|null {
         $params = $attributes['params'] ?? [];
         $body = $attributes['body'] ?? null;
         $options = $attributes['options'] ?? [];
@@ -173,7 +173,7 @@ class Client
      * @throws \Psr\Http\Client\ClientExceptionInterface
      * @throws \OpenSearch\Exception\HttpExceptionInterface
      */
-    private function performRequest(AbstractEndpoint $endpoint): array|string|null
+    private function performRequest(AbstractEndpoint $endpoint): iterable|string|null
     {
         return $this->httpTransport->sendRequest(
             $endpoint->getMethod(),


### PR DESCRIPTION
### Description
This changes the return type of performRequest() to iterable for BC. It was only partially fixed in #308 as the client template wasn't changed, so the next API update will revert it.

### Issues Resolved
Fixes #307

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
