### PR TITLE
Fix checking for json content type when decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed checking for content type in JSON deserialization ([#318](https://github.com/opensearch-project/opensearch-php/issues/318))
 - Fixed mismatch in return types between `Client::performRequest()` and `Transport::sendRequest()` ([#307](https://github.com/opensearch-project/opensearch-php/issues/307))
 - Fixed legacy client options being passed as headers ([#301](https://github.com/opensearch-project/opensearch-php/issues/301))
 - Fixed endpoint options not being passed to legacy transport ([#296](https://github.com/opensearch-project/opensearch-php/issues/296))


### PR DESCRIPTION
### Description
Fixes an issue detecting the content-type when deserializing.

### Issues Resolved
Fixes https://github.com/opensearch-project/opensearch-php/issues/318

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
