### PR TITLE
fix: lychee build

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,11 +1,8 @@
 name: Link Checker
 on:
   push:
-    branches:
-      - "*"
-  pull_request:
-    branches:
-      - "*"
+    branches: ["main"]
+  pull_request: ~
 
 jobs:
   linkchecker:
@@ -18,7 +15,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --accept=200,403,429  "**/*.html" "**/*.md" "**/*.txt" "**/*.json" --exclude "https://github.com/\[your*" --exclude "https://localhost:9200" --exclude '^mailto:'
+          args: "--verbose --no-progress './**/*.md' './**/*.html' './**/*.txt'"
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Fail if there were link errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [2.4.5]
 ### Fixed
-- Fixed double encoding of index ([#348](https://github.com/opensearch-project/opensearch-php/pull/348))
+- Fixed double encoding of index ([#348](https://github.com/opensearch-project/opensearch-php/issues/348))
 
 ## [2.4.4]
 ### Added

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -12,4 +12,4 @@ The below matrix shows the compatibility of the [`opensearch-project/opensearch-
 
 ## Upgrading
 
-Major versions of OpenSearch introduce breaking changes that require careful upgrades of the client. While `opensearch-project/opensearch-php` 2.0.0 works against the latest OpenSearch 1.x, certain deprecated features removed in OpenSearch 2.0 have also been removed from the client. Please refer to the [OpenSearch documentation](https://opensearch.org/docs/latest/clients/index/) for more information.
+Major versions of OpenSearch introduce breaking changes that require careful upgrades of the client. While `opensearch-project/opensearch-php` 2.0.0 works against the latest OpenSearch 1.x, certain deprecated features removed in OpenSearch 2.0 have also been removed from the client. Please refer to the [OpenSearch documentation](https://docs.opensearch.org/latest/clients/index/) for more information.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ OpenSearch is an open source product released under the Apache 2.0 license (see 
 
 We respect intellectual property rights of others and we want to make sure all incoming contributions are correctly attributed and licensed. A Developer Certificate of Origin (DCO) is a lightweight mechanism to do that.
 
-The DCO is a declaration attached to every contribution made by every developer. In the commit message of the contribution, the developer simply adds a `Signed-off-by` statement and thereby agrees to the DCO, which you can find below or at [DeveloperCertificate.org](http://developercertificate.org/).
+The DCO is a declaration attached to every contribution made by every developer. In the commit message of the contribution, the developer simply adds a `Signed-off-by` statement and thereby agrees to the DCO, which you can find below or at [DeveloperCertificate.org](https://developercertificate.org/).
 
 ```
 Developer's Certificate of Origin 1.1

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -21,7 +21,7 @@ e.g. `git clone https://github.com/[your username]/opensearch-php.git`.
 
 #### PHP 7.3 or higher
 
-OpenSearch PHP Client builds using [PHP](https://php.net) 7.3 at a minimum.
+OpenSearch PHP Client builds using [PHP](https://www.php.net) 7.3 at a minimum.
 
 ### Unit Testing
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 * [User Guide](USER_GUIDE.md)
 * [Samples](samples)
 * [Developer Guide](DEVELOPER_GUIDE.md)
-* [Downloads](https://opensearch.org/downloads.html).
-* [Documentation](https://opensearch.org/docs/latest/)
-* Need help? Try [Forums](https://discuss.opendistrocommunity.dev/)
+* [Downloads](https://opensearch.org/downloads/).
+* [Documentation](https://docs.opensearch.org/latest/)
+* Need help? Try [Forums](https://forum.opensearch.org/)
 * [Project Principles](https://opensearch.org/#principles)
 * [Contributing to OpenSearch](CONTRIBUTING.md)
 * [Maintainer Responsibilities](MAINTAINERS.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,3 @@
 ## Reporting a Vulnerability
 
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/) or directly via email to aws-security@amazon.com. Please do **not** create a public GitHub issue.
+If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](https://aws.amazon.com/security/vulnerability-reporting/) or directly via email to aws-security@amazon.com. Please do **not** create a public GitHub issue.

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,6 @@
+exclude_path = ["vendor"]
+accept = ["200","403","429"]
+exclude = [
+    "https://localhost:9200",
+    "^mailto:",
+]


### PR DESCRIPTION
In #358  we updated lychee, but unfortunately the GitHub workflow wasn't getting triggered so we didn't see the link checker build failures.

This PR updates the config, moving it to `lychee.toml` and fixing the redirects that came up in the link checker report.

We removed checks for `*.json` as the only file checked was `composer.json` which is unnecessary. 
