### PR TITLE
Fix/json deserialization error

### DIFF
--- a/src/OpenSearch/Serializers/SmartSerializer.php
+++ b/src/OpenSearch/Serializers/SmartSerializer.php
@@ -56,8 +56,17 @@ class SmartSerializer implements SerializerInterface
      */
     public function deserialize(?string $data, array $headers)
     {
-        if (isset($headers['content_type']) === true) {
-            if (strpos($headers['content_type'], 'json') !== false) {
+        if (isset($headers['Content-Type'])) {
+            $contentType = $headers['Content-Type'];
+        } elseif (isset($headers['content_type'])) {
+            $contentType = $headers['content_type'];
+        } else {
+            $contentType = null;
+        }
+
+        if (!is_null($contentType)) {
+            $contentType = is_array($contentType) ? $contentType[0] : $contentType;
+            if (strpos($contentType, 'json') !== false) {
                 return $this->decode($data);
             } else {
                 //Not json, return as string

--- a/tests/Serializers/SmartSerializerTest.php
+++ b/tests/Serializers/SmartSerializerTest.php
@@ -65,7 +65,6 @@ class SmartSerializerTest extends TestCase
 
         $result = $this->serializer->deserialize($data, $headers);
 
-        $this->assertIsArray($result);
         $this->assertArrayHasKey('foo', $result);
         $this->assertEquals('bar', $result['foo']);
     }
@@ -77,8 +76,6 @@ class SmartSerializerTest extends TestCase
 
         $result = $this->serializer->deserialize($data, $headers);
 
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('foo', $result);
         $this->assertEquals('bar', $result['foo']);
     }
 
@@ -89,8 +86,6 @@ class SmartSerializerTest extends TestCase
 
         $result = $this->serializer->deserialize($data, $headers);
 
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('foo', $result);
         $this->assertEquals('bar', $result['foo']);
     }
 
@@ -101,8 +96,6 @@ class SmartSerializerTest extends TestCase
 
         $result = $this->serializer->deserialize($data, $headers);
 
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('foo', $result);
         $this->assertEquals('bar', $result['foo']);
     }
 
@@ -113,7 +106,6 @@ class SmartSerializerTest extends TestCase
 
         $result = $this->serializer->deserialize($data, $headers);
 
-        $this->assertIsString($result);
         $this->assertEquals('plain text data', $result);
     }
 }

--- a/tests/Serializers/SmartSerializerTest.php
+++ b/tests/Serializers/SmartSerializerTest.php
@@ -58,4 +58,62 @@ class SmartSerializerTest extends TestCase
         }
     }
 
+    public function testDeserializeJsonWithKebabCaseContentTypeHeader(): void
+    {
+        $data = '{ "foo" : "bar" }';
+        $headers = ['Content-Type' => 'application/json'];
+
+        $result = $this->serializer->deserialize($data, $headers);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('foo', $result);
+        $this->assertEquals('bar', $result['foo']);
+    }
+
+    public function testDeserializeJsonWithKebabCaseArrayContentTypeHeader(): void
+    {
+        $data = '{ "foo" : "bar" }';
+        $headers = ['Content-Type' => ['application/json']];
+
+        $result = $this->serializer->deserialize($data, $headers);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('foo', $result);
+        $this->assertEquals('bar', $result['foo']);
+    }
+
+    public function testDeserializeJsonWithSnakeCaseContentTypeHeader(): void
+    {
+        $data = '{ "foo" : "bar" }';
+        $headers = ['content_type' => 'application/json'];
+
+        $result = $this->serializer->deserialize($data, $headers);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('foo', $result);
+        $this->assertEquals('bar', $result['foo']);
+    }
+
+    public function testDeserializeJsonWithoutContentTypeHeader(): void
+    {
+        $data = '{ "foo" : "bar" }';
+        $headers = [];
+
+        $result = $this->serializer->deserialize($data, $headers);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('foo', $result);
+        $this->assertEquals('bar', $result['foo']);
+    }
+
+    public function testDeserializeNonJsonData(): void
+    {
+        $data = 'plain text data';
+        $headers = ['Content-Type' => 'text/plain'];
+
+        $result = $this->serializer->deserialize($data, $headers);
+
+        $this->assertIsString($result);
+        $this->assertEquals('plain text data', $result);
+    }
 }


### PR DESCRIPTION
### Description
Originally, the code only checked for the `content_type` key. However, when using the Guzzle client, it was found that the response header returns with the key `Content-Type`.
This fix ensures that responses using the `Content-Type` key are handled correctly as well.

### Issues Resolved
Fixes #318 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
