### PR TITLE
Move health check to shared action

### DIFF
--- a/.github/actions/health-check/action.yml
+++ b/.github/actions/health-check/action.yml
@@ -1,0 +1,14 @@
+name: Wait for cluster to be healthy
+description: 'Waits until the OpenSearch cluster health is green'
+
+runs:
+  using: composite
+  steps:
+    - name: Wait for cluster to be healthy
+      shell: bash
+      run: |
+        for i in {1..10}; do
+          curl -s --fail "http://localhost:9200/_cluster/health?wait_for_status=green&timeout=5s" >/dev/null && { echo "✅ Cluster is green!"; exit 0; }
+          echo "Retry $i/10..."; sleep 5
+        done
+        echo "❌ Cluster did not become green"; exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,12 +65,6 @@ jobs:
           discovery.type: single-node
           plugins.security.disabled: true
           OPENSEARCH_INITIAL_ADMIN_PASSWORD: myStrongPassword123!
-        options: >-
-          --health-cmd="curl -s -f http://localhost:9200/_cluster/health?wait_for_status=green&timeout=5s || exit 1"
-          --health-start-period=10s
-          --health-interval=5s
-          --health-retries=10
-          --health-timeout=5s
 
     steps:
       - name: Checkout
@@ -87,6 +81,9 @@ jobs:
       - name: Install dependencies
         run: |
           composer install --prefer-dist
+
+      - name: Wait for cluster to be healthy
+        uses: ./.github/actions/health-check
 
       - name: PHPUnit
         run: |
@@ -194,12 +191,6 @@ jobs:
           discovery.type: single-node
           plugins.security.disabled: true
           OPENSEARCH_INITIAL_ADMIN_PASSWORD: myStrongPassword123!
-        options: >-
-          --health-cmd="curl -s -f http://localhost:9200/_cluster/health?wait_for_status=green&timeout=5s || exit 1"
-          --health-start-period=10s
-          --health-interval=5s
-          --health-retries=10
-          --health-timeout=5s
 
     steps:
     - name: Checkout
@@ -218,12 +209,7 @@ jobs:
         composer install --prefer-dist
 
     - name: Wait for cluster to be healthy
-      run: |
-        for i in {1..10}; do
-          curl -s --fail "http://localhost:9200/_cluster/health?wait_for_status=green&timeout=5s" >/dev/null && { echo "✅ Cluster is green!"; exit 0; }
-          echo "Retry $i/10..."; sleep 5
-        done
-        echo "❌ Cluster did not become green"; exit 1
+      uses: ./.github/actions/health-check
 
     - name: Integration tests
       run: |

--- a/.github/workflows/test_unreleased.yml
+++ b/.github/workflows/test_unreleased.yml
@@ -91,12 +91,7 @@ jobs:
           ./opensearch-*/bin/opensearch -d
 
       - name: Wait for cluster to be healthy
-        run: |
-          for i in {1..10}; do
-            curl -s --fail "http://localhost:9200/_cluster/health?wait_for_status=green&timeout=5s" >/dev/null && { echo "✅ Cluster is green!"; exit 0; }
-            echo "Retry $i/10..."; sleep 5
-          done
-          echo "❌ Cluster did not become green"; exit 1
+        uses: ./.github/actions/health-check
 
       - name: Integration tests
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 ### Changed
+- Moved duplicate health check workflow step to a shared action  ([#366](https://github.com/opensearch-project/opensearch-php/pull/366))
 ### Deprecated
 ### Removed
 ### Fixed


### PR DESCRIPTION
### Description

Removes duplicate code for checking cluster health before tests are run.

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
