### PR TITLE
fix: double encoding of index name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
-- Fixed double encoding of index ([#348](https://github.com/opensearch-project/opensearch-php/pull/348))
 ### Security
 ### Updated APIs
+
+## [2.4.5]
+### Fixed
+- Fixed double encoding of index ([#348](https://github.com/opensearch-project/opensearch-php/pull/348))
 
 ## [2.4.4]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed double encoding of index ([#348](https://github.com/opensearch-project/opensearch-php/pull/348))
 ### Security
 ### Updated APIs
 

--- a/src/OpenSearch/Client.php
+++ b/src/OpenSearch/Client.php
@@ -114,7 +114,7 @@ use OpenSearch\Endpoints\UpdateByQueryRethrottle;
  */
 class Client
 {
-    public const VERSION = '2.4.4';
+    public const VERSION = '2.4.5';
 
     /**
      * @var Transport

--- a/src/OpenSearch/Endpoints/AbstractEndpoint.php
+++ b/src/OpenSearch/Endpoints/AbstractEndpoint.php
@@ -129,7 +129,7 @@ abstract class AbstractEndpoint implements EndpointInterface
             $index = implode(",", $index);
         }
 
-        $this->index = urlencode($index);
+        $this->index = $index;
 
         return $this;
     }

--- a/tests/Endpoints/CreateTest.php
+++ b/tests/Endpoints/CreateTest.php
@@ -39,6 +39,17 @@ class CreateTest extends TestCase
         $this->instance = new Create();
     }
 
+    public function testEncodingOfIndex(): void
+    {
+        $this->instance->setIndex(index: '*');
+        $this->instance->setId(10);
+
+        $result = $this->instance->getURI();
+
+        // Assert
+        $this->assertEquals('/%2A/_create/10', $result);
+    }
+
     public function testGetURIWhenIndexAndIdAreDefined(): void
     {
         // Arrange


### PR DESCRIPTION
### Description
Removes the double encoding introduced in last release

### Issues Resolved
Fixes https://github.com/opensearch-project/opensearch-php/issues/348 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
