### PR TITLE
Fix error when content_type is NULL

### DIFF
--- a/src/OpenSearch/Serializers/SmartSerializer.php
+++ b/src/OpenSearch/Serializers/SmartSerializer.php
@@ -88,7 +88,7 @@ class SmartSerializer implements SerializerInterface
     private function isJson(array $headers): bool
     {
         // Legacy support for 'transfer_stats'.
-        if (array_key_exists('content_type', $headers)) {
+        if (!empty($headers['content_type'])) {
             return str_contains($headers['content_type'], 'json');
         }
 


### PR DESCRIPTION
### Description
Fixes an error introduced in #320 when content_type comes back as NULL.

```
TypeError: str_contains(): Argument #1 ($haystack) must be of type string, null given in /vendor/opensearch-project/opensearch-php/src/OpenSearch/Serializers/SmartSerializer.php:92
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
