### PR TITLE
Make EndpointFactory and optional Client constructor param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 ### Changed
+- Updated Client constructor to make EndpointFactory and optional parameter.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/src/OpenSearch/Client.php
+++ b/src/OpenSearch/Client.php
@@ -317,14 +317,14 @@ class Client
      * Client constructor
      *
      * @param TransportInterface|Transport $transport
-     * @param callable|EndpointFactoryInterface $endpointFactory
+     * @param callable|EndpointFactoryInterface|null $endpointFactory
      * @param NamespaceBuilderInterface[] $registeredNamespaces
      *
      * @phpstan-ignore parameter.deprecatedClass
      */
     public function __construct(
         TransportInterface|Transport $transport,
-        callable|EndpointFactoryInterface $endpointFactory,
+        callable|EndpointFactoryInterface|null $endpointFactory,
         array $registeredNamespaces = [],
     ) {
         if (!$transport instanceof TransportInterface) {
@@ -336,17 +336,22 @@ class Client
         } else {
             $this->httpTransport = $transport;
         }
+
         if (is_callable($endpointFactory)) {
             @trigger_error('Passing a callable as the $endpointFactory param in ' . __METHOD__ . ' is deprecated in 2.4.0 and will be removed in 3.0.0. Pass an instance of \OpenSearch\EndpointFactoryInterface instead.', E_USER_DEPRECATED);
             $endpoints = $endpointFactory;
             // @phpstan-ignore new.deprecated
             $endpointFactory = new LegacyEndpointFactory($endpointFactory);
         } else {
+            if ($endpointFactory === null) {
+                $endpointFactory = new EndpointFactory();
+            }
             $endpoints = function ($c) use ($endpointFactory) {
                 @trigger_error('The $endpoints property is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
                 return $endpointFactory->getEndpoint('OpenSearch\\Endpoints\\' . $c);
             };
         }
+
         // @phpstan-ignore property.deprecated
         $this->endpoints = $endpoints;
         $this->endpointFactory = $endpointFactory;

--- a/src/OpenSearch/Client.php
+++ b/src/OpenSearch/Client.php
@@ -324,7 +324,7 @@ class Client
      */
     public function __construct(
         TransportInterface|Transport $transport,
-        callable|EndpointFactoryInterface|null $endpointFactory,
+        callable|EndpointFactoryInterface|null $endpointFactory = null,
         array $registeredNamespaces = [],
     ) {
         if (!$transport instanceof TransportInterface) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -122,4 +122,26 @@ class ClientTest extends TestCase
         $this->assertEquals(['bang'], $response);
     }
 
+    /**
+     * @covers ::request
+     */
+    public function testOptionalEndpointFactory(): void
+    {
+
+        $this->transport->expects($this->once())
+            ->method('sendRequest')
+            ->with('GET', '/', ['foo' => 'bar'], 'whizz')
+            ->willReturn(['bang']);
+
+        $this->client = new Client($this->transport);
+
+        $response = $this->client->request('GET', '/', [
+            'params' => ['foo' => 'bar'],
+            'body' => 'whizz',
+        ]);
+
+        $this->assertEquals(['bang'], $response);
+
+    }
+
 }

--- a/util/template/client-class
+++ b/util/template/client-class
@@ -70,14 +70,14 @@ class Client
      * Client constructor
      *
      * @param TransportInterface|Transport $transport
-     * @param callable|EndpointFactoryInterface $endpointFactory
+     * @param callable|EndpointFactoryInterface|null $endpointFactory
      * @param NamespaceBuilderInterface[] $registeredNamespaces
      *
      * @phpstan-ignore parameter.deprecatedClass
      */
     public function __construct(
         TransportInterface|Transport $transport,
-        callable|EndpointFactoryInterface $endpointFactory,
+        callable|EndpointFactoryInterface|null $endpointFactory,
         array $registeredNamespaces = [],
     ) {
         if (!$transport instanceof TransportInterface) {
@@ -89,17 +89,22 @@ class Client
         } else {
             $this->httpTransport = $transport;
         }
+
         if (is_callable($endpointFactory)) {
             @trigger_error('Passing a callable as the $endpointFactory param in ' . __METHOD__ . ' is deprecated in 2.4.0 and will be removed in 3.0.0. Pass an instance of \OpenSearch\EndpointFactoryInterface instead.', E_USER_DEPRECATED);
             $endpoints = $endpointFactory;
             // @phpstan-ignore new.deprecated
             $endpointFactory = new LegacyEndpointFactory($endpointFactory);
         } else {
+            if ($endpointFactory === null) {
+                $endpointFactory = new EndpointFactory();
+            }
             $endpoints = function ($c) use ($endpointFactory) {
                 @trigger_error('The $endpoints property is deprecated in 2.4.0 and will be removed in 3.0.0.', E_USER_DEPRECATED);
                 return $endpointFactory->getEndpoint('OpenSearch\\Endpoints\\' . $c);
             };
         }
+
         // @phpstan-ignore property.deprecated
         $this->endpoints = $endpoints;
         $this->endpointFactory = $endpointFactory;

--- a/util/template/client-class
+++ b/util/template/client-class
@@ -77,7 +77,7 @@ class Client
      */
     public function __construct(
         TransportInterface|Transport $transport,
-        callable|EndpointFactoryInterface|null $endpointFactory,
+        callable|EndpointFactoryInterface|null $endpointFactory = null,
         array $registeredNamespaces = [],
     ) {
         if (!$transport instanceof TransportInterface) {


### PR DESCRIPTION
### Description
We can create an default EndpointFactory in the Client constructor rather than requiring users to provide one.

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
