### PR TITLE
ConnectionPool: clarify NoNodesAvailableException message to indicate possible storage issue

### DIFF
--- a/src/OpenSearch/ConnectionPool/SniffingConnectionPool.php
+++ b/src/OpenSearch/ConnectionPool/SniffingConnectionPool.php
@@ -80,7 +80,7 @@ class SniffingConnectionPool extends AbstractConnectionPool
         }
 
         if ($force === true) {
-            throw new NoNodesAvailableException("No alive nodes found in your cluster [possible storage issue]");
+            throw new NoNodesAvailableException("None of the configured OpenSearch nodes are healthy or could not be reached. Check the configured URLs");
         }
 
         return $this->nextConnection(true);

--- a/src/OpenSearch/ConnectionPool/StaticConnectionPool.php
+++ b/src/OpenSearch/ConnectionPool/StaticConnectionPool.php
@@ -87,7 +87,7 @@ class StaticConnectionPool extends AbstractConnectionPool implements ConnectionP
             }
         }
 
-        throw new NoNodesAvailableException("No alive nodes found in your cluster [possible storage issue]");
+        throw new NoNodesAvailableException("None of the configured OpenSearch nodes are healthy or could not be reached. Check the configured URLs");
     }
 
     public function scheduleCheck(): void

--- a/src/OpenSearch/ConnectionPool/StaticNoPingConnectionPool.php
+++ b/src/OpenSearch/ConnectionPool/StaticNoPingConnectionPool.php
@@ -73,7 +73,7 @@ class StaticNoPingConnectionPool extends AbstractConnectionPool implements Conne
             }
         }
 
-        throw new NoNodesAvailableException("No alive nodes found in your cluster [possible storage issue]");
+        throw new NoNodesAvailableException("None of the configured OpenSearch nodes are healthy or could not be reached. Check the configured URLs");
     }
 
     public function scheduleCheck(): void


### PR DESCRIPTION
Change the NoNodesAvailableException message to include a short note
indicating a possible storage issue.

This is purely a logging text-change (no behaviour changes). The new
message helps on-call/ops check disk usage and watermarks earlier when
they see the "No alive nodes" exception.

Files changed:
- src/OpenSearch/ConnectionPool/StaticNoPingConnectionPool.php
- src/OpenSearch/ConnectionPool/StaticConnectionPool.php
- src/OpenSearch/ConnectionPool/SniffingConnectionPool.php
