### PR TITLE
Fix options not being passed to legacy transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fixed mismatch in return types between `Client::performRequest()` and `Transport::sendRequest()` ([#307](https://github.com/opensearch-project/opensearch-php/issues/307))
 - Fixed legacy client options being passed as headers ([#301](https://github.com/opensearch-project/opensearch-php/issues/301))
+- Fixed endpoint options not being passed to legacy transport ([#296](https://github.com/opensearch-project/opensearch-php/issues/296))
 ### Security
 ### Updated APIs
 - Updated opensearch-php APIs to reflect [opensearch-api-specification@5ed668d](https://github.com/opensearch-project/opensearch-api-specification/commit/5ed668d81b34ae90c22a605755fe1c340f38c27d)

--- a/src/OpenSearch/LegacyTransportWrapper.php
+++ b/src/OpenSearch/LegacyTransportWrapper.php
@@ -29,9 +29,9 @@ class LegacyTransportWrapper implements TransportInterface
         mixed $body = null,
         array $headers = [],
     ): iterable|string|null {
-        $promise = $this->transport->performRequest($method, $uri, $params, $body);
         // Provide legacy support for options.
         $options = $headers;
+        $promise = $this->transport->performRequest($method, $uri, $params, $body, $options);
         return $this->transport->resultOrFuture($promise, $options);
     }
 

--- a/tests/LegacyClientIntegrationTest.php
+++ b/tests/LegacyClientIntegrationTest.php
@@ -26,8 +26,8 @@ use OpenSearch\ClientBuilder;
 use OpenSearch\Common\Exceptions\Missing404Exception;
 use OpenSearch\Exception\RuntimeException;
 use OpenSearch\Tests\ClientBuilder\ArrayLogger;
-use Psr\Log\LogLevel;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
 
 /**
  * Class ClientTest
@@ -193,5 +193,16 @@ class LegacyClientIntegrationTest extends TestCase
         }
 
         return '';
+    }
+
+    /**
+     * Tests we ignore 404 when passed as an option.
+     */
+    public function testIgnore404(): void
+    {
+        $result = $this->getClient()->indices()->getAlias(['name' => 'i_dont_exist', 'client' => ['ignore' => 404]]);
+
+        $this->assertEquals(404, $result['status']);
+
     }
 }


### PR DESCRIPTION
### Description

Fixes a BC issue where options passed in via an endpoint query weren't being passed to the legacy transport.

### Issues Resolved

Fixes #296 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
