### PR TITLE
Fix(SearchResponseIterator): Move scroll_id to body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed scrolling triggers deprecation error ([#163](https://github.com/opensearch-project/opensearch-php/issues/163), [#356](https://github.com/opensearch-project/opensearch-php/pull/356))
 ### Security
 ### Updated APIs
 
@@ -135,7 +136,10 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed basic authentication being overridden by connection params in `ClientBuilder` ([#160](https://github.com/opensearch-project/opensearch-php/pull/160))
 - Fixed PHP warning in `Connection::tryDeserializeError()` for some error responses ([#167](https://github.com/opensearch-project/opensearch-php/issues/167))
 
-[Unreleased]: https://github.com/opensearch-project/opensearch-php/compare/2.4.2...main
+[Unreleased]: https://github.com/opensearch-project/opensearch-php/compare/2.4.5...main
+[2.4.5]: https://github.com/opensearch-project/opensearch-php/compare/2.4.4...2.4.5
+[2.4.4]: https://github.com/opensearch-project/opensearch-php/compare/2.4.3...2.4.4
+[2.4.3]: https://github.com/opensearch-project/opensearch-php/compare/2.4.2...2.4.3
 [2.4.2]: https://github.com/opensearch-project/opensearch-php/compare/2.4.1...2.4.2
 [2.4.1]: https://github.com/opensearch-project/opensearch-php/compare/2.4.0...2.4.1
 [2.4.0]: https://github.com/opensearch-project/opensearch-php/compare/2.3.0...2.4.0

--- a/src/OpenSearch/Helper/Iterators/SearchResponseIterator.php
+++ b/src/OpenSearch/Helper/Iterators/SearchResponseIterator.php
@@ -143,8 +143,10 @@ class SearchResponseIterator implements Iterator
     {
         $this->current_scrolled_response = $this->client->scroll(
             [
-            'scroll_id' => $this->scroll_id,
-            'scroll'    => $this->scroll_ttl
+                'scroll' => $this->scroll_ttl,
+                'body'   => [
+                    'scroll_id' => $this->scroll_id,
+                ],
             ]
         );
         $this->scroll_id = $this->current_scrolled_response['_scroll_id'];

--- a/tests/Helper/Iterators/SearchResponseIteratorTest.php
+++ b/tests/Helper/Iterators/SearchResponseIteratorTest.php
@@ -21,10 +21,11 @@ declare(strict_types=1);
 
 namespace OpenSearch\Tests\Helper\Iterators;
 
+use Mockery as m;
 use OpenSearch\Client;
 use OpenSearch\Helper\Iterators\SearchResponseIterator;
-use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 /**
  * Class SearchResponseIteratorTest
@@ -41,12 +42,12 @@ class SearchResponseIteratorTest extends TestCase
     public function testWithNoResults()
     {
         $search_params = [
-            'scroll'      => '5m',
-            'index'       => 'twitter',
-            'size'        => 1000,
-            'body'        => [
+            'scroll' => '5m',
+            'index' => 'twitter',
+            'size' => 1000,
+            'body' => [
                 'query' => [
-                    'match_all' => new \stdClass()
+                    'match_all' => new stdClass()
                 ]
             ]
         ];
@@ -70,12 +71,12 @@ class SearchResponseIteratorTest extends TestCase
     public function testWithHits()
     {
         $search_params = [
-            'scroll'      => '5m',
-            'index'       => 'twitter',
-            'size'        => 1000,
-            'body'        => [
+            'scroll' => '5m',
+            'index' => 'twitter',
+            'size' => 1000,
+            'body' => [
                 'query' => [
-                    'match_all' => new \stdClass()
+                    'match_all' => new stdClass()
                 ]
             ]
         ];
@@ -88,14 +89,14 @@ class SearchResponseIteratorTest extends TestCase
             ->with($search_params)
             ->andReturn(
                 [
-                '_scroll_id' => 'scroll_id_01',
-                'hits' => [
+                    '_scroll_id' => 'scroll_id_01',
                     'hits' => [
-                        [
-                            'foo' => 'bar'
+                        'hits' => [
+                            [
+                                'foo' => 'bar'
+                            ]
                         ]
                     ]
-                ]
                 ]
             );
 
@@ -104,8 +105,10 @@ class SearchResponseIteratorTest extends TestCase
             ->ordered()
             ->with(
                 [
-                    'scroll_id'  => 'scroll_id_01',
-                    'scroll' => '5m'
+                    'scroll' => '5m',
+                    'body' => [
+                        'scroll_id' => 'scroll_id_01',
+                    ]
                 ]
             )
             ->andReturn(
@@ -126,8 +129,10 @@ class SearchResponseIteratorTest extends TestCase
             ->ordered()
             ->with(
                 [
-                    'scroll_id'  => 'scroll_id_02',
-                    'scroll' => '5m'
+                    'scroll' => '5m',
+                    'body' => [
+                        'scroll_id' => 'scroll_id_02',
+                    ]
                 ]
             )
             ->andReturn(
@@ -148,8 +153,10 @@ class SearchResponseIteratorTest extends TestCase
             ->ordered()
             ->with(
                 [
-                    'scroll_id'  => 'scroll_id_03',
-                    'scroll' => '5m'
+                    'scroll' => '5m',
+                    'body' => [
+                        'scroll_id' => 'scroll_id_03',
+                    ]
                 ]
             )
             ->andReturn(
@@ -165,8 +172,10 @@ class SearchResponseIteratorTest extends TestCase
             ->never()
             ->with(
                 [
-                    'scroll_id'  => 'scroll_id_04',
-                    'scroll' => '5m'
+                    'scroll' => '5m',
+                    'body' => [
+                        'scroll_id' => 'scroll_id_04',
+                    ]
                 ]
             );
 


### PR DESCRIPTION
### Description

This change fixes a deprecation warning that occurs when using the `SearchResponseIterator`.

It updates the `scroll()` API call within the iterator to pass the `scroll_id` in the request body, as required by the modern API, instead of as a top-level parameter. This resolves the `E_USER_DEPRECATED` notice that was being triggered on each iteration.

Additionally, this PR corrects an outdated version link for the `[Unreleased]` section in the `CHANGELOG.md` file, making the changelog links accurate.

### Issues Resolved
Closes #163

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).