### PR TITLE
Adds a AwsSigningHttpClientFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 ### Added
+- Added `auth_aws` option to GuzzleClientFactory and SymfonyClientFactory ([#314](https://github.com/opensearch-project/opensearch-php/pull/314))
 ### Changed
 - Updated Client constructor to make EndpointFactory and optional parameter.
 ### Deprecated

--- a/src/OpenSearch/Aws/SigningClientFactory.php
+++ b/src/OpenSearch/Aws/SigningClientFactory.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Aws;
+
+use Aws\Credentials\CredentialProvider;
+use Aws\Credentials\Credentials;
+use Aws\Exception\CredentialsException;
+use Aws\Signature\SignatureInterface;
+use Aws\Signature\SignatureV4;
+use Psr\Http\Client\ClientInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * A factory for creating an HTTP Client that signs requests using AWS credentials.
+ */
+class SigningClientFactory
+{
+    /**
+     * The allowed AWS services.
+     */
+    public const ALLOWED_SERVICES = ['es', 'aoss'];
+
+    public function __construct(
+        protected ?SignatureInterface $signer = null,
+        protected ?CredentialProvider $provider = null,
+        protected ?LoggerInterface $logger = null,
+    ) {
+    }
+
+    /**
+     * Creates a new signing client.
+     *
+     * @param ClientInterface $innerClient
+     *   The decorated inner HTTP client.
+     * @param array<string,string> $options
+     *   The AWS auth options.
+     */
+    public function create(ClientInterface $innerClient, array $options): ClientInterface
+    {
+        if (!isset($options['host'])) {
+            throw new \InvalidArgumentException('The host option is required.');
+        }
+
+        // Get the credentials.
+        $provider = $this->getCredentialProvider($options);
+        $promise = $provider();
+        try {
+            $credentials = $promise->wait();
+        } catch (CredentialsException $e) {
+            $this->logger?->error('Failed to get AWS credentials: @message', ['@message' => $e->getMessage()]);
+            $credentials = new Credentials('', '');
+        }
+
+        // Get the signer.
+        $signer = $this->getSigner($options);
+
+        return new SigningClientDecorator($innerClient, $credentials, $signer, ['host' => $options['host']]);
+    }
+
+    /**
+     * Gets the credential provider.
+     *
+     * @param array<string,mixed> $options
+     *   The options array.
+     */
+    protected function getCredentialProvider(array $options): CredentialProvider|\Closure|null|callable
+    {
+        // Check for a provided credential provider.
+        if ($this->provider) {
+            return $this->provider;
+        }
+
+        // Check for provided access key and secret.
+        if (isset($options['credentials'])) {
+            return CredentialProvider::fromCredentials(
+                new Credentials(
+                    $options['credentials']['access_key'] ?? '',
+                    $options['credentials']['secret_key'] ?? '',
+                    $options['credentials']['session_token'] ?? null,
+                )
+            );
+        }
+
+        // Fallback to the default provider.
+        return CredentialProvider::defaultProvider();
+    }
+
+    /**
+     * Gets the request signer.
+     *
+     * @param array<string,string> $options
+     *   The options.
+     */
+    protected function getSigner(array $options): SignatureInterface
+    {
+        if ($this->signer) {
+            return $this->signer;
+        }
+
+        if (!isset($options['region'])) {
+            throw new \InvalidArgumentException('The region option is required.');
+        }
+
+        $service = $options['service'] ?? 'es';
+
+        if (!in_array($service, self::ALLOWED_SERVICES, true)) {
+            throw new \InvalidArgumentException('The service option must be either "es" or "aoss".');
+        }
+
+        return new SignatureV4($service, $options['region'], $options);
+    }
+
+}

--- a/src/OpenSearch/GuzzleClientFactory.php
+++ b/src/OpenSearch/GuzzleClientFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenSearch;
 
+use OpenSearch\Aws\SigningClientFactory;
 use OpenSearch\HttpClient\GuzzleHttpClientFactory;
 use Psr\Log\LoggerInterface;
 use GuzzleHttp\Psr7\HttpFactory;
@@ -17,6 +18,7 @@ class GuzzleClientFactory implements ClientFactoryInterface
     public function __construct(
         protected int $maxRetries = 0,
         protected ?LoggerInterface $logger = null,
+        protected ?SigningClientFactory $awsSigningHttpClientFactory = null,
     ) {
     }
 
@@ -26,7 +28,22 @@ class GuzzleClientFactory implements ClientFactoryInterface
      */
     public function create(array $options): Client
     {
+        // Clean up the options array for the Guzzle HTTP Client.
+        if (isset($options['auth_aws'])) {
+            $awsAuth = $options['auth_aws'];
+            unset($options['auth_aws']);
+        }
+
         $httpClient = (new GuzzleHttpClientFactory($this->maxRetries, $this->logger))->create($options);
+
+        if (isset($awsAuth)) {
+            if (!isset($awsAuth['host'])) {
+                // Get the host from the base URI.
+                $awsAuth['host'] = parse_url($options['base_uri'], PHP_URL_HOST);
+            }
+            $httpClient = $this->getSigningClientFactory()->create($httpClient, $awsAuth);
+        }
+
         $httpFactory = new HttpFactory();
 
         $serializer = new SmartSerializer();
@@ -45,4 +62,16 @@ class GuzzleClientFactory implements ClientFactoryInterface
 
         return new Client($transport, new EndpointFactory($serializer), []);
     }
+
+    /**
+     * Gets the AWS signing client factory.
+     */
+    protected function getSigningClientFactory(): SigningClientFactory
+    {
+        if ($this->awsSigningHttpClientFactory === null) {
+            $this->awsSigningHttpClientFactory = new SigningClientFactory();
+        }
+        return $this->awsSigningHttpClientFactory;
+    }
+
 }

--- a/tests/Aws/SigningClientFactoryTest.php
+++ b/tests/Aws/SigningClientFactoryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenSearch\Tests\Aws;
+
+use OpenSearch\Aws\SigningClientFactory;
+use OpenSearch\HttpClient\SymfonyHttpClientFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+
+/**
+ * @coversDefaultClass \OpenSearch\Aws\SigningClientFactory
+ */
+class SigningClientFactoryTest extends TestCase
+{
+    /**
+     * @covers ::create
+     */
+    public function testCreate(): void
+    {
+        $symfonyClient = (new SymfonyHttpClientFactory())->create([
+            'base_uri' => 'http://localhost:9200',
+        ]);
+        $client = (new SigningClientFactory())->create($symfonyClient, [
+            'host' => 'example.com',
+            'region' => 'us-east-1',
+            'credentials' => [
+                'access_key' => 'foo',
+                'secret_key' => 'bar',
+            ],
+        ]);
+
+        // Check we get a client back.
+        $this->assertInstanceOf(ClientInterface::class, $client);
+    }
+
+    /**
+     * @covers ::create
+     */
+    public function testValidateService(): void
+    {
+        $symfonyClient = (new SymfonyHttpClientFactory())->create([
+            'base_uri' => 'http://localhost:9200',
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The service option must be either "es" or "aoss".');
+
+        (new SigningClientFactory())->create($symfonyClient, [
+            'host' => 'example.com',
+            'region' => 'us-east-1',
+            'service' => 'foo',
+            'credentials' => [
+                'access_key' => 'foo',
+                'secret_key' => 'bar',
+            ],
+        ]);
+    }
+}

--- a/tests/GuzzleClientFactoryTest.php
+++ b/tests/GuzzleClientFactoryTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace OpenSearch\Tests;
 
+use OpenSearch\Client;
 use OpenSearch\GuzzleClientFactory;
 use PHPUnit\Framework\TestCase;
-use OpenSearch\Client;
 
 /**
  * @coversDefaultClass \OpenSearch\GuzzleClientFactory
@@ -26,6 +26,26 @@ class GuzzleClientFactoryTest extends TestCase
             'base_uri' => 'https://localhost:9200',
             'auth' => ['admin', 'password'],
             'verify' => false,
+        ]);
+
+        $this->assertInstanceOf(Client::class, $client);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::create
+     */
+    public function testCreateWithAwsAuth(): void
+    {
+        $client = (new GuzzleClientFactory())->create([
+            'base_uri' => 'http://localhost:9200',
+            'auth_aws' => [
+                'region' => 'us-east-1',
+                'credentials' => [
+                    'access_key' => 'foo',
+                    'secret_key' => 'bar',
+                ],
+            ],
         ]);
 
         $this->assertInstanceOf(Client::class, $client);

--- a/tests/SymfonyClientFactoryTest.php
+++ b/tests/SymfonyClientFactoryTest.php
@@ -32,6 +32,26 @@ class SymfonyClientFactoryTest extends TestCase
 
     /**
      * @covers ::__construct
+     * @covers ::create
+     */
+    public function testCreateWithAwsAuth(): void
+    {
+        $client = (new SymfonyClientFactory())->create([
+            'base_uri' => 'http://localhost:9200',
+            'auth_aws' => [
+                'region' => 'us-east-1',
+                'credentials' => [
+                    'access_key' => 'foo',
+                    'secret_key' => 'bar',
+                ],
+            ],
+        ]);
+
+        $this->assertInstanceOf(Client::class, $client);
+    }
+
+    /**
+     * @covers ::__construct
      */
     public function testLegacyOptions(): void
     {


### PR DESCRIPTION
### Description

Adds an 'auth_aws' option to both `SymfonyClientFactory` and `GuzzleClientFactory`

Also updates auth guide.

Example usage:

```php
$client = (new SymfonyClientFactory())->create([
    'base_uri' => $endpoint,
    'auth_aws' => [
        'region' => $region,
        'service' => 'es',
        'credentials' => [
            'access_key' => $aws_access_key_id,
            'secret_key' => $aws_secret_access_key,
            'session_token' => $aws_session_token,
        ],
    ],
]);
```

### Issues Resolved

#257

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
