### PR TITLE
feat: Add param array shapes (2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Added
+- Update docblocks to define array shapes ([#398](https://github.com/opensearch-project/opensearch-php/pull/398))
 ### Changed
 - Replace php scripts with Symfony commands ([#394](https://github.com/opensearch-project/opensearch-php/pull/394))
 - Update minimum PHP version to 8.2 and add PHP 8.5 testing ([#394](https://github.com/opensearch-project/opensearch-php/pull/394))
@@ -13,6 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - fix: error thrown trying to parse type for param docs ([#395](https://github.com/opensearch-project/opensearch-php/pull/395))
 ### Security
 ### Updated APIs
+- Updated opensearch-php APIs to reflect [opensearch-api-specification@8d5d6d5](https://github.com/opensearch-project/opensearch-api-specification/commit/8d5d6d56b898158961648781fa4a16c97eca157d)
 - Updated opensearch-php APIs to reflect [opensearch-api-specification@cbb07cd](https://github.com/opensearch-project/opensearch-api-specification/commit/cbb07cd7856ade16a50b1f1004c50ec2b33e5943)
 
 ## [2.5.1]

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -65,6 +65,37 @@ parameters:
 			path: src/OpenSearch/Namespaces/SecurityNamespace.php
 
 		-
+			message: "#^Parameter \\#1 \\$params of method OpenSearch\\\\Client\\:\\:delete\\(\\) expects array\\{id\\?\\: string, index\\?\\: string, if_primary_term\\?\\: int, if_seq_no\\?\\: int, refresh\\?\\: mixed, routing\\?\\: mixed, timeout\\?\\: string, version\\?\\: int, \\.\\.\\.\\}, array\\{index\\: array\\{'', '', ''\\}, id\\: 'test'\\} given\\.$#"
+			count: 1
+			path: tests/ClientIntegrationTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$params of method OpenSearch\\\\Client\\:\\:delete\\(\\) expects array\\{id\\?\\: string, index\\?\\: string, if_primary_term\\?\\: int, if_seq_no\\?\\: int, refresh\\?\\: mixed, routing\\?\\: mixed, timeout\\?\\: string, version\\?\\: int, \\.\\.\\.\\}, array\\{index\\: array\\{null, null, null\\}, id\\: 'test'\\} given\\.$#"
+			count: 1
+			path: tests/ClientIntegrationTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$params of method OpenSearch\\\\Client\\:\\:delete\\(\\) expects array\\{id\\?\\: string, index\\?\\: string, if_primary_term\\?\\: int, if_seq_no\\?\\: int, refresh\\?\\: mixed, routing\\?\\: mixed, timeout\\?\\: string, version\\?\\: int, \\.\\.\\.\\}, array\\{index\\: 'test', id\\: null\\} given\\.$#"
+			count: 1
+			path: tests/ClientTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$params of method OpenSearch\\\\Client\\:\\:delete\\(\\) expects array\\{id\\?\\: string, index\\?\\: string, if_primary_term\\?\\: int, if_seq_no\\?\\: int, refresh\\?\\: mixed, routing\\?\\: mixed, timeout\\?\\: string, version\\?\\: int, \\.\\.\\.\\}, array\\{index\\: null, id\\: 'test'\\} given\\.$#"
+			count: 1
+			path: tests/ClientTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$params of method OpenSearch\\\\Client\\:\\:delete\\(\\) expects array\\{id\\?\\: string, index\\?\\: string, if_primary_term\\?\\: int, if_seq_no\\?\\: int, refresh\\?\\: mixed, routing\\?\\: mixed, timeout\\?\\: string, version\\?\\: int, \\.\\.\\.\\}, array\\{index\\: array\\{'', '', ''\\}, id\\: 'test'\\} given\\.$#"
+			count: 1
+			path: tests/LegacyClientIntegrationTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$params of method OpenSearch\\\\Client\\:\\:delete\\(\\) expects array\\{id\\?\\: string, index\\?\\: string, if_primary_term\\?\\: int, if_seq_no\\?\\: int, refresh\\?\\: mixed, routing\\?\\: mixed, timeout\\?\\: string, version\\?\\: int, \\.\\.\\.\\}, array\\{index\\: array\\{null, null, null\\}, id\\: 'test'\\} given\\.$#"
+			count: 1
+			path: tests/LegacyClientIntegrationTest.php
+
+		-
 			message: "#^Call to an undefined method OpenSearch\\\\Client\\:\\:slm\\(\\)\\.$#"
 			count: 2
 			path: tests/Utility.php
+

--- a/src/OpenSearch/Client.php
+++ b/src/OpenSearch/Client.php
@@ -449,24 +449,23 @@ class Client
     /**
      * Allows to perform multiple index/update/delete operations in a single request.
      *
-     * $params['index']                  = (string) Name of the data stream, index, or index alias to perform bulk actions on.
-     * $params['_source']                = (any) `true` or `false` to return the `_source` field or not, or a list of fields to return.
-     * $params['_source_excludes']       = (any) A comma-separated list of source fields to exclude from the response.
-     * $params['_source_includes']       = (any) A comma-separated list of source fields to include in the response.
-     * $params['pipeline']               = (string) ID of the pipeline to use to preprocess incoming documents. If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request. If a final pipeline is configured it will always run, regardless of the value of this parameter.
-     * $params['refresh']                = (any) If `true`, OpenSearch refreshes the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` do nothing with refreshes. Valid values: `true`, `false`, `wait_for`.
-     * $params['require_alias']          = (boolean) If `true`, the request's actions must target an index alias. (Default = false)
-     * $params['routing']                = (string) A custom value used to route operations to a specific shard.
-     * $params['timeout']                = (string) Period each action waits for the following operations: automatic index creation, dynamic mapping updates, waiting for active shards.
-     * $params['wait_for_active_shards'] = (any) The number of shard copies that must be active before proceeding with the operation. Set to all or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
-     * $params['pretty']                 = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                  = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']            = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                 = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']            = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                   = (array) The operation definition and data (action-data pairs), separated by newlines (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, _source?: mixed, _source_excludes?: mixed, _source_includes?: mixed, pipeline?: string, refresh?: mixed, require_alias?: bool, routing?: string, timeout?: string, wait_for_active_shards?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: Name of the data stream, index, or index alias to perform bulk actions on.
+     * - _source: `true` or `false` to return the `_source` field or not, or a list of fields to return.
+     * - _source_excludes: A comma-separated list of source fields to exclude from the response.
+     * - _source_includes: A comma-separated list of source fields to include in the response.
+     * - pipeline: ID of the pipeline to use to preprocess incoming documents. If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request. If a final pipeline is configured it will always run, regardless of the value of this parameter.
+     * - refresh: If `true`, OpenSearch refreshes the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` do nothing with refreshes. Valid values: `true`, `false`, `wait_for`.
+     * - require_alias: If `true`, the request's actions must target an index alias. (Default: false)
+     * - routing: A custom value used to route operations to a specific shard.
+     * - timeout: Period each action waits for the following operations: automatic index creation, dynamic mapping updates, waiting for active shards.
+     * - wait_for_active_shards: The number of shard copies that must be active before proceeding with the operation. Set to all or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The operation definition and data (action-data pairs), separated by newlines (Required)
      * @return array
      */
     public function bulk(array $params = [])
@@ -485,26 +484,25 @@ class Client
     /**
      * Allows to perform multiple index/update/delete operations using request response streaming.
      *
-     * $params['index']                  = (string) Name of the data stream, index, or index alias to perform bulk actions on.
-     * $params['_source']                = (any) `true` or `false` to return the `_source` field or not, or a list of fields to return.
-     * $params['_source_excludes']       = (any) A comma-separated list of source fields to exclude from the response.
-     * $params['_source_includes']       = (any) A comma-separated list of source fields to include in the response.
-     * $params['batch_interval']         = (string) Specifies for how long bulk operations should be accumulated into a batch before sending the batch to data nodes.
-     * $params['batch_size']             = (integer) Specifies how many bulk operations should be accumulated into a batch before sending the batch to data nodes.
-     * $params['pipeline']               = (string) ID of the pipeline to use to preprocess incoming documents. If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request. If a final pipeline is configured it will always run, regardless of the value of this parameter.
-     * $params['refresh']                = (any) If `true`, OpenSearch refreshes the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` do nothing with refreshes. Valid values: `true`, `false`, `wait_for`.
-     * $params['require_alias']          = (boolean) If `true`, the request's actions must target an index alias. (Default = false)
-     * $params['routing']                = (any) A custom value used to route operations to a specific shard.
-     * $params['timeout']                = (string) Period each action waits for the following operations: automatic index creation, dynamic mapping updates, waiting for active shards.
-     * $params['wait_for_active_shards'] = (any) The number of shard copies that must be active before proceeding with the operation. Set to all or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
-     * $params['pretty']                 = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                  = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']            = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                 = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']            = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                   = (array) The operation definition and data (action-data pairs), separated by newlines (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, _source?: mixed, _source_excludes?: mixed, _source_includes?: mixed, batch_interval?: string, batch_size?: int, pipeline?: string, refresh?: mixed, require_alias?: bool, routing?: mixed, timeout?: string, wait_for_active_shards?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: Name of the data stream, index, or index alias to perform bulk actions on.
+     * - _source: `true` or `false` to return the `_source` field or not, or a list of fields to return.
+     * - _source_excludes: A comma-separated list of source fields to exclude from the response.
+     * - _source_includes: A comma-separated list of source fields to include in the response.
+     * - batch_interval: Specifies for how long bulk operations should be accumulated into a batch before sending the batch to data nodes.
+     * - batch_size: Specifies how many bulk operations should be accumulated into a batch before sending the batch to data nodes.
+     * - pipeline: ID of the pipeline to use to preprocess incoming documents. If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request. If a final pipeline is configured it will always run, regardless of the value of this parameter.
+     * - refresh: If `true`, OpenSearch refreshes the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` do nothing with refreshes. Valid values: `true`, `false`, `wait_for`.
+     * - require_alias: If `true`, the request's actions must target an index alias. (Default: false)
+     * - routing: A custom value used to route operations to a specific shard.
+     * - timeout: Period each action waits for the following operations: automatic index creation, dynamic mapping updates, waiting for active shards.
+     * - wait_for_active_shards: The number of shard copies that must be active before proceeding with the operation. Set to all or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The operation definition and data (action-data pairs), separated by newlines (Required)
      * @return array
      */
     public function bulkStream(array $params = [])
@@ -523,15 +521,14 @@ class Client
     /**
      * Explicitly clears the search context for a scroll.
      *
-     * $params['scroll_id']   = DEPRECATED (array) A comma-separated list of scroll IDs to clear. To clear all scroll IDs, use `_all`.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']        = (array) A comma-separated list of scroll IDs to clear if none was specified using the `scroll_id` parameter
-     *
-     * @param array $params Associative array of parameters
+     * @param array{scroll_id?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - scroll_id: A comma-separated list of scroll IDs to clear. To clear all scroll IDs, use `_all`.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: A comma-separated list of scroll IDs to clear if none was specified using the `scroll_id` parameter
      * @return array
      */
     public function clearScroll(array $params = [])
@@ -550,29 +547,28 @@ class Client
     /**
      * Returns number of documents matching a query.
      *
-     * $params['index']              = (array) A comma-separated list of data streams, indexes, and aliases to search. Supports wildcards (`*`). To search all data streams and indexes, omit this parameter or use `*` or `_all`.
-     * $params['allow_no_indices']   = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
-     * $params['analyze_wildcard']   = (boolean) If `true`, wildcard and prefix queries are analyzed. This parameter can only be used when the `q` query string parameter is specified. (Default = false)
-     * $params['analyzer']           = (string) Analyzer to use for the query string. This parameter can only be used when the `q` query string parameter is specified.
-     * $params['default_operator']   = (enum) The default operator for query string query: `AND` or `OR`. This parameter can only be used when the `q` query string parameter is specified. (Options = and,AND,or,OR)
-     * $params['df']                 = (string) Field to use as default where no field prefix is given in the query string. This parameter can only be used when the `q` query string parameter is specified.
-     * $params['expand_wildcards']   = (any)
-     * $params['ignore_throttled']   = (boolean) If `true`, concrete, expanded or aliased indexes are ignored when frozen.
-     * $params['ignore_unavailable'] = (boolean) If `false`, the request returns an error if it targets a missing or closed index.
-     * $params['lenient']            = (boolean) If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
-     * $params['min_score']          = (number) Sets the minimum `_score` value that documents must have to be included in the result.
-     * $params['preference']         = (string) Specifies the node or shard the operation should be performed on. Random by default. (Default = random)
-     * $params['q']                  = (string) Query in the Lucene query string syntax.
-     * $params['routing']            = (any) A custom value used to route operations to a specific shard.
-     * $params['terminate_after']    = (integer) Maximum number of documents to collect for each shard. If a query reaches this limit, OpenSearch terminates the query early. OpenSearch collects documents before sorting.
-     * $params['pretty']             = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']              = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']        = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']             = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']        = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']               = (array) Query to restrict the results specified with the Query DSL (optional)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_no_indices?: bool, analyze_wildcard?: bool, analyzer?: string, default_operator?: mixed, df?: string, expand_wildcards?: mixed, ignore_throttled?: bool, ignore_unavailable?: bool, lenient?: bool, min_score?: int|float, preference?: string, q?: string, routing?: mixed, terminate_after?: int, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases to search. Supports wildcards (`*`). To search all data streams and indexes, omit this parameter or use `*` or `_all`.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
+     * - analyze_wildcard: If `true`, wildcard and prefix queries are analyzed. This parameter can only be used when the `q` query string parameter is specified. (Default: false)
+     * - analyzer: Analyzer to use for the query string. This parameter can only be used when the `q` query string parameter is specified.
+     * - default_operator: The default operator for query string query: `AND` or `OR`. This parameter can only be used when the `q` query string parameter is specified. (Options: and, AND, or, OR)
+     * - df: Field to use as default where no field prefix is given in the query string. This parameter can only be used when the `q` query string parameter is specified.
+     * - expand_wildcards:
+     * - ignore_throttled: If `true`, concrete, expanded or aliased indexes are ignored when frozen.
+     * - ignore_unavailable: If `false`, the request returns an error if it targets a missing or closed index.
+     * - lenient: If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
+     * - min_score: Sets the minimum `_score` value that documents must have to be included in the result.
+     * - preference: Specifies the node or shard the operation should be performed on. Random by default. (Default: random)
+     * - q: Query in the Lucene query string syntax.
+     * - routing: A custom value used to route operations to a specific shard.
+     * - terminate_after: Maximum number of documents to collect for each shard. If a query reaches this limit, OpenSearch terminates the query early. OpenSearch collects documents before sorting.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: Query to restrict the results specified with the Query DSL (optional)
      * @return array
      */
     public function count(array $params = [])
@@ -591,19 +587,18 @@ class Client
     /**
      * Creates point in time context.
      *
-     * $params['index']                      = (array) A comma-separated list of indexes; use `_all` or empty string to perform the operation on all indexes. (Required)
-     * $params['allow_partial_pit_creation'] = (boolean) Allow if point in time can be created with partial failures.
-     * $params['expand_wildcards']           = (any) Whether to expand wildcard expression to concrete indexes that are open, closed or both.
-     * $params['keep_alive']                 = (string) Specify the keep alive for point in time.
-     * $params['preference']                 = (string) Specify the node or shard the operation should be performed on. (Default = random)
-     * $params['routing']                    = (any) A comma-separated list of specific routing values.
-     * $params['pretty']                     = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                      = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']                = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                     = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']                = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_partial_pit_creation?: bool, expand_wildcards?: mixed, keep_alive?: string, preference?: string, routing?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of indexes; use `_all` or empty string to perform the operation on all indexes.
+     * - allow_partial_pit_creation: Allow if point in time can be created with partial failures.
+     * - expand_wildcards: Whether to expand wildcard expression to concrete indexes that are open, closed or both.
+     * - keep_alive: Specify the keep alive for point in time.
+     * - preference: Specify the node or shard the operation should be performed on. (Default: random)
+     * - routing: A comma-separated list of specific routing values.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function createPit(array $params = [])
@@ -620,23 +615,22 @@ class Client
     /**
      * Removes a document from the index.
      *
-     * $params['id']                     = (string) The unique identifier for the document. (Required)
-     * $params['index']                  = (string) Name of the target index. (Required)
-     * $params['if_primary_term']        = (integer) Only perform the operation if the document has this primary term.
-     * $params['if_seq_no']              = (integer) Only perform the operation if the document has this sequence number.
-     * $params['refresh']                = (any) If `true`, OpenSearch refreshes the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` do nothing with refreshes. Valid values: `true`, `false`, `wait_for`.
-     * $params['routing']                = (any) A custom value used to route operations to a specific shard.
-     * $params['timeout']                = (string) Period to wait for active shards.
-     * $params['version']                = (integer) Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
-     * $params['version_type']           = (any) The specific version type: `external`, `external_gte`.
-     * $params['wait_for_active_shards'] = (any) The number of shard copies that must be active before proceeding with the operation. Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
-     * $params['pretty']                 = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                  = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']            = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                 = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']            = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, index?: string, if_primary_term?: int, if_seq_no?: int, refresh?: mixed, routing?: mixed, timeout?: string, version?: int, version_type?: mixed, wait_for_active_shards?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: The unique identifier for the document. (Required)
+     * - index: Name of the target index.
+     * - if_primary_term: Only perform the operation if the document has this primary term.
+     * - if_seq_no: Only perform the operation if the document has this sequence number.
+     * - refresh: If `true`, OpenSearch refreshes the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` do nothing with refreshes. Valid values: `true`, `false`, `wait_for`.
+     * - routing: A custom value used to route operations to a specific shard.
+     * - timeout: Period to wait for active shards.
+     * - version: Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
+     * - version_type: The specific version type: `external`, `external_gte`.
+     * - wait_for_active_shards: The number of shard copies that must be active before proceeding with the operation. Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function delete(array $params = [])
@@ -655,13 +649,12 @@ class Client
     /**
      * Deletes all active point in time searches.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteAllPits(array $params = [])
@@ -675,48 +668,47 @@ class Client
     /**
      * Deletes documents matching the provided query.
      *
-     * $params['index']                  = (array) A comma-separated list of data streams, indexes, and aliases to search. Supports wildcards (`*`). To search all data streams or indexes, omit this parameter or use `*` or `_all`. (Required)
-     * $params['_source']                = (any) Set to `true` or `false` to return the `_source` field or not, or a list of fields to return.
-     * $params['_source_excludes']       = (array) List of fields to exclude from the returned `_source` field.
-     * $params['_source_includes']       = (array) List of fields to extract and return from the `_source` field.
-     * $params['allow_no_indices']       = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
-     * $params['analyze_wildcard']       = (boolean) If `true`, wildcard and prefix queries are analyzed. (Default = false)
-     * $params['analyzer']               = (string) Analyzer to use for the query string.
-     * $params['conflicts']              = (any) What to do if delete by query hits version conflicts: `abort` or `proceed`.
-     * $params['default_operator']       = (enum) The default operator for query string query: `AND` or `OR`. (Options = and,AND,or,OR)
-     * $params['df']                     = (string) Field to use as default where no field prefix is given in the query string.
-     * $params['expand_wildcards']       = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
-     * $params['from']                   = (integer) Starting offset. (Default = 0)
-     * $params['ignore_unavailable']     = (boolean) If `false`, the request returns an error if it targets a missing or closed index.
-     * $params['lenient']                = (boolean) If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
-     * $params['max_docs']               = (integer) Maximum number of documents to process. Defaults to all documents.
-     * $params['preference']             = (string) Specifies the node or shard the operation should be performed on. Random by default. (Default = random)
-     * $params['q']                      = (string) Query in the Lucene query string syntax.
-     * $params['refresh']                = (any) If `true`, OpenSearch refreshes all shards involved in the delete by query after the request completes.
-     * $params['request_cache']          = (boolean) If `true`, the request cache is used for this request. Defaults to the index-level setting.
-     * $params['requests_per_second']    = (number) The throttle for this request in sub-requests per second. (Default = 0)
-     * $params['routing']                = (any) A custom value used to route operations to a specific shard.
-     * $params['scroll']                 = (string) Period to retain the search context for scrolling.
-     * $params['scroll_size']            = (integer) Size of the scroll request that powers the operation. (Default = 100)
-     * $params['search_timeout']         = (string) Explicit timeout for each search request. Defaults to no timeout.
-     * $params['search_type']            = (any) The type of the search operation. Available options: `query_then_fetch`, `dfs_query_then_fetch`.
-     * $params['size']                   = (integer) Deprecated, use `max_docs` instead.
-     * $params['slices']                 = (any) The number of slices this task should be divided into.
-     * $params['sort']                   = (array) A comma-separated list of <field>:<direction> pairs.
-     * $params['stats']                  = (array) Specific `tag` of the request for logging and statistical purposes.
-     * $params['terminate_after']        = (integer) Maximum number of documents to collect for each shard. If a query reaches this limit, OpenSearch terminates the query early. OpenSearch collects documents before sorting. Use with caution. OpenSearch applies this parameter to each shard handling the request. When possible, let OpenSearch perform early termination automatically. Avoid specifying this parameter for requests that target data streams with backing indexes across multiple data tiers.
-     * $params['timeout']                = (string) Period each deletion request waits for active shards.
-     * $params['version']                = (boolean) If `true`, returns the document version as part of a hit.
-     * $params['wait_for_active_shards'] = (any) The number of shard copies that must be active before proceeding with the operation. Set to all or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
-     * $params['wait_for_completion']    = (boolean) If `true`, the request blocks until the operation is complete. (Default = true)
-     * $params['pretty']                 = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                  = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']            = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                 = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']            = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                   = (array) The search definition using the Query DSL (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, _source?: mixed, _source_excludes?: mixed, _source_includes?: mixed, allow_no_indices?: bool, analyze_wildcard?: bool, analyzer?: string, conflicts?: mixed, default_operator?: mixed, df?: string, expand_wildcards?: mixed, from?: int, ignore_unavailable?: bool, lenient?: bool, max_docs?: int, preference?: string, q?: string, refresh?: mixed, request_cache?: bool, requests_per_second?: int|float, routing?: mixed, scroll?: string, scroll_size?: int, search_timeout?: string, search_type?: mixed, size?: int, slices?: mixed, sort?: mixed, stats?: mixed, terminate_after?: int, timeout?: string, version?: bool, wait_for_active_shards?: mixed, wait_for_completion?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases to search. Supports wildcards (`*`). To search all data streams or indexes, omit this parameter or use `*` or `_all`.
+     * - _source: Set to `true` or `false` to return the `_source` field or not, or a list of fields to return.
+     * - _source_excludes: List of fields to exclude from the returned `_source` field.
+     * - _source_includes: List of fields to extract and return from the `_source` field.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
+     * - analyze_wildcard: If `true`, wildcard and prefix queries are analyzed. (Default: false)
+     * - analyzer: Analyzer to use for the query string.
+     * - conflicts: What to do if delete by query hits version conflicts: `abort` or `proceed`.
+     * - default_operator: The default operator for query string query: `AND` or `OR`. (Options: and, AND, or, OR)
+     * - df: Field to use as default where no field prefix is given in the query string.
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * - from: Starting offset. (Default: 0)
+     * - ignore_unavailable: If `false`, the request returns an error if it targets a missing or closed index.
+     * - lenient: If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
+     * - max_docs: Maximum number of documents to process. Defaults to all documents.
+     * - preference: Specifies the node or shard the operation should be performed on. Random by default. (Default: random)
+     * - q: Query in the Lucene query string syntax.
+     * - refresh: If `true`, OpenSearch refreshes all shards involved in the delete by query after the request completes.
+     * - request_cache: If `true`, the request cache is used for this request. Defaults to the index-level setting.
+     * - requests_per_second: The throttle for this request in sub-requests per second. (Default: 0)
+     * - routing: A custom value used to route operations to a specific shard.
+     * - scroll: Period to retain the search context for scrolling.
+     * - scroll_size: Size of the scroll request that powers the operation. (Default: 100)
+     * - search_timeout: Explicit timeout for each search request. Defaults to no timeout.
+     * - search_type: The type of the search operation. Available options: `query_then_fetch`, `dfs_query_then_fetch`.
+     * - size: Deprecated, use `max_docs` instead.
+     * - slices: The number of slices this task should be divided into.
+     * - sort: A comma-separated list of <field>:<direction> pairs.
+     * - stats: Specific `tag` of the request for logging and statistical purposes.
+     * - terminate_after: Maximum number of documents to collect for each shard. If a query reaches this limit, OpenSearch terminates the query early. OpenSearch collects documents before sorting. Use with caution. OpenSearch applies this parameter to each shard handling the request. When possible, let OpenSearch perform early termination automatically. Avoid specifying this parameter for requests that target data streams with backing indexes across multiple data tiers.
+     * - timeout: Period each deletion request waits for active shards.
+     * - version: If `true`, returns the document version as part of a hit.
+     * - wait_for_active_shards: The number of shard copies that must be active before proceeding with the operation. Set to all or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+     * - wait_for_completion: If `true`, the request blocks until the operation is complete. (Default: true)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The search definition using the Query DSL (Required)
      * @return array
      */
     public function deleteByQuery(array $params = [])
@@ -735,15 +727,14 @@ class Client
     /**
      * Changes the number of requests per second for a particular Delete By Query operation.
      *
-     * $params['task_id']             = (string) The ID for the task. (Required)
-     * $params['requests_per_second'] = (number) The throttle for this request in sub-requests per second.
-     * $params['pretty']              = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']               = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']         = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']              = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']         = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{task_id?: string, requests_per_second?: int|float, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - task_id: The ID for the task.
+     * - requests_per_second: The throttle for this request in sub-requests per second.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteByQueryRethrottle(array $params = [])
@@ -760,14 +751,13 @@ class Client
     /**
      * Deletes one or more point in time searches based on the IDs passed.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']        = (array) The point-in-time ids to be deleted
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The point-in-time ids to be deleted
      * @return array
      */
     public function deletePit(array $params = [])
@@ -784,17 +774,16 @@ class Client
     /**
      * Deletes a script.
      *
-     * $params['id']                      = (string) Identifier for the stored script or search template. (Required)
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['timeout']                 = (string) Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, cluster_manager_timeout?: string, master_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: Identifier for the stored script or search template. (Required)
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - timeout: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteScript(array $params = [])
@@ -811,25 +800,24 @@ class Client
     /**
      * Returns information about whether a document exists in an index.
      *
-     * $params['id']               = (string) Identifier of the document. (Required)
-     * $params['index']            = (string) A comma-separated list of data streams, indexes, and aliases. Supports wildcards (`*`). (Required)
-     * $params['_source']          = (any) `true` or `false` to return the `_source` field or not, or a list of fields to return.
-     * $params['_source_excludes'] = (any) A comma-separated list of source fields to exclude in the response.
-     * $params['_source_includes'] = (any) A comma-separated list of source fields to include in the response.
-     * $params['preference']       = (string) Specifies the node or shard the operation should be performed on. Random by default. (Default = random)
-     * $params['realtime']         = (boolean) If `true`, the request is real time as opposed to near real time.
-     * $params['refresh']          = (any) If `true`, OpenSearch refreshes all shards involved in the delete by query after the request completes.
-     * $params['routing']          = (any) Target the specified primary shard.
-     * $params['stored_fields']    = (any) List of stored fields to return as part of a hit. If no fields are specified, no stored fields are included in the response. If this field is specified, the `_source` parameter defaults to false.
-     * $params['version']          = (integer) Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
-     * $params['version_type']     = (any) The specific version type: `external`, `external_gte`.
-     * $params['pretty']           = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']            = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']      = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']           = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']      = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, index?: string, _source?: mixed, _source_excludes?: mixed, _source_includes?: mixed, preference?: string, realtime?: bool, refresh?: mixed, routing?: mixed, stored_fields?: mixed, version?: int, version_type?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: Identifier of the document. (Required)
+     * - index: A comma-separated list of data streams, indexes, and aliases. Supports wildcards (`*`).
+     * - _source: `true` or `false` to return the `_source` field or not, or a list of fields to return.
+     * - _source_excludes: A comma-separated list of source fields to exclude in the response.
+     * - _source_includes: A comma-separated list of source fields to include in the response.
+     * - preference: Specifies the node or shard the operation should be performed on. Random by default. (Default: random)
+     * - realtime: If `true`, the request is real time as opposed to near real time.
+     * - refresh: If `true`, OpenSearch refreshes all shards involved in the delete by query after the request completes.
+     * - routing: Target the specified primary shard.
+     * - stored_fields: List of stored fields to return as part of a hit. If no fields are specified, no stored fields are included in the response. If this field is specified, the `_source` parameter defaults to false.
+     * - version: Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
+     * - version_type: The specific version type: `external`, `external_gte`.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return bool
      */
     public function exists(array $params = []): bool
@@ -852,24 +840,23 @@ class Client
     /**
      * Returns information about whether a document source exists in an index.
      *
-     * $params['id']               = (string) Identifier of the document. (Required)
-     * $params['index']            = (string) A comma-separated list of data streams, indexes, and aliases. Supports wildcards (`*`). (Required)
-     * $params['_source']          = (any) `true` or `false` to return the `_source` field or not, or a list of fields to return.
-     * $params['_source_excludes'] = (any) A comma-separated list of source fields to exclude in the response.
-     * $params['_source_includes'] = (any) A comma-separated list of source fields to include in the response.
-     * $params['preference']       = (string) Specifies the node or shard the operation should be performed on. Random by default. (Default = random)
-     * $params['realtime']         = (boolean) If `true`, the request is real time as opposed to near real time.
-     * $params['refresh']          = (any) If `true`, OpenSearch refreshes all shards involved in the delete by query after the request completes.
-     * $params['routing']          = (any) Target the specified primary shard.
-     * $params['version']          = (integer) Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
-     * $params['version_type']     = (any) The specific version type: `external`, `external_gte`.
-     * $params['pretty']           = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']            = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']      = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']           = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']      = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, index?: string, _source?: mixed, _source_excludes?: mixed, _source_includes?: mixed, preference?: string, realtime?: bool, refresh?: mixed, routing?: mixed, version?: int, version_type?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: Identifier of the document. (Required)
+     * - index: A comma-separated list of data streams, indexes, and aliases. Supports wildcards (`*`).
+     * - _source: `true` or `false` to return the `_source` field or not, or a list of fields to return.
+     * - _source_excludes: A comma-separated list of source fields to exclude in the response.
+     * - _source_includes: A comma-separated list of source fields to include in the response.
+     * - preference: Specifies the node or shard the operation should be performed on. Random by default. (Default: random)
+     * - realtime: If `true`, the request is real time as opposed to near real time.
+     * - refresh: If `true`, OpenSearch refreshes all shards involved in the delete by query after the request completes.
+     * - routing: Target the specified primary shard.
+     * - version: Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
+     * - version_type: The specific version type: `external`, `external_gte`.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return bool
      */
     public function existsSource(array $params = []): bool
@@ -892,28 +879,27 @@ class Client
     /**
      * Returns information about why a specific document matches (or doesn't match) a query.
      *
-     * $params['id']               = (string) Defines the document ID. (Required)
-     * $params['index']            = (string) Index names used to limit the request. Only a single index name can be provided to this parameter. (Required)
-     * $params['_source']          = (any) Set to `true` or `false` to return the `_source` field or not, or a list of fields to return.
-     * $params['_source_excludes'] = (any) A comma-separated list of source fields to exclude from the response.
-     * $params['_source_includes'] = (any) A comma-separated list of source fields to include in the response.
-     * $params['analyze_wildcard'] = (boolean) If `true`, wildcard and prefix queries are analyzed. (Default = false)
-     * $params['analyzer']         = (string) Analyzer to use for the query string. This parameter can only be used when the `q` query string parameter is specified.
-     * $params['default_operator'] = (enum) The default operator for query string query: `AND` or `OR`. (Options = and,AND,or,OR)
-     * $params['df']               = (string) Field to use as default where no field prefix is given in the query string. (Default = _all)
-     * $params['lenient']          = (boolean) If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
-     * $params['preference']       = (string) Specifies the node or shard the operation should be performed on. Random by default. (Default = random)
-     * $params['q']                = (string) Query in the Lucene query string syntax.
-     * $params['routing']          = (any) A custom value used to route operations to a specific shard.
-     * $params['stored_fields']    = (any) A comma-separated list of stored fields to return in the response.
-     * $params['pretty']           = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']            = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']      = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']           = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']      = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']             = (array) The query definition using the Query DSL
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, index?: string, _source?: mixed, _source_excludes?: mixed, _source_includes?: mixed, analyze_wildcard?: bool, analyzer?: string, default_operator?: mixed, df?: string, lenient?: bool, preference?: string, q?: string, routing?: mixed, stored_fields?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - id: Defines the document ID. (Required)
+     * - index: Index names used to limit the request. Only a single index name can be provided to this parameter.
+     * - _source: Set to `true` or `false` to return the `_source` field or not, or a list of fields to return.
+     * - _source_excludes: A comma-separated list of source fields to exclude from the response.
+     * - _source_includes: A comma-separated list of source fields to include in the response.
+     * - analyze_wildcard: If `true`, wildcard and prefix queries are analyzed. (Default: false)
+     * - analyzer: Analyzer to use for the query string. This parameter can only be used when the `q` query string parameter is specified.
+     * - default_operator: The default operator for query string query: `AND` or `OR`. (Options: and, AND, or, OR)
+     * - df: Field to use as default where no field prefix is given in the query string. (Default: _all)
+     * - lenient: If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
+     * - preference: Specifies the node or shard the operation should be performed on. Random by default. (Default: random)
+     * - q: Query in the Lucene query string syntax.
+     * - routing: A custom value used to route operations to a specific shard.
+     * - stored_fields: A comma-separated list of stored fields to return in the response.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The query definition using the Query DSL
      * @return array
      */
     public function explain(array $params = [])
@@ -934,20 +920,19 @@ class Client
     /**
      * Returns the information about the capabilities of fields among multiple indexes.
      *
-     * $params['index']              = (array) A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (*). To target all data streams and indexes, omit this parameter or use * or `_all`.
-     * $params['allow_no_indices']   = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. For example, a request targeting `foo*,bar*` returns an error if an index starts with foo but no index starts with bar.
-     * $params['expand_wildcards']   = (any) The type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`.
-     * $params['fields']             = (any) A comma-separated list of fields to retrieve capabilities for. Wildcard (`*`) expressions are supported.
-     * $params['ignore_unavailable'] = (boolean) If `true`, missing or closed indexes are not included in the response.
-     * $params['include_unmapped']   = (boolean) If `true`, unmapped fields are included in the response. (Default = false)
-     * $params['pretty']             = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']              = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']        = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']             = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']        = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']               = (array) An index filter specified with the Query DSL
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_no_indices?: bool, expand_wildcards?: mixed, fields?: mixed, ignore_unavailable?: bool, include_unmapped?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (*). To target all data streams and indexes, omit this parameter or use * or `_all`.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. For example, a request targeting `foo*,bar*` returns an error if an index starts with foo but no index starts with bar.
+     * - expand_wildcards: The type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`.
+     * - fields: A comma-separated list of fields to retrieve capabilities for. Wildcard (`*`) expressions are supported.
+     * - ignore_unavailable: If `true`, missing or closed indexes are not included in the response.
+     * - include_unmapped: If `true`, unmapped fields are included in the response. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: An index filter specified with the Query DSL
      * @return array
      */
     public function fieldCaps(array $params = [])
@@ -966,25 +951,24 @@ class Client
     /**
      * Returns a document.
      *
-     * $params['id']               = (string) The unique identifier of the document. (Required)
-     * $params['index']            = (string) The name of the index containing the document. (Required)
-     * $params['_source']          = (any) Set to `true` or `false` to return the `_source` field or not, or a list of fields to return.
-     * $params['_source_excludes'] = (any) A comma-separated list of source fields to exclude in the response.
-     * $params['_source_includes'] = (any) A comma-separated list of source fields to include in the response.
-     * $params['preference']       = (string) Specifies the node or shard the operation should be performed on. Random by default. (Default = random)
-     * $params['realtime']         = (boolean) If `true`, the request is real time as opposed to near real time.
-     * $params['refresh']          = (any) If `true`, OpenSearch refreshes the affected shards to make this operation visible to search. If `false`, do nothing with refreshes.
-     * $params['routing']          = (any) Target the specified primary shard.
-     * $params['stored_fields']    = (any) List of stored fields to return as part of a hit. If no fields are specified, no stored fields are included in the response. If this field is specified, the `_source` parameter defaults to false.
-     * $params['version']          = (integer) Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
-     * $params['version_type']     = (any) The specific version type: `internal`, `external`, `external_gte`.
-     * $params['pretty']           = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']            = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']      = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']           = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']      = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, index?: string, _source?: mixed, _source_excludes?: mixed, _source_includes?: mixed, preference?: string, realtime?: bool, refresh?: mixed, routing?: mixed, stored_fields?: mixed, version?: int, version_type?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: The unique identifier of the document. (Required)
+     * - index: The name of the index containing the document.
+     * - _source: Set to `true` or `false` to return the `_source` field or not, or a list of fields to return.
+     * - _source_excludes: A comma-separated list of source fields to exclude in the response.
+     * - _source_includes: A comma-separated list of source fields to include in the response.
+     * - preference: Specifies the node or shard the operation should be performed on. Random by default. (Default: random)
+     * - realtime: If `true`, the request is real time as opposed to near real time.
+     * - refresh: If `true`, OpenSearch refreshes the affected shards to make this operation visible to search. If `false`, do nothing with refreshes.
+     * - routing: Target the specified primary shard.
+     * - stored_fields: List of stored fields to return as part of a hit. If no fields are specified, no stored fields are included in the response. If this field is specified, the `_source` parameter defaults to false.
+     * - version: Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
+     * - version_type: The specific version type: `internal`, `external`, `external_gte`.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function get(array $params = [])
@@ -1003,13 +987,12 @@ class Client
     /**
      * Lists all active point in time searches.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getAllPits(array $params = [])
@@ -1023,16 +1006,15 @@ class Client
     /**
      * Returns a script.
      *
-     * $params['id']                      = (string) Identifier for the stored script or search template. (Required)
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['master_timeout']          = (string) Specify timeout for connection to master
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, cluster_manager_timeout?: string, master_timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: Identifier for the stored script or search template. (Required)
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - master_timeout: Specify timeout for connection to master
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getScript(array $params = [])
@@ -1049,13 +1031,12 @@ class Client
     /**
      * Returns all script contexts.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getScriptContext(array $params = [])
@@ -1069,13 +1050,12 @@ class Client
     /**
      * Returns available script types, languages and contexts.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getScriptLanguages(array $params = [])
@@ -1089,24 +1069,23 @@ class Client
     /**
      * Returns the source of a document.
      *
-     * $params['id']               = (string) The unique identifier of the document. (Required)
-     * $params['index']            = (string) The name of the index containing the document. (Required)
-     * $params['_source']          = (any) Set to `true` or `false` to return the `_source` field or not, or a list of fields to return.
-     * $params['_source_excludes'] = (any) A comma-separated list of source fields to exclude in the response.
-     * $params['_source_includes'] = (any) A comma-separated list of source fields to include in the response.
-     * $params['preference']       = (string) Specifies the node or shard the operation should be performed on. Random by default. (Default = random)
-     * $params['realtime']         = (boolean) Boolean) If `true`, the request is real time as opposed to near real time.
-     * $params['refresh']          = (any) If `true`, OpenSearch refreshes the affected shards to make this operation visible to search. If `false`, do nothing with refreshes.
-     * $params['routing']          = (any) Target the specified primary shard.
-     * $params['version']          = (integer) Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
-     * $params['version_type']     = (any) The specific version type. One of `internal`, `external`, `external_gte`.
-     * $params['pretty']           = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']            = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']      = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']           = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']      = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, index?: string, _source?: mixed, _source_excludes?: mixed, _source_includes?: mixed, preference?: string, realtime?: bool, refresh?: mixed, routing?: mixed, version?: int, version_type?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: The unique identifier of the document. (Required)
+     * - index: The name of the index containing the document.
+     * - _source: Set to `true` or `false` to return the `_source` field or not, or a list of fields to return.
+     * - _source_excludes: A comma-separated list of source fields to exclude in the response.
+     * - _source_includes: A comma-separated list of source fields to include in the response.
+     * - preference: Specifies the node or shard the operation should be performed on. Random by default. (Default: random)
+     * - realtime: Boolean) If `true`, the request is real time as opposed to near real time.
+     * - refresh: If `true`, OpenSearch refreshes the affected shards to make this operation visible to search. If `false`, do nothing with refreshes.
+     * - routing: Target the specified primary shard.
+     * - version: Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
+     * - version_type: The specific version type. One of `internal`, `external`, `external_gte`.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getSource(array $params = [])
@@ -1125,27 +1104,26 @@ class Client
     /**
      * Creates or updates a document in an index.
      *
-     * $params['index']                  = (string) Name of the data stream or index to target. (Required)
-     * $params['id']                     = (string) The unique identifier for the document.
-     * $params['if_primary_term']        = (integer) Only perform the operation if the document has this primary term.
-     * $params['if_seq_no']              = (integer) Only perform the operation if the document has this sequence number.
-     * $params['op_type']                = (any) Set to create to only index the document if it does not already exist (put if absent). If a document with the specified `_id` already exists, the indexing operation will fail. Same as using the `<index>/_create` endpoint. Valid values: `index`, `create`. If document id is specified, it defaults to `index`. Otherwise, it defaults to `create`.
-     * $params['pipeline']               = (string) ID of the pipeline to use to preprocess incoming documents. If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request. If a final pipeline is configured it will always run, regardless of the value of this parameter.
-     * $params['refresh']                = (any) If `true`, OpenSearch refreshes the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` do nothing with refreshes. Valid values: `true`, `false`, `wait_for`.
-     * $params['require_alias']          = (boolean) If `true`, the destination must be an index alias. (Default = false)
-     * $params['routing']                = (any) A custom value used to route operations to a specific shard.
-     * $params['timeout']                = (string) Period the request waits for the following operations: automatic index creation, dynamic mapping updates, waiting for active shards.
-     * $params['version']                = (integer) Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
-     * $params['version_type']           = (any) The specific version type: `external`, `external_gte`.
-     * $params['wait_for_active_shards'] = (any) The number of shard copies that must be active before proceeding with the operation. Set to all or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
-     * $params['pretty']                 = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                  = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']            = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                 = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']            = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                   = (array) The document (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, id?: string, if_primary_term?: int, if_seq_no?: int, op_type?: mixed, pipeline?: string, refresh?: mixed, require_alias?: bool, routing?: mixed, timeout?: string, version?: int, version_type?: mixed, wait_for_active_shards?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: Name of the data stream or index to target.
+     * - id: The unique identifier for the document. (Required)
+     * - if_primary_term: Only perform the operation if the document has this primary term.
+     * - if_seq_no: Only perform the operation if the document has this sequence number.
+     * - op_type: Set to create to only index the document if it does not already exist (put if absent). If a document with the specified `_id` already exists, the indexing operation will fail. Same as using the `<index>/_create` endpoint. Valid values: `index`, `create`. If document id is specified, it defaults to `index`. Otherwise, it defaults to `create`.
+     * - pipeline: ID of the pipeline to use to preprocess incoming documents. If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request. If a final pipeline is configured it will always run, regardless of the value of this parameter.
+     * - refresh: If `true`, OpenSearch refreshes the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` do nothing with refreshes. Valid values: `true`, `false`, `wait_for`.
+     * - require_alias: If `true`, the destination must be an index alias. (Default: false)
+     * - routing: A custom value used to route operations to a specific shard.
+     * - timeout: Period the request waits for the following operations: automatic index creation, dynamic mapping updates, waiting for active shards.
+     * - version: Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.
+     * - version_type: The specific version type: `external`, `external_gte`.
+     * - wait_for_active_shards: The number of shard copies that must be active before proceeding with the operation. Set to all or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The document (Required)
      * @return array
      */
     public function index(array $params = [])
@@ -1166,13 +1144,12 @@ class Client
     /**
      * Returns basic information about the cluster.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function info(array $params = [])
@@ -1186,23 +1163,22 @@ class Client
     /**
      * Allows to get multiple documents in one request.
      *
-     * $params['index']            = (string) The name of the index to retrieve documents from when `ids` are specified, or when a document in the `docs` array does not specify an index.
-     * $params['_source']          = (any) Set to `true` or `false` to return the `_source` field or not, or a list of fields to return.
-     * $params['_source_excludes'] = (any) A comma-separated list of source fields to exclude from the response. You can also use this parameter to exclude fields from the subset specified in `_source_includes` query parameter.
-     * $params['_source_includes'] = (any) A comma-separated list of source fields to include in the response. If this parameter is specified, only these source fields are returned. You can exclude fields from this subset using the `_source_excludes` query parameter. If the `_source` parameter is `false`, this parameter is ignored.
-     * $params['preference']       = (string) Specifies the node or shard the operation should be performed on. Random by default. (Default = random)
-     * $params['realtime']         = (boolean) If `true`, the request is real time as opposed to near real time.
-     * $params['refresh']          = (any) If `true`, the request refreshes relevant shards before retrieving documents.
-     * $params['routing']          = (any) A custom value used to route operations to a specific shard.
-     * $params['stored_fields']    = (any) If `true`, retrieves the document fields stored in the index rather than the document `_source`.
-     * $params['pretty']           = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']            = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']      = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']           = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']      = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']             = (array) Document identifiers; can be either `docs` (containing full document information) or `ids` (when index is provided in the URL. (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, _source?: mixed, _source_excludes?: mixed, _source_includes?: mixed, preference?: string, realtime?: bool, refresh?: mixed, routing?: mixed, stored_fields?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: The name of the index to retrieve documents from when `ids` are specified, or when a document in the `docs` array does not specify an index.
+     * - _source: Set to `true` or `false` to return the `_source` field or not, or a list of fields to return.
+     * - _source_excludes: A comma-separated list of source fields to exclude from the response. You can also use this parameter to exclude fields from the subset specified in `_source_includes` query parameter.
+     * - _source_includes: A comma-separated list of source fields to include in the response. If this parameter is specified, only these source fields are returned. You can exclude fields from this subset using the `_source_excludes` query parameter. If the `_source` parameter is `false`, this parameter is ignored.
+     * - preference: Specifies the node or shard the operation should be performed on. Random by default. (Default: random)
+     * - realtime: If `true`, the request is real time as opposed to near real time.
+     * - refresh: If `true`, the request refreshes relevant shards before retrieving documents.
+     * - routing: A custom value used to route operations to a specific shard.
+     * - stored_fields: If `true`, retrieves the document fields stored in the index rather than the document `_source`.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: Document identifiers; can be either `docs` (containing full document information) or `ids` (when index is provided in the URL. (Required)
      * @return array
      */
     public function mget(array $params = [])
@@ -1221,22 +1197,22 @@ class Client
     /**
      * Allows to execute several search operations in one request.
      *
-     * $params['index']                         = (array) A comma-separated list of data streams, indexes, and index aliases to search.
-     * $params['ccs_minimize_roundtrips']       = (boolean) If `true`, network round-trips between the coordinating node and remote clusters are minimized for cross-cluster search requests. (Default = true)
-     * $params['max_concurrent_searches']       = (integer) Maximum number of concurrent searches the multi search API can execute.
-     * $params['max_concurrent_shard_requests'] = (integer) Maximum number of concurrent shard requests that each sub-search request executes per node. (Default = 5)
-     * $params['pre_filter_shard_size']         = (integer) Defines a threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method i.e., if date filters are mandatory to match but the shard bounds and the query are disjoint.
-     * $params['rest_total_hits_as_int']        = (boolean) If `true`, `hits.total` are returned as an integer in the response. Defaults to false, which returns an object. (Default = false)
-     * $params['search_type']                   = (any) Indicates whether global term and document frequencies should be used when scoring returned documents.
-     * $params['typed_keys']                    = (boolean) Specifies whether aggregation and suggester names should be prefixed by their respective types in the response.
-     * $params['pretty']                        = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                         = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']                   = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                        = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']                   = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                          = (array) The request definitions (metadata-search request definition pairs), separated by newlines (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_partial_results?: bool, ccs_minimize_roundtrips?: bool, max_concurrent_searches?: int, max_concurrent_shard_requests?: int, pre_filter_shard_size?: int, rest_total_hits_as_int?: bool, search_type?: mixed, typed_keys?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and index aliases to search.
+     * - allow_partial_results: Specifies whether to return partial results if there are shard request timeouts or shard failures (Default: true)
+     * - ccs_minimize_roundtrips: If `true`, network round-trips between the coordinating node and remote clusters are minimized for cross-cluster search requests. (Default: true)
+     * - max_concurrent_searches: Maximum number of concurrent searches the multi search API can execute.
+     * - max_concurrent_shard_requests: Maximum number of concurrent shard requests that each sub-search request executes per node. (Default: 5)
+     * - pre_filter_shard_size: Defines a threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method i.e., if date filters are mandatory to match but the shard bounds and the query are disjoint.
+     * - rest_total_hits_as_int: If `true`, `hits.total` are returned as an integer in the response. Defaults to false, which returns an object. (Default: false)
+     * - search_type: Indicates whether global term and document frequencies should be used when scoring returned documents.
+     * - typed_keys: Specifies whether aggregation and suggester names should be prefixed by their respective types in the response.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The request definitions (metadata-search request definition pairs), separated by newlines (Required)
      * @return array
      */
     public function msearch(array $params = [])
@@ -1255,20 +1231,19 @@ class Client
     /**
      * Allows to execute several search template operations in one request.
      *
-     * $params['index']                   = (array) A comma-separated list of data streams, indexes, and aliases to search. Supports wildcards (`*`). To search all data streams and indexes, omit this parameter or use `*`.
-     * $params['ccs_minimize_roundtrips'] = (boolean) If `true`, network round-trips are minimized for cross-cluster search requests. (Default = true)
-     * $params['max_concurrent_searches'] = (integer) Maximum number of concurrent searches the API can run.
-     * $params['rest_total_hits_as_int']  = (boolean) If `true`, the response returns `hits.total` as an integer. If `false`, it returns `hits.total` as an object. (Default = false)
-     * $params['search_type']             = (any) The type of the search operation. Available options: `query_then_fetch`, `dfs_query_then_fetch`.
-     * $params['typed_keys']              = (boolean) If `true`, the response prefixes aggregation and suggester names with their respective types.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) The request definitions (metadata-search request definition pairs), separated by newlines (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, ccs_minimize_roundtrips?: bool, max_concurrent_searches?: int, rest_total_hits_as_int?: bool, search_type?: mixed, typed_keys?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases to search. Supports wildcards (`*`). To search all data streams and indexes, omit this parameter or use `*`.
+     * - ccs_minimize_roundtrips: If `true`, network round-trips are minimized for cross-cluster search requests. (Default: true)
+     * - max_concurrent_searches: Maximum number of concurrent searches the API can run.
+     * - rest_total_hits_as_int: If `true`, the response returns `hits.total` as an integer. If `false`, it returns `hits.total` as an object. (Default: false)
+     * - search_type: The type of the search operation. Available options: `query_then_fetch`, `dfs_query_then_fetch`.
+     * - typed_keys: If `true`, the response prefixes aggregation and suggester names with their respective types.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The request definitions (metadata-search request definition pairs), separated by newlines (Required)
      * @return array
      */
     public function msearchTemplate(array $params = [])
@@ -1287,27 +1262,26 @@ class Client
     /**
      * Returns multiple termvectors in one request.
      *
-     * $params['index']            = (string) The name of the index that contains the document.
-     * $params['field_statistics'] = (boolean) If `true`, the response includes the document count, sum of document frequencies, and sum of total term frequencies. (Default = true)
-     * $params['fields']           = (any)
-     * $params['ids']              = (array) A comma-separated list of documents IDs. You must provide either the `docs` field in the request body or specify `ids` as a query parameter or in the request body.
-     * $params['offsets']          = (boolean) If `true`, the response includes term offsets. (Default = true)
-     * $params['payloads']         = (boolean) If `true`, the response includes term payloads. (Default = true)
-     * $params['positions']        = (boolean) If `true`, the response includes term positions. (Default = true)
-     * $params['preference']       = (string) Specifies the node or shard on which the operation should be performed. See [preference query parameter]({{site.url}}{{site.baseurl}}/api-reference/search-apis/search/#the-preference-query-parameter) for a list of available options. By default the requests are routed randomly to available shard copies (primary or replica), with no guarantee of consistency across repeated queries.
-     * $params['realtime']         = (boolean) If `true`, the request is real time as opposed to near real time. (Default = true)
-     * $params['routing']          = (any) A custom value used to route operations to a specific shard.
-     * $params['term_statistics']  = (boolean) If `true`, the response includes term frequency and document frequency. (Default = false)
-     * $params['version']          = (integer) If `true`, returns the document version as part of a hit.
-     * $params['version_type']     = (any) The specific version type.
-     * $params['pretty']           = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']            = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']      = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']           = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']      = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']             = (array) Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, field_statistics?: bool, fields?: mixed, ids?: mixed, offsets?: bool, payloads?: bool, positions?: bool, preference?: string, realtime?: bool, routing?: mixed, term_statistics?: bool, version?: int, version_type?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: The name of the index that contains the document.
+     * - field_statistics: If `true`, the response includes the document count, sum of document frequencies, and sum of total term frequencies. (Default: true)
+     * - fields:
+     * - ids: A comma-separated list of documents IDs. You must provide either the `docs` field in the request body or specify `ids` as a query parameter or in the request body.
+     * - offsets: If `true`, the response includes term offsets. (Default: true)
+     * - payloads: If `true`, the response includes term payloads. (Default: true)
+     * - positions: If `true`, the response includes term positions. (Default: true)
+     * - preference: Specifies the node or shard on which the operation should be performed. See [preference query parameter]({{site.url}}{{site.baseurl}}/api-reference/search-apis/search/#the-preference-query-parameter) for a list of available options. By default the requests are routed randomly to available shard copies (primary or replica), with no guarantee of consistency across repeated queries.
+     * - realtime: If `true`, the request is real time as opposed to near real time. (Default: true)
+     * - routing: A custom value used to route operations to a specific shard.
+     * - term_statistics: If `true`, the response includes term frequency and document frequency. (Default: false)
+     * - version: If `true`, returns the document version as part of a hit.
+     * - version_type: The specific version type.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: Define ids, documents, parameters or a list of parameters per document here. You must at least provide a list of document ids. See documentation.
      * @return array
      */
     public function mtermvectors(array $params = [])
@@ -1326,13 +1300,12 @@ class Client
     /**
      * Returns whether the cluster is running.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return bool
      */
     public function ping(array $params = []): bool
@@ -1350,19 +1323,18 @@ class Client
     /**
      * Creates or updates a script.
      *
-     * $params['id']                      = (string) Identifier for the stored script or search template. Must be unique within the cluster. (Required)
-     * $params['context']                 = (string) Context in which the script or search template should run. To prevent errors, the API immediately compiles the script or template in this context.
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['timeout']                 = (string) Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) The document (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, context?: string, cluster_manager_timeout?: string, master_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - id: Identifier for the stored script or search template. Must be unique within the cluster. (Required)
+     * - context: Context in which the script or search template should run. To prevent errors, the API immediately compiles the script or template in this context.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - timeout: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The document (Required)
      * @return array
      */
     public function putScript(array $params = [])
@@ -1383,19 +1355,18 @@ class Client
     /**
      * Allows to evaluate the quality of ranked search results over a set of typical search queries.
      *
-     * $params['index']              = (array) A comma-separated list of data streams, indexes, and index aliases used to limit the request. Wildcard (`*`) expressions are supported. To target all data streams and indexes in a cluster, omit this parameter or use `_all` or `*`.
-     * $params['allow_no_indices']   = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
-     * $params['expand_wildcards']   = (any) Whether to expand wildcard expression to concrete indexes that are open, closed or both.
-     * $params['ignore_unavailable'] = (boolean) If `true`, missing or closed indexes are not included in the response.
-     * $params['search_type']        = (any) Search operation type
-     * $params['pretty']             = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']              = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']        = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']             = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']        = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']               = (array) The ranking evaluation search definition, including search requests, document ratings and ranking metric definition. (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_no_indices?: bool, expand_wildcards?: mixed, ignore_unavailable?: bool, search_type?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and index aliases used to limit the request. Wildcard (`*`) expressions are supported. To target all data streams and indexes in a cluster, omit this parameter or use `_all` or `*`.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
+     * - expand_wildcards: Whether to expand wildcard expression to concrete indexes that are open, closed or both.
+     * - ignore_unavailable: If `true`, missing or closed indexes are not included in the response.
+     * - search_type: Search operation type
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The ranking evaluation search definition, including search requests, document ratings and ranking metric definition. (Required)
      * @return array
      */
     public function rankEval(array $params = [])
@@ -1414,23 +1385,22 @@ class Client
     /**
      * Allows to copy documents from one index to another, optionally filtering the sourcedocuments by a query, changing the destination index settings, or fetching thedocuments from a remote cluster.
      *
-     * $params['max_docs']               = (integer) Maximum number of documents to process. By default, all documents.
-     * $params['refresh']                = (any) If `true`, the request refreshes affected shards to make this operation visible to search.
-     * $params['requests_per_second']    = (number) The throttle for this request in sub-requests per second. Defaults to no throttle. (Default = 0)
-     * $params['require_alias']          = (boolean)
-     * $params['scroll']                 = (string) Specifies how long a consistent view of the index should be maintained for scrolled search.
-     * $params['slices']                 = (any) The number of slices this task should be divided into. Defaults to 1 slice, meaning the task isn't sliced into subtasks.
-     * $params['timeout']                = (string) Period each indexing waits for automatic index creation, dynamic mapping updates, and waiting for active shards.
-     * $params['wait_for_active_shards'] = (any) The number of shard copies that must be active before proceeding with the operation. Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
-     * $params['wait_for_completion']    = (boolean) If `true`, the request blocks until the operation is complete. (Default = true)
-     * $params['pretty']                 = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                  = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']            = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                 = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']            = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                   = (array) The search definition using the Query DSL and the prototype for the index request. (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{max_docs?: int, refresh?: mixed, requests_per_second?: int|float, require_alias?: bool, scroll?: string, slices?: mixed, timeout?: string, wait_for_active_shards?: mixed, wait_for_completion?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - max_docs: Maximum number of documents to process. By default, all documents.
+     * - refresh: If `true`, the request refreshes affected shards to make this operation visible to search.
+     * - requests_per_second: The throttle for this request in sub-requests per second. Defaults to no throttle. (Default: 0)
+     * - require_alias:
+     * - scroll: Specifies how long a consistent view of the index should be maintained for scrolled search.
+     * - slices: The number of slices this task should be divided into. Defaults to 1 slice, meaning the task isn't sliced into subtasks.
+     * - timeout: Period each indexing waits for automatic index creation, dynamic mapping updates, and waiting for active shards.
+     * - wait_for_active_shards: The number of shard copies that must be active before proceeding with the operation. Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+     * - wait_for_completion: If `true`, the request blocks until the operation is complete. (Default: true)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The search definition using the Query DSL and the prototype for the index request. (Required)
      * @return array
      */
     public function reindex(array $params = [])
@@ -1447,15 +1417,14 @@ class Client
     /**
      * Changes the number of requests per second for a particular reindex operation.
      *
-     * $params['task_id']             = (string) Identifier for the task. (Required)
-     * $params['requests_per_second'] = (number) The throttle for this request in sub-requests per second.
-     * $params['pretty']              = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']               = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']         = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']              = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']         = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{task_id?: string, requests_per_second?: int|float, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - task_id: Identifier for the task.
+     * - requests_per_second: The throttle for this request in sub-requests per second.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function reindexRethrottle(array $params = [])
@@ -1472,15 +1441,14 @@ class Client
     /**
      * Allows to use the Mustache language to pre-render a search definition.
      *
-     * $params['id']          = (string) ID of the search template to render. If no `source` is specified, this or the `id` request body parameter is required.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']        = (array) The search definition template and its parameters.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - id: ID of the search template to render. If no `source` is specified, this or the `id` request body parameter is required. (Required)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The search definition template and its parameters.
      * @return array
      */
     public function renderSearchTemplate(array $params = [])
@@ -1499,14 +1467,13 @@ class Client
     /**
      * Allows an arbitrary script to be executed and a result to be returned.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']        = (array) The script to execute
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The script to execute
      * @return array
      */
     public function scriptsPainlessExecute(array $params = [])
@@ -1523,16 +1490,16 @@ class Client
     /**
      * Allows to retrieve a large numbers of results from a single search request.
      *
-     * $params['scroll_id']              = DEPRECATED (string) The scroll ID
-     * $params['rest_total_hits_as_int'] = (boolean) If `true`, the API response's `hit.total` property is returned as an integer. If `false`, the API response's `hit.total` property is returned as an object. (Default = false)
-     * $params['scroll']                 = (string) Period to retain the search context for scrolling.
-     * $params['pretty']                 = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                  = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']            = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                 = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']            = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{scroll_id?: string, rest_total_hits_as_int?: bool, scroll?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - scroll_id: The scroll ID for scrolled search
+     * - rest_total_hits_as_int: If `true`, the API response's `hit.total` property is returned as an integer. If `false`, the API response's `hit.total` property is returned as an object. (Default: false)
+     * - scroll: Period to retain the search context for scrolling.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function scroll(array $params = [])
@@ -1551,62 +1518,61 @@ class Client
     /**
      * Returns results matching a query.
      *
-     * $params['index']                         = (array) A comma-separated list of data streams, indexes, and aliases to search. Supports wildcards (`*`). To search all data streams and indexes, omit this parameter or use `*` or `_all`.
-     * $params['_source']                       = (any) Indicates which source fields are returned for matching documents. These fields are returned in the `hits._source` property of the search response. Valid values are: `true` to return the entire document source; `false` to not return the document source; `<string>` to return the source fields that are specified as a comma-separated list (supports wildcard (`*`) patterns).
-     * $params['_source_excludes']              = (any) A comma-separated list of source fields to exclude from the response. You can also use this parameter to exclude fields from the subset specified in `_source_includes` query parameter. If the `_source` parameter is `false`, this parameter is ignored.
-     * $params['_source_includes']              = (any) A comma-separated list of source fields to include in the response. If this parameter is specified, only these source fields are returned. You can exclude fields from this subset using the `_source_excludes` query parameter. If the `_source` parameter is `false`, this parameter is ignored.
-     * $params['allow_no_indices']              = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
-     * $params['allow_partial_search_results']  = (boolean) If `true`, returns partial results if there are shard request timeouts or shard failures. If `false`, returns an error with no partial results. (Default = true)
-     * $params['analyze_wildcard']              = (boolean) If `true`, wildcard and prefix queries are analyzed. This parameter can only be used when the q query string parameter is specified. (Default = false)
-     * $params['analyzer']                      = (string) Analyzer to use for the query string. This parameter can only be used when the q query string parameter is specified.
-     * $params['batched_reduce_size']           = (integer) The number of shard results that should be reduced at once on the coordinating node. This value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large. (Default = 512)
-     * $params['cancel_after_time_interval']    = (string) The time after which the search request will be canceled. Request-level parameter takes precedence over `cancel_after_time_interval` cluster setting.
-     * $params['ccs_minimize_roundtrips']       = (boolean) If `true`, network round-trips between the coordinating node and the remote clusters are minimized when executing cross-cluster search (CCS) requests. (Default = true)
-     * $params['default_operator']              = (enum) The default operator for query string query: AND or OR. This parameter can only be used when the `q` query string parameter is specified. (Options = and,AND,or,OR)
-     * $params['df']                            = (string) Field to use as default where no field prefix is given in the query string. This parameter can only be used when the q query string parameter is specified.
-     * $params['docvalue_fields']               = (any) A comma-separated list of fields to return as the docvalue representation for each hit.
-     * $params['expand_wildcards']              = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`.
-     * $params['explain']                       = (boolean) If `true`, returns detailed information about score computation as part of a hit.
-     * $params['from']                          = (integer) Starting document offset. Needs to be non-negative. By default, you cannot page through more than 10,000 hits using the `from` and `size` parameters. To page through more hits, use the `search_after` parameter. (Default = 0)
-     * $params['ignore_throttled']              = (boolean) If `true`, concrete, expanded or aliased indexes will be ignored when frozen.
-     * $params['ignore_unavailable']            = (boolean) If `false`, the request returns an error if it targets a missing or closed index.
-     * $params['include_named_queries_score']   = (boolean) Indicates whether `hit.matched_queries` should be rendered as a map that includes the name of the matched query associated with its score (true) or as an array containing the name of the matched queries (false) (Default = false)
-     * $params['lenient']                       = (boolean) If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored. This parameter can only be used when the `q` query string parameter is specified.
-     * $params['max_concurrent_shard_requests'] = (integer) Defines the number of concurrent shard requests per node this search executes concurrently. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests. (Default = 5)
-     * $params['phase_took']                    = (boolean) Indicates whether to return phase-level `took` time values in the response. (Default = false)
-     * $params['pre_filter_shard_size']         = (integer) Defines a threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method (if date filters are mandatory to match but the shard bounds and the query are disjoint). When unspecified, the pre-filter phase is executed if any of these conditions is met: the request targets more than 128 shards; the request targets one or more read-only index; the primary sort of the query targets an indexed field.
-     * $params['preference']                    = (string) Nodes and shards used for the search. By default, OpenSearch selects from eligible nodes and shards using adaptive replica selection, accounting for allocation awareness. Valid values are: `_only_local` to run the search only on shards on the local node; `_local` to, if possible, run the search on shards on the local node, or if not, select shards using the default method; `_only_nodes:<node-id>,<node-id>` to run the search on only the specified nodes IDs, where, if suitable shards exist on more than one selected node, use shards on those nodes using the default method, or if none of the specified nodes are available, select shards from any available node using the default method; `_prefer_nodes:<node-id>,<node-id>` to if possible, run the search on the specified nodes IDs, or if not, select shards using the default method; `_shards:<shard>,<shard>` to run the search only on the specified shards; `<custom-string>` (any string that does not start with `_`) to route searches with the same `<custom-string>` to the same shards in the same order. (Default = random)
-     * $params['q']                             = (string) Query in the Lucene query string syntax using query parameter search. Query parameter searches do not support the full OpenSearch Query DSL but are handy for testing.
-     * $params['request_cache']                 = (boolean) If `true`, the caching of search results is enabled for requests where `size` is `0`. Defaults to index level settings.
-     * $params['rest_total_hits_as_int']        = (boolean) Indicates whether `hits.total` should be rendered as an integer or an object in the rest search response. (Default = false)
-     * $params['routing']                       = (any) A custom value used to route operations to a specific shard.
-     * $params['scroll']                        = (string) Period to retain the search context for scrolling. See Scroll search results. By default, this value cannot exceed `1d` (24 hours). You can change this limit using the `search.max_keep_alive` cluster-level setting.
-     * $params['search_pipeline']               = (string) Customizable sequence of processing stages applied to search queries.
-     * $params['search_type']                   = (any) How distributed term frequencies are calculated for relevance scoring.
-     * $params['seq_no_primary_term']           = (boolean) If `true`, returns sequence number and primary term of the last modification of each hit.
-     * $params['size']                          = (integer) Defines the number of hits to return. By default, you cannot page through more than 10,000 hits using the `from` and `size` parameters. To page through more hits, use the `search_after` parameter. (Default = 10)
-     * $params['sort']                          = (any) A comma-separated list of <field>:<direction> pairs.
-     * $params['stats']                         = (array) Specific `tag` of the request for logging and statistical purposes.
-     * $params['stored_fields']                 = (any) A comma-separated list of stored fields to return as part of a hit. If no fields are specified, no stored fields are included in the response. If this field is specified, the `_source` parameter defaults to `false`. You can pass `_source: true` to return both source fields and stored fields in the search response.
-     * $params['suggest_field']                 = (string) Specifies which field to use for suggestions.
-     * $params['suggest_mode']                  = (enum) Specifies the suggest mode. This parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified. (Options = always,missing,popular)
-     * $params['suggest_size']                  = (integer) Number of suggestions to return. This parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified.
-     * $params['suggest_text']                  = (string) The source text for which the suggestions should be returned. This parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified.
-     * $params['terminate_after']               = (integer) Maximum number of documents to collect for each shard. If a query reaches this limit, OpenSearch terminates the query early. OpenSearch collects documents before sorting. Use with caution. OpenSearch applies this parameter to each shard handling the request. When possible, let OpenSearch perform early termination automatically. Avoid specifying this parameter for requests that target data streams with backing indexes across multiple data tiers. If set to `0` (default), the query does not terminate early.
-     * $params['timeout']                       = (string) Specifies the period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['track_scores']                  = (boolean) If `true`, calculate and return document scores, even if the scores are not used for sorting.
-     * $params['track_total_hits']              = (any) Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the response does not include the total number of hits matching the query.
-     * $params['typed_keys']                    = (boolean) If `true`, aggregation and suggester names are be prefixed by their respective types in the response.
-     * $params['verbose_pipeline']              = (boolean) Enables or disables verbose mode for the search pipeline. When verbose mode is enabled, detailed information about each processor in the search pipeline is included in the search response. This includes the processor name, execution status, input, output, and time taken for processing. This parameter is primarily intended for debugging purposes, allowing users to track how data flows and transforms through the search pipeline.
-     * $params['version']                       = (boolean) If `true`, returns document version as part of a hit.
-     * $params['pretty']                        = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                         = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']                   = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                        = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']                   = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                          = (array) The search definition using the Query DSL
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, _source?: mixed, _source_excludes?: mixed, _source_includes?: mixed, allow_no_indices?: bool, allow_partial_search_results?: bool, analyze_wildcard?: bool, analyzer?: string, batched_reduce_size?: int, cancel_after_time_interval?: string, ccs_minimize_roundtrips?: bool, default_operator?: mixed, df?: string, docvalue_fields?: mixed, expand_wildcards?: mixed, explain?: bool, from?: int, ignore_throttled?: bool, ignore_unavailable?: bool, include_named_queries_score?: bool, lenient?: bool, max_concurrent_shard_requests?: int, phase_took?: bool, pre_filter_shard_size?: int, preference?: string, q?: string, request_cache?: bool, rest_total_hits_as_int?: bool, routing?: mixed, scroll?: string, search_pipeline?: string, search_type?: mixed, seq_no_primary_term?: bool, size?: int, sort?: mixed, stats?: mixed, stored_fields?: mixed, suggest_field?: string, suggest_mode?: mixed, suggest_size?: int, suggest_text?: string, terminate_after?: int, timeout?: string, track_scores?: bool, track_total_hits?: mixed, typed_keys?: bool, verbose_pipeline?: bool, version?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases to search. Supports wildcards (`*`). To search all data streams and indexes, omit this parameter or use `*` or `_all`.
+     * - _source: Indicates which source fields are returned for matching documents. These fields are returned in the `hits._source` property of the search response. Valid values are: `true` to return the entire document source; `false` to not return the document source; `<string>` to return the source fields that are specified as a comma-separated list (supports wildcard (`*`) patterns).
+     * - _source_excludes: A comma-separated list of source fields to exclude from the response. You can also use this parameter to exclude fields from the subset specified in `_source_includes` query parameter. If the `_source` parameter is `false`, this parameter is ignored.
+     * - _source_includes: A comma-separated list of source fields to include in the response. If this parameter is specified, only these source fields are returned. You can exclude fields from this subset using the `_source_excludes` query parameter. If the `_source` parameter is `false`, this parameter is ignored.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
+     * - allow_partial_search_results: If `true`, returns partial results if there are shard request timeouts or shard failures. If `false`, returns an error with no partial results. (Default: true)
+     * - analyze_wildcard: If `true`, wildcard and prefix queries are analyzed. This parameter can only be used when the q query string parameter is specified. (Default: false)
+     * - analyzer: Analyzer to use for the query string. This parameter can only be used when the q query string parameter is specified.
+     * - batched_reduce_size: The number of shard results that should be reduced at once on the coordinating node. This value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large. (Default: 512)
+     * - cancel_after_time_interval: The time after which the search request will be canceled. Request-level parameter takes precedence over `cancel_after_time_interval` cluster setting.
+     * - ccs_minimize_roundtrips: If `true`, network round-trips between the coordinating node and the remote clusters are minimized when executing cross-cluster search (CCS) requests. (Default: true)
+     * - default_operator: The default operator for query string query: AND or OR. This parameter can only be used when the `q` query string parameter is specified. (Options: and, AND, or, OR)
+     * - df: Field to use as default where no field prefix is given in the query string. This parameter can only be used when the q query string parameter is specified.
+     * - docvalue_fields: A comma-separated list of fields to return as the docvalue representation for each hit.
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`.
+     * - explain: If `true`, returns detailed information about score computation as part of a hit.
+     * - from: Starting document offset. Needs to be non-negative. By default, you cannot page through more than 10,000 hits using the `from` and `size` parameters. To page through more hits, use the `search_after` parameter. (Default: 0)
+     * - ignore_throttled: If `true`, concrete, expanded or aliased indexes will be ignored when frozen.
+     * - ignore_unavailable: If `false`, the request returns an error if it targets a missing or closed index.
+     * - include_named_queries_score: Indicates whether `hit.matched_queries` should be rendered as a map that includes the name of the matched query associated with its score (true) or as an array containing the name of the matched queries (false) (Default: false)
+     * - lenient: If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored. This parameter can only be used when the `q` query string parameter is specified.
+     * - max_concurrent_shard_requests: Defines the number of concurrent shard requests per node this search executes concurrently. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests. (Default: 5)
+     * - phase_took: Indicates whether to return phase-level `took` time values in the response. (Default: false)
+     * - pre_filter_shard_size: Defines a threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method (if date filters are mandatory to match but the shard bounds and the query are disjoint). When unspecified, the pre-filter phase is executed if any of these conditions is met: the request targets more than 128 shards; the request targets one or more read-only index; the primary sort of the query targets an indexed field.
+     * - preference: Nodes and shards used for the search. By default, OpenSearch selects from eligible nodes and shards using adaptive replica selection, accounting for allocation awareness. Valid values are: `_only_local` to run the search only on shards on the local node; `_local` to, if possible, run the search on shards on the local node, or if not, select shards using the default method; `_only_nodes:<node-id>,<node-id>` to run the search on only the specified nodes IDs, where, if suitable shards exist on more than one selected node, use shards on those nodes using the default method, or if none of the specified nodes are available, select shards from any available node using the default method; `_prefer_nodes:<node-id>,<node-id>` to if possible, run the search on the specified nodes IDs, or if not, select shards using the default method; `_shards:<shard>,<shard>` to run the search only on the specified shards; `<custom-string>` (any string that does not start with `_`) to route searches with the same `<custom-string>` to the same shards in the same order. (Default: random)
+     * - q: Query in the Lucene query string syntax using query parameter search. Query parameter searches do not support the full OpenSearch Query DSL but are handy for testing.
+     * - request_cache: If `true`, the caching of search results is enabled for requests where `size` is `0`. Defaults to index level settings.
+     * - rest_total_hits_as_int: Indicates whether `hits.total` should be rendered as an integer or an object in the rest search response. (Default: false)
+     * - routing: A custom value used to route operations to a specific shard.
+     * - scroll: Period to retain the search context for scrolling. See Scroll search results. By default, this value cannot exceed `1d` (24 hours). You can change this limit using the `search.max_keep_alive` cluster-level setting.
+     * - search_pipeline: Customizable sequence of processing stages applied to search queries.
+     * - search_type: How distributed term frequencies are calculated for relevance scoring.
+     * - seq_no_primary_term: If `true`, returns sequence number and primary term of the last modification of each hit.
+     * - size: Defines the number of hits to return. By default, you cannot page through more than 10,000 hits using the `from` and `size` parameters. To page through more hits, use the `search_after` parameter. (Default: 10)
+     * - sort: A comma-separated list of <field>:<direction> pairs.
+     * - stats: Specific `tag` of the request for logging and statistical purposes.
+     * - stored_fields: A comma-separated list of stored fields to return as part of a hit. If no fields are specified, no stored fields are included in the response. If this field is specified, the `_source` parameter defaults to `false`. You can pass `_source: true` to return both source fields and stored fields in the search response.
+     * - suggest_field: Specifies which field to use for suggestions.
+     * - suggest_mode: Specifies the suggest mode. This parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified. (Options: always, missing, popular)
+     * - suggest_size: Number of suggestions to return. This parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified.
+     * - suggest_text: The source text for which the suggestions should be returned. This parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified.
+     * - terminate_after: Maximum number of documents to collect for each shard. If a query reaches this limit, OpenSearch terminates the query early. OpenSearch collects documents before sorting. Use with caution. OpenSearch applies this parameter to each shard handling the request. When possible, let OpenSearch perform early termination automatically. Avoid specifying this parameter for requests that target data streams with backing indexes across multiple data tiers. If set to `0` (default), the query does not terminate early.
+     * - timeout: Specifies the period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error.
+     * - track_scores: If `true`, calculate and return document scores, even if the scores are not used for sorting.
+     * - track_total_hits: Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the response does not include the total number of hits matching the query.
+     * - typed_keys: If `true`, aggregation and suggester names are be prefixed by their respective types in the response.
+     * - verbose_pipeline: Enables or disables verbose mode for the search pipeline. When verbose mode is enabled, detailed information about each processor in the search pipeline is included in the search response. This includes the processor name, execution status, input, output, and time taken for processing. This parameter is primarily intended for debugging purposes, allowing users to track how data flows and transforms through the search pipeline.
+     * - version: If `true`, returns document version as part of a hit.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The search definition using the Query DSL
      * @return array
      */
     public function search(array $params = [])
@@ -1625,20 +1591,20 @@ class Client
     /**
      * Returns information about the indexes and shards that a search request would be executed against.
      *
-     * $params['index']              = (array) Returns the indexes and shards that a search request would be executed against.
-     * $params['allow_no_indices']   = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
-     * $params['expand_wildcards']   = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
-     * $params['ignore_unavailable'] = (boolean) If `false`, the request returns an error if it targets a missing or closed index.
-     * $params['local']              = (boolean) If `true`, the request retrieves information from the local node only. (Default = false)
-     * $params['preference']         = (string) Specifies the node or shard the operation should be performed on. Random by default. (Default = random)
-     * $params['routing']            = (any) A custom value used to route operations to a specific shard.
-     * $params['pretty']             = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']              = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']        = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']             = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']        = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_no_indices?: bool, expand_wildcards?: mixed, ignore_unavailable?: bool, local?: bool, preference?: string, routing?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: Returns the indexes and shards that a search request would be executed against.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * - ignore_unavailable: If `false`, the request returns an error if it targets a missing or closed index.
+     * - local: If `true`, the request retrieves information from the local node only. (Default: false)
+     * - preference: Specifies the node or shard the operation should be performed on. Random by default. (Default: random)
+     * - routing: A custom value used to route operations to a specific shard.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function searchShards(array $params = [])
@@ -1657,30 +1623,29 @@ class Client
     /**
      * Allows to use the Mustache language to pre-render a search definition.
      *
-     * $params['index']                   = (array) A comma-separated list of data streams, indexes, and aliases to search. Supports wildcards (*).
-     * $params['allow_no_indices']        = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
-     * $params['ccs_minimize_roundtrips'] = (boolean) If `true`, network round-trips are minimized for cross-cluster search requests. (Default = true)
-     * $params['expand_wildcards']        = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
-     * $params['explain']                 = (boolean) If `true`, the response includes additional details about score computation as part of a hit.
-     * $params['ignore_throttled']        = (boolean) If `true`, specified concrete, expanded, or aliased indexes are not included in the response when throttled.
-     * $params['ignore_unavailable']      = (boolean) If `false`, the request returns an error if it targets a missing or closed index.
-     * $params['phase_took']              = (boolean) Indicates whether to return phase-level `took` time values in the response. (Default = false)
-     * $params['preference']              = (string) Specifies the node or shard the operation should be performed on. Random by default. (Default = random)
-     * $params['profile']                 = (boolean) If `true`, the query execution is profiled.
-     * $params['rest_total_hits_as_int']  = (boolean) If `true`, `hits.total` are rendered as an integer in the response. (Default = false)
-     * $params['routing']                 = (any) A custom value used to route operations to a specific shard.
-     * $params['scroll']                  = (string) Specifies how long a consistent view of the index should be maintained for scrolled search.
-     * $params['search_pipeline']         = (string) Customizable sequence of processing stages applied to search queries.
-     * $params['search_type']             = (any) The type of the search operation.
-     * $params['typed_keys']              = (boolean) If `true`, the response prefixes aggregation and suggester names with their respective types.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) The search definition template and its parameters. (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_no_indices?: bool, ccs_minimize_roundtrips?: bool, expand_wildcards?: mixed, explain?: bool, ignore_throttled?: bool, ignore_unavailable?: bool, phase_took?: bool, preference?: string, profile?: bool, rest_total_hits_as_int?: bool, routing?: mixed, scroll?: string, search_pipeline?: string, search_type?: mixed, typed_keys?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases to search. Supports wildcards (*).
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
+     * - ccs_minimize_roundtrips: If `true`, network round-trips are minimized for cross-cluster search requests. (Default: true)
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * - explain: If `true`, the response includes additional details about score computation as part of a hit.
+     * - ignore_throttled: If `true`, specified concrete, expanded, or aliased indexes are not included in the response when throttled.
+     * - ignore_unavailable: If `false`, the request returns an error if it targets a missing or closed index.
+     * - phase_took: Indicates whether to return phase-level `took` time values in the response. (Default: false)
+     * - preference: Specifies the node or shard the operation should be performed on. Random by default. (Default: random)
+     * - profile: If `true`, the query execution is profiled.
+     * - rest_total_hits_as_int: If `true`, `hits.total` are rendered as an integer in the response. (Default: false)
+     * - routing: A custom value used to route operations to a specific shard.
+     * - scroll: Specifies how long a consistent view of the index should be maintained for scrolled search.
+     * - search_pipeline: Customizable sequence of processing stages applied to search queries.
+     * - search_type: The type of the search operation.
+     * - typed_keys: If `true`, the response prefixes aggregation and suggester names with their respective types.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The search definition template and its parameters. (Required)
      * @return array
      */
     public function searchTemplate(array $params = [])
@@ -1699,27 +1664,26 @@ class Client
     /**
      * Returns information and statistics about terms in the fields of a particular document.
      *
-     * $params['index']            = (string) The name of the index containing the document. (Required)
-     * $params['id']               = (string) The unique identifier of the document.
-     * $params['field_statistics'] = (boolean) If `true`, the response includes the document count, sum of document frequencies, and sum of total term frequencies. (Default = true)
-     * $params['fields']           = (any)
-     * $params['offsets']          = (boolean) If `true`, the response includes term offsets. (Default = true)
-     * $params['payloads']         = (boolean) If `true`, the response includes term payloads. (Default = true)
-     * $params['positions']        = (boolean) If `true`, the response includes term positions. (Default = true)
-     * $params['preference']       = (string) Specifies the node or shard on which the operation should be performed. See [preference query parameter]({{site.url}}{{site.baseurl}}/api-reference/search-apis/search/#the-preference-query-parameter) for a list of available options. By default the requests are routed randomly to available shard copies (primary or replica), with no guarantee of consistency across repeated queries.
-     * $params['realtime']         = (boolean) If `true`, the request is real time as opposed to near real time. (Default = true)
-     * $params['routing']          = (any) A custom value used to route operations to a specific shard.
-     * $params['term_statistics']  = (boolean) If `true`, the response includes term frequency and document frequency. (Default = false)
-     * $params['version']          = (integer) If `true`, returns the document version as part of a hit.
-     * $params['version_type']     = (any) The specific version type.
-     * $params['pretty']           = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']            = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']      = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']           = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']      = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']             = (array) Define parameters and or supply a document to get termvectors for. See documentation.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, id?: string, field_statistics?: bool, fields?: mixed, offsets?: bool, payloads?: bool, positions?: bool, preference?: string, realtime?: bool, routing?: mixed, term_statistics?: bool, version?: int, version_type?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: The name of the index containing the document.
+     * - id: The unique identifier of the document. (Required)
+     * - field_statistics: If `true`, the response includes the document count, sum of document frequencies, and sum of total term frequencies. (Default: true)
+     * - fields:
+     * - offsets: If `true`, the response includes term offsets. (Default: true)
+     * - payloads: If `true`, the response includes term payloads. (Default: true)
+     * - positions: If `true`, the response includes term positions. (Default: true)
+     * - preference: Specifies the node or shard on which the operation should be performed. See [preference query parameter]({{site.url}}{{site.baseurl}}/api-reference/search-apis/search/#the-preference-query-parameter) for a list of available options. By default the requests are routed randomly to available shard copies (primary or replica), with no guarantee of consistency across repeated queries.
+     * - realtime: If `true`, the request is real time as opposed to near real time. (Default: true)
+     * - routing: A custom value used to route operations to a specific shard.
+     * - term_statistics: If `true`, the response includes term frequency and document frequency. (Default: false)
+     * - version: If `true`, returns the document version as part of a hit.
+     * - version_type: The specific version type.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: Define parameters and or supply a document to get termvectors for. See documentation.
      * @return array
      */
     public function termvectors(array $params = [])
@@ -1740,28 +1704,27 @@ class Client
     /**
      * Updates a document with a script or partial document.
      *
-     * $params['id']                     = (string) Document ID (Required)
-     * $params['index']                  = (string) The name of the index (Required)
-     * $params['_source']                = (any) Set to `false` to disable source retrieval. You can also specify a comma-separated list of the fields you want to retrieve.
-     * $params['_source_excludes']       = (any) Specify the source fields you want to exclude.
-     * $params['_source_includes']       = (any) Specify the source fields you want to retrieve.
-     * $params['if_primary_term']        = (integer) Only perform the operation if the document has this primary term.
-     * $params['if_seq_no']              = (integer) Only perform the operation if the document has this sequence number.
-     * $params['lang']                   = (string) The script language. (Default = painless)
-     * $params['refresh']                = (any) If 'true', OpenSearch refreshes the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` do nothing with refreshes.
-     * $params['require_alias']          = (boolean) If `true`, the destination must be an index alias. (Default = false)
-     * $params['retry_on_conflict']      = (integer) Specify how many times should the operation be retried when a conflict occurs. (Default = 0)
-     * $params['routing']                = (any) A custom value used to route operations to a specific shard.
-     * $params['timeout']                = (string) Period to wait for dynamic mapping updates and active shards. This guarantees OpenSearch waits for at least the timeout before failing. The actual wait time could be longer, particularly when multiple waits occur.
-     * $params['wait_for_active_shards'] = (any) The number of shard copies that must be active before proceeding with the operations. Set to 'all' or any positive integer up to the total number of shards in the index (number_of_replicas+1). Defaults to 1 meaning the primary shard.
-     * $params['pretty']                 = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                  = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']            = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                 = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']            = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                   = (array) The request definition requires either `script` or partial `doc` (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, index?: string, _source?: mixed, _source_excludes?: mixed, _source_includes?: mixed, if_primary_term?: int, if_seq_no?: int, lang?: string, refresh?: mixed, require_alias?: bool, retry_on_conflict?: int, routing?: mixed, timeout?: string, wait_for_active_shards?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - id: Document ID (Required)
+     * - index: The name of the index
+     * - _source: Set to `false` to disable source retrieval. You can also specify a comma-separated list of the fields you want to retrieve.
+     * - _source_excludes: Specify the source fields you want to exclude.
+     * - _source_includes: Specify the source fields you want to retrieve.
+     * - if_primary_term: Only perform the operation if the document has this primary term.
+     * - if_seq_no: Only perform the operation if the document has this sequence number.
+     * - lang: The script language. (Default: painless)
+     * - refresh: If 'true', OpenSearch refreshes the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` do nothing with refreshes.
+     * - require_alias: If `true`, the destination must be an index alias. (Default: false)
+     * - retry_on_conflict: Specify how many times should the operation be retried when a conflict occurs. (Default: 0)
+     * - routing: A custom value used to route operations to a specific shard.
+     * - timeout: Period to wait for dynamic mapping updates and active shards. This guarantees OpenSearch waits for at least the timeout before failing. The actual wait time could be longer, particularly when multiple waits occur.
+     * - wait_for_active_shards: The number of shard copies that must be active before proceeding with the operations. Set to 'all' or any positive integer up to the total number of shards in the index (number_of_replicas+1). Defaults to 1 meaning the primary shard.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The request definition requires either `script` or partial `doc` (Required)
      * @return array
      */
     public function update(array $params = [])
@@ -1782,49 +1745,48 @@ class Client
     /**
      * Performs an update on every document in the index without changing the source,for example to pick up a mapping change.
      *
-     * $params['index']                  = (array) A comma-separated list of data streams, indexes, and aliases to search. Supports wildcards (`*`). To search all data streams or indexes, omit this parameter or use `*` or `_all`. (Required)
-     * $params['_source']                = (any) Set to `true` or `false` to return the `_source` field or not, or a list of fields to return.
-     * $params['_source_excludes']       = (array) List of fields to exclude from the returned `_source` field.
-     * $params['_source_includes']       = (array) List of fields to extract and return from the `_source` field.
-     * $params['allow_no_indices']       = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
-     * $params['analyze_wildcard']       = (boolean) If `true`, wildcard and prefix queries are analyzed. (Default = false)
-     * $params['analyzer']               = (string) Analyzer to use for the query string.
-     * $params['conflicts']              = (any) What to do if update by query hits version conflicts: `abort` or `proceed`.
-     * $params['default_operator']       = (enum) The default operator for query string query: `AND` or `OR`. (Options = and,AND,or,OR)
-     * $params['df']                     = (string) Field to use as default where no field prefix is given in the query string.
-     * $params['expand_wildcards']       = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
-     * $params['from']                   = (integer) Starting offset. (Default = 0)
-     * $params['ignore_unavailable']     = (boolean) If `false`, the request returns an error if it targets a missing or closed index.
-     * $params['lenient']                = (boolean) If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
-     * $params['max_docs']               = (integer) Maximum number of documents to process. Defaults to all documents.
-     * $params['pipeline']               = (string) ID of the pipeline to use to preprocess incoming documents. If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request. If a final pipeline is configured it will always run, regardless of the value of this parameter.
-     * $params['preference']             = (string) Specifies the node or shard the operation should be performed on. Random by default. (Default = random)
-     * $params['q']                      = (string) Query in the Lucene query string syntax.
-     * $params['refresh']                = (any) If `true`, OpenSearch refreshes affected shards to make the operation visible to search.
-     * $params['request_cache']          = (boolean) If `true`, the request cache is used for this request.
-     * $params['requests_per_second']    = (number) The throttle for this request in sub-requests per second. (Default = 0)
-     * $params['routing']                = (any) A custom value used to route operations to a specific shard.
-     * $params['scroll']                 = (string) Period to retain the search context for scrolling.
-     * $params['scroll_size']            = (integer) Size of the scroll request that powers the operation. (Default = 100)
-     * $params['search_timeout']         = (string) Explicit timeout for each search request.
-     * $params['search_type']            = (any) The type of the search operation. Available options: `query_then_fetch`, `dfs_query_then_fetch`.
-     * $params['size']                   = (integer) Deprecated, use `max_docs` instead.
-     * $params['slices']                 = (any) The number of slices this task should be divided into.
-     * $params['sort']                   = (array) A comma-separated list of <field>:<direction> pairs.
-     * $params['stats']                  = (array) Specific `tag` of the request for logging and statistical purposes.
-     * $params['terminate_after']        = (integer) Maximum number of documents to collect for each shard. If a query reaches this limit, OpenSearch terminates the query early. OpenSearch collects documents before sorting. Use with caution. OpenSearch applies this parameter to each shard handling the request. When possible, let OpenSearch perform early termination automatically. Avoid specifying this parameter for requests that target data streams with backing indexes across multiple data tiers.
-     * $params['timeout']                = (string) Period each update request waits for the following operations: dynamic mapping updates, waiting for active shards.
-     * $params['version']                = (boolean) If `true`, returns the document version as part of a hit.
-     * $params['wait_for_active_shards'] = (any) The number of shard copies that must be active before proceeding with the operation. Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
-     * $params['wait_for_completion']    = (boolean) If `true`, the request blocks until the operation is complete. (Default = true)
-     * $params['pretty']                 = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                  = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']            = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                 = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']            = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                   = (array) The search definition using the Query DSL
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, _source?: mixed, _source_excludes?: mixed, _source_includes?: mixed, allow_no_indices?: bool, analyze_wildcard?: bool, analyzer?: string, conflicts?: mixed, default_operator?: mixed, df?: string, expand_wildcards?: mixed, from?: int, ignore_unavailable?: bool, lenient?: bool, max_docs?: int, pipeline?: string, preference?: string, q?: string, refresh?: mixed, request_cache?: bool, requests_per_second?: int|float, routing?: mixed, scroll?: string, scroll_size?: int, search_timeout?: string, search_type?: mixed, size?: int, slices?: mixed, sort?: mixed, stats?: mixed, terminate_after?: int, timeout?: string, version?: bool, wait_for_active_shards?: mixed, wait_for_completion?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases to search. Supports wildcards (`*`). To search all data streams or indexes, omit this parameter or use `*` or `_all`.
+     * - _source: Set to `true` or `false` to return the `_source` field or not, or a list of fields to return.
+     * - _source_excludes: List of fields to exclude from the returned `_source` field.
+     * - _source_includes: List of fields to extract and return from the `_source` field.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
+     * - analyze_wildcard: If `true`, wildcard and prefix queries are analyzed. (Default: false)
+     * - analyzer: Analyzer to use for the query string.
+     * - conflicts: What to do if update by query hits version conflicts: `abort` or `proceed`.
+     * - default_operator: The default operator for query string query: `AND` or `OR`. (Options: and, AND, or, OR)
+     * - df: Field to use as default where no field prefix is given in the query string.
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * - from: Starting offset. (Default: 0)
+     * - ignore_unavailable: If `false`, the request returns an error if it targets a missing or closed index.
+     * - lenient: If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
+     * - max_docs: Maximum number of documents to process. Defaults to all documents.
+     * - pipeline: ID of the pipeline to use to preprocess incoming documents. If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request. If a final pipeline is configured it will always run, regardless of the value of this parameter.
+     * - preference: Specifies the node or shard the operation should be performed on. Random by default. (Default: random)
+     * - q: Query in the Lucene query string syntax.
+     * - refresh: If `true`, OpenSearch refreshes affected shards to make the operation visible to search.
+     * - request_cache: If `true`, the request cache is used for this request.
+     * - requests_per_second: The throttle for this request in sub-requests per second. (Default: 0)
+     * - routing: A custom value used to route operations to a specific shard.
+     * - scroll: Period to retain the search context for scrolling.
+     * - scroll_size: Size of the scroll request that powers the operation. (Default: 100)
+     * - search_timeout: Explicit timeout for each search request.
+     * - search_type: The type of the search operation. Available options: `query_then_fetch`, `dfs_query_then_fetch`.
+     * - size: Deprecated, use `max_docs` instead.
+     * - slices: The number of slices this task should be divided into.
+     * - sort: A comma-separated list of <field>:<direction> pairs.
+     * - stats: Specific `tag` of the request for logging and statistical purposes.
+     * - terminate_after: Maximum number of documents to collect for each shard. If a query reaches this limit, OpenSearch terminates the query early. OpenSearch collects documents before sorting. Use with caution. OpenSearch applies this parameter to each shard handling the request. When possible, let OpenSearch perform early termination automatically. Avoid specifying this parameter for requests that target data streams with backing indexes across multiple data tiers.
+     * - timeout: Period each update request waits for the following operations: dynamic mapping updates, waiting for active shards.
+     * - version: If `true`, returns the document version as part of a hit.
+     * - wait_for_active_shards: The number of shard copies that must be active before proceeding with the operation. Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+     * - wait_for_completion: If `true`, the request blocks until the operation is complete. (Default: true)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The search definition using the Query DSL
      * @return array
      */
     public function updateByQuery(array $params = [])
@@ -1843,15 +1805,14 @@ class Client
     /**
      * Changes the number of requests per second for a particular Update By Query operation.
      *
-     * $params['task_id']             = (string) The ID for the task. (Required)
-     * $params['requests_per_second'] = (number) The throttle for this request in sub-requests per second.
-     * $params['pretty']              = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']               = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']         = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']              = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']         = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{task_id?: string, requests_per_second?: int|float, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - task_id: The ID for the task.
+     * - requests_per_second: The throttle for this request in sub-requests per second.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function updateByQueryRethrottle(array $params = [])

--- a/src/OpenSearch/Endpoints/Msearch.php
+++ b/src/OpenSearch/Endpoints/Msearch.php
@@ -45,6 +45,7 @@ class Msearch extends AbstractEndpoint
     public function getParamWhitelist(): array
     {
         return [
+            'allow_partial_results',
             'ccs_minimize_roundtrips',
             'max_concurrent_searches',
             'max_concurrent_shard_requests',

--- a/src/OpenSearch/Namespaces/AsynchronousSearchNamespace.php
+++ b/src/OpenSearch/Namespaces/AsynchronousSearchNamespace.php
@@ -30,14 +30,13 @@ class AsynchronousSearchNamespace extends AbstractNamespace
     /**
      * Deletes any responses from an asynchronous search.
      *
-     * $params['id']          = (string)  (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: (Required)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function delete(array $params = [])
@@ -54,14 +53,13 @@ class AsynchronousSearchNamespace extends AbstractNamespace
     /**
      * Gets partial responses from an asynchronous search.
      *
-     * $params['id']          = (string)  (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: (Required)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function get(array $params = [])
@@ -78,17 +76,17 @@ class AsynchronousSearchNamespace extends AbstractNamespace
     /**
      * Performs an asynchronous search.
      *
-     * $params['index']                       = (string) The name of the index to be searched. Can be an individual name, a comma-separated list of indexes, or a wildcard expression of index names.
-     * $params['keep_alive']                  = (string) The amount of time that the result is saved in the cluster. For example, `2d` means that the results are stored in the cluster for 48 hours. The saved search results are deleted after this period or if the search is canceled. Note that this includes the query execution time. If the query exceeds this amount of time, the process cancels this query automatically.
-     * $params['keep_on_completion']          = (boolean) Whether to save the results in the cluster after the search is complete. You can examine the stored results at a later time.
-     * $params['wait_for_completion_timeout'] = (string) The amount of time to wait for the results. You can poll the remaining results based on an ID. The maximum value is 300 seconds. Default is `1s`.
-     * $params['pretty']                      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']                 = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']                 = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, keep_alive?: string, keep_on_completion?: bool, wait_for_completion_timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: The name of the index to be searched. Can be an individual name, a comma-separated list of indexes, or a wildcard expression of index names.
+     * - keep_alive: The amount of time that the result is saved in the cluster. For example, `2d` means that the results are stored in the cluster for 48 hours. The saved search results are deleted after this period or if the search is canceled. Note that this includes the query execution time. If the query exceeds this amount of time, the process cancels this query automatically.
+     * - keep_on_completion: Whether to save the results in the cluster after the search is complete. You can examine the stored results at a later time.
+     * - wait_for_completion_timeout: The amount of time to wait for the results. You can poll the remaining results based on an ID. The maximum value is 300 seconds. Default is `1s`.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function search(array $params = [])
@@ -105,13 +103,12 @@ class AsynchronousSearchNamespace extends AbstractNamespace
     /**
      * Monitors any asynchronous searches that are `running`, `completed`, or `persisted`.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function stats(array $params = [])

--- a/src/OpenSearch/Namespaces/CatNamespace.php
+++ b/src/OpenSearch/Namespaces/CatNamespace.php
@@ -56,21 +56,20 @@ class CatNamespace extends AbstractNamespace
     /**
      * Shows information about aliases currently configured to indexes, including filter and routing information.
      *
-     * $params['name']             = (array)
-     * $params['expand_wildcards'] = (any)
-     * $params['format']           = (string) A short version of the `Accept` header, such as `json` or `yaml`.
-     * $params['h']                = (array) A comma-separated list of column names to display.
-     * $params['help']             = (boolean) Returns help information. (Default = false)
-     * $params['local']            = (boolean) Whether to return information from the local node only instead of from the cluster manager node. (Default = false)
-     * $params['s']                = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['v']                = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']           = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']            = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']      = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']           = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']      = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: mixed, expand_wildcards?: mixed, format?: string, h?: mixed, help?: bool, local?: bool, s?: mixed, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name:
+     * - expand_wildcards:
+     * - format: A short version of the `Accept` header, such as `json` or `yaml`.
+     * - h: A comma-separated list of column names to display.
+     * - help: Returns help information. (Default: false)
+     * - local: Whether to return information from the local node only instead of from the cluster manager node. (Default: false)
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function aliases(array $params = [])
@@ -87,19 +86,18 @@ class CatNamespace extends AbstractNamespace
     /**
      * Lists all active CAT point-in-time segments.
      *
-     * $params['bytes']       = (any) The units used to display byte values.
-     * $params['format']      = (string) A short version of the `Accept` header, such as `json` or `yaml`.
-     * $params['h']           = (array) A comma-separated list of column names to display.
-     * $params['help']        = (boolean) Returns help information. (Default = false)
-     * $params['s']           = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['v']           = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{bytes?: mixed, format?: string, h?: mixed, help?: bool, s?: mixed, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - bytes: The units used to display byte values.
+     * - format: A short version of the `Accept` header, such as `json` or `yaml`.
+     * - h: A comma-separated list of column names to display.
+     * - help: Returns help information. (Default: false)
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function allPitSegments(array $params = [])
@@ -113,23 +111,22 @@ class CatNamespace extends AbstractNamespace
     /**
      * Provides a snapshot of how many shards are allocated to each data node and how much disk space they are using.
      *
-     * $params['node_id']                 = (array) A comma-separated list of node IDs or names used to limit the returned information.
-     * $params['bytes']                   = (any) The units used to display byte values.
-     * $params['cluster_manager_timeout'] = (string) A timeout for connection to the cluster manager node.
-     * $params['format']                  = (string) A short version of the HTTP `Accept` header, such as `json` or `yaml`.
-     * $params['h']                       = (array) A comma-separated list of column names to display.
-     * $params['help']                    = (boolean) Returns help information. (Default = false)
-     * $params['local']                   = (boolean) Returns local information but does not retrieve the state from cluster-manager node. (Default = false)
-     * $params['master_timeout']          = (string) A timeout for connection to the cluster manager node.
-     * $params['s']                       = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['v']                       = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{node_id?: mixed, bytes?: mixed, cluster_manager_timeout?: string, format?: string, h?: mixed, help?: bool, local?: bool, master_timeout?: string, s?: mixed, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - node_id: A comma-separated list of node IDs or names used to limit the returned information.
+     * - bytes: The units used to display byte values.
+     * - cluster_manager_timeout: A timeout for connection to the cluster manager node.
+     * - format: A short version of the HTTP `Accept` header, such as `json` or `yaml`.
+     * - h: A comma-separated list of column names to display.
+     * - help: Returns help information. (Default: false)
+     * - local: Returns local information but does not retrieve the state from cluster-manager node. (Default: false)
+     * - master_timeout: A timeout for connection to the cluster manager node.
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function allocation(array $params = [])
@@ -146,21 +143,20 @@ class CatNamespace extends AbstractNamespace
     /**
      * Returns information about the cluster-manager node.
      *
-     * $params['cluster_manager_timeout'] = (string) A timeout for connection to the cluster manager node.
-     * $params['format']                  = (string) A short version of the HTTP `Accept` header, such as `json` or `yaml`.
-     * $params['h']                       = (array) A comma-separated list of column names to display.
-     * $params['help']                    = (boolean) Returns help information. (Default = false)
-     * $params['local']                   = (boolean) Returns local information but does not retrieve the state from the cluster manager node. (Default = false)
-     * $params['master_timeout']          = (string) A timeout for connection to the cluster manager node.
-     * $params['s']                       = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['v']                       = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{cluster_manager_timeout?: string, format?: string, h?: mixed, help?: bool, local?: bool, master_timeout?: string, s?: mixed, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - cluster_manager_timeout: A timeout for connection to the cluster manager node.
+     * - format: A short version of the HTTP `Accept` header, such as `json` or `yaml`.
+     * - h: A comma-separated list of column names to display.
+     * - help: Returns help information. (Default: false)
+     * - local: Returns local information but does not retrieve the state from the cluster manager node. (Default: false)
+     * - master_timeout: A timeout for connection to the cluster manager node.
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function clusterManager(array $params = [])
@@ -174,19 +170,18 @@ class CatNamespace extends AbstractNamespace
     /**
      * Provides quick access to the document count of the entire cluster or of an individual index.
      *
-     * $params['index']       = (array) A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
-     * $params['format']      = (string) A short version of the `Accept` header, such as `json` or `yaml`.
-     * $params['h']           = (array) A comma-separated list of column names to display.
-     * $params['help']        = (boolean) Returns help information. (Default = false)
-     * $params['s']           = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['v']           = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, format?: string, h?: mixed, help?: bool, s?: mixed, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
+     * - format: A short version of the `Accept` header, such as `json` or `yaml`.
+     * - h: A comma-separated list of column names to display.
+     * - help: Returns help information. (Default: false)
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function count(array $params = [])
@@ -203,20 +198,19 @@ class CatNamespace extends AbstractNamespace
     /**
      * Shows how much heap memory is currently being used by field data on every data node in the cluster.
      *
-     * $params['fields']      = (array) A comma-separated list of fields used to limit the amount of returned information. To retrieve all fields, omit this parameter.
-     * $params['bytes']       = (any) The units used to display byte values.
-     * $params['format']      = (string) A short version of the `Accept` header, such as `json` or `yaml`.
-     * $params['h']           = (array) A comma-separated list of column names to display.
-     * $params['help']        = (boolean) Returns help information. (Default = false)
-     * $params['s']           = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['v']           = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{fields?: mixed, bytes?: mixed, format?: string, h?: mixed, help?: bool, s?: mixed, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - fields: A comma-separated list of fields used to limit the amount of returned information.
+     * - bytes: The units used to display byte values.
+     * - format: A short version of the `Accept` header, such as `json` or `yaml`.
+     * - h: A comma-separated list of column names to display.
+     * - help: Returns help information. (Default: false)
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function fielddata(array $params = [])
@@ -233,20 +227,19 @@ class CatNamespace extends AbstractNamespace
     /**
      * Returns a concise representation of the cluster health.
      *
-     * $params['format']      = (string) A short version of the `Accept` header, such as `json` or `yaml`.
-     * $params['h']           = (array) A comma-separated list of column names to display.
-     * $params['help']        = (boolean) Returns help information. (Default = false)
-     * $params['s']           = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['time']        = (any) The unit used to display time values.
-     * $params['ts']          = (boolean) When `true`, returns `HH:MM:SS` and Unix epoch timestamps. (Default = true)
-     * $params['v']           = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{format?: string, h?: mixed, help?: bool, s?: mixed, time?: mixed, ts?: bool, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - format: A short version of the `Accept` header, such as `json` or `yaml`.
+     * - h: A comma-separated list of column names to display.
+     * - help: Returns help information. (Default: false)
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - time: The unit used to display time values.
+     * - ts: When `true`, returns `HH:MM:SS` and Unix epoch timestamps. (Default: true)
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function health(array $params = [])
@@ -260,13 +253,12 @@ class CatNamespace extends AbstractNamespace
     /**
      * Returns help for the Cat APIs.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function help(array $params = [])
@@ -280,28 +272,27 @@ class CatNamespace extends AbstractNamespace
     /**
      * Lists information related to indexes, that is, how much disk space they are using, how many shards they have, their health status, and so on.
      *
-     * $params['index']                     = (array) A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
-     * $params['bytes']                     = (any) The units used to display byte values.
-     * $params['cluster_manager_timeout']   = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['expand_wildcards']          = (any)
-     * $params['format']                    = (string) A short version of the `Accept` header, such as `json` or `yaml`.
-     * $params['h']                         = (array) A comma-separated list of column names to display.
-     * $params['health']                    = (any) Limits indexes based on their health status. Supported values are `green`, `yellow`, and `red`.
-     * $params['help']                      = (boolean) Returns help information. (Default = false)
-     * $params['include_unloaded_segments'] = (boolean) Whether to include information from segments not loaded into memory. (Default = false)
-     * $params['local']                     = (boolean) Returns local information but does not retrieve the state from the cluster manager node. (Default = false)
-     * $params['master_timeout']            = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['pri']                       = (boolean) When `true`, returns information only from the primary shards. (Default = false)
-     * $params['s']                         = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['time']                      = (any) Specifies the time units.
-     * $params['v']                         = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']                    = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                     = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']               = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                    = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']               = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, bytes?: mixed, cluster_manager_timeout?: string, expand_wildcards?: mixed, format?: string, h?: mixed, health?: mixed, help?: bool, include_unloaded_segments?: bool, local?: bool, master_timeout?: string, pri?: bool, s?: mixed, time?: mixed, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
+     * - bytes: The units used to display byte values.
+     * - cluster_manager_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - expand_wildcards:
+     * - format: A short version of the `Accept` header, such as `json` or `yaml`.
+     * - h: A comma-separated list of column names to display.
+     * - health: Limits indexes based on their health status. Supported values are `green`, `yellow`, and `red`.
+     * - help: Returns help information. (Default: false)
+     * - include_unloaded_segments: Whether to include information from segments not loaded into memory. (Default: false)
+     * - local: Returns local information but does not retrieve the state from the cluster manager node. (Default: false)
+     * - master_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - pri: When `true`, returns information only from the primary shards. (Default: false)
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - time: Specifies the time units.
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function indices(array $params = [])
@@ -318,21 +309,20 @@ class CatNamespace extends AbstractNamespace
     /**
      * Returns information about the cluster-manager node.
      *
-     * $params['cluster_manager_timeout'] = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['format']                  = (string) A short version of the `Accept` header, such as `json` or `yaml`.
-     * $params['h']                       = (array) A comma-separated list of column names to display.
-     * $params['help']                    = (boolean) Returns help information. (Default = false)
-     * $params['local']                   = (boolean) Returns local information but does not retrieve the state from the cluster manager node. (Default = false)
-     * $params['master_timeout']          = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['s']                       = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['v']                       = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{cluster_manager_timeout?: string, format?: string, h?: mixed, help?: bool, local?: bool, master_timeout?: string, s?: mixed, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - cluster_manager_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - format: A short version of the `Accept` header, such as `json` or `yaml`.
+     * - h: A comma-separated list of column names to display.
+     * - help: Returns help information. (Default: false)
+     * - local: Returns local information but does not retrieve the state from the cluster manager node. (Default: false)
+     * - master_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function master(array $params = [])
@@ -346,21 +336,20 @@ class CatNamespace extends AbstractNamespace
     /**
      * Returns information about custom node attributes.
      *
-     * $params['cluster_manager_timeout'] = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['format']                  = (string) A short version of the `Accept` header, such as `json` or `yaml`.
-     * $params['h']                       = (array) A comma-separated list of column names to display.
-     * $params['help']                    = (boolean) Returns help information. (Default = false)
-     * $params['local']                   = (boolean) Returns local information but does not retrieve the state from the cluster manager node. (Default = false)
-     * $params['master_timeout']          = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['s']                       = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['v']                       = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{cluster_manager_timeout?: string, format?: string, h?: mixed, help?: bool, local?: bool, master_timeout?: string, s?: mixed, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - cluster_manager_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - format: A short version of the `Accept` header, such as `json` or `yaml`.
+     * - h: A comma-separated list of column names to display.
+     * - help: Returns help information. (Default: false)
+     * - local: Returns local information but does not retrieve the state from the cluster manager node. (Default: false)
+     * - master_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function nodeattrs(array $params = [])
@@ -374,24 +363,23 @@ class CatNamespace extends AbstractNamespace
     /**
      * Returns basic statistics about the performance of cluster nodes.
      *
-     * $params['bytes']                   = (any) The units used to display byte values.
-     * $params['cluster_manager_timeout'] = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['format']                  = (string) A short version of the `Accept` header, such as `json` or `yaml`.
-     * $params['full_id']                 = (any) When `true`, returns the full node ID. When `false`, returns the shortened node ID.
-     * $params['h']                       = (array) A comma-separated list of column names to display.
-     * $params['help']                    = (boolean) Returns help information. (Default = false)
-     * $params['local']                   = (boolean) Returns local information but does not retrieve the state from the cluster manager node. (Default = false)
-     * $params['master_timeout']          = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['s']                       = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['time']                    = (any) Specifies the time units, for example, `5d` or `7h`. For more information, see [Supported units](https://opensearch.org/docs/latest/api-reference/units/).
-     * $params['v']                       = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{bytes?: mixed, cluster_manager_timeout?: string, format?: string, full_id?: mixed, h?: mixed, help?: bool, local?: bool, master_timeout?: string, s?: mixed, time?: mixed, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - bytes: The units used to display byte values.
+     * - cluster_manager_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - format: A short version of the `Accept` header, such as `json` or `yaml`.
+     * - full_id: When `true`, returns the full node ID. When `false`, returns the shortened node ID.
+     * - h: A comma-separated list of column names to display.
+     * - help: Returns help information. (Default: false)
+     * - local: Returns local information but does not retrieve the state from the cluster manager node. (Default: false)
+     * - master_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - time: Specifies the time units, for example, `5d` or `7h`. For more information, see [Supported units](https://opensearch.org/docs/latest/api-reference/units/).
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function nodes(array $params = [])
@@ -405,22 +393,21 @@ class CatNamespace extends AbstractNamespace
     /**
      * Returns a concise representation of the cluster's pending tasks.
      *
-     * $params['cluster_manager_timeout'] = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['format']                  = (string) A short version of the `Accept` header, such as `json` or `yaml`.
-     * $params['h']                       = (array) A comma-separated list of column names to display.
-     * $params['help']                    = (boolean) Returns help information. (Default = false)
-     * $params['local']                   = (boolean) Returns local information but does not retrieve the state from the cluster manager node. (Default = false)
-     * $params['master_timeout']          = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['s']                       = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['time']                    = (any) Specifies the time units, for example, `5d` or `7h`. For more information, see [Supported units](https://opensearch.org/docs/latest/api-reference/units/).
-     * $params['v']                       = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{cluster_manager_timeout?: string, format?: string, h?: mixed, help?: bool, local?: bool, master_timeout?: string, s?: mixed, time?: mixed, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - cluster_manager_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - format: A short version of the `Accept` header, such as `json` or `yaml`.
+     * - h: A comma-separated list of column names to display.
+     * - help: Returns help information. (Default: false)
+     * - local: Returns local information but does not retrieve the state from the cluster manager node. (Default: false)
+     * - master_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - time: Specifies the time units, for example, `5d` or `7h`. For more information, see [Supported units](https://opensearch.org/docs/latest/api-reference/units/).
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function pendingTasks(array $params = [])
@@ -434,19 +421,19 @@ class CatNamespace extends AbstractNamespace
     /**
      * Lists one or several CAT point-in-time segments.
      *
-     * $params['bytes']       = (any) The units used to display byte values.
-     * $params['format']      = (string) A short version of the `Accept` header, such as `json` or `yaml`.
-     * $params['h']           = (array) A comma-separated list of column names to display.
-     * $params['help']        = (boolean) Returns help information. (Default = false)
-     * $params['s']           = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['v']           = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{bytes?: mixed, format?: string, h?: mixed, help?: bool, s?: mixed, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - bytes: The units used to display byte values.
+     * - format: A short version of the `Accept` header, such as `json` or `yaml`.
+     * - h: A comma-separated list of column names to display.
+     * - help: Returns help information. (Default: false)
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function pitSegments(array $params = [])
@@ -463,21 +450,20 @@ class CatNamespace extends AbstractNamespace
     /**
      * Returns information about the names, components, and versions of the installed plugins.
      *
-     * $params['cluster_manager_timeout'] = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['format']                  = (string) A short version of the `Accept` header, such as `json` or `yaml`.
-     * $params['h']                       = (array) A comma-separated list of column names to display.
-     * $params['help']                    = (boolean) Returns help information. (Default = false)
-     * $params['local']                   = (boolean) Returns local information but does not retrieve the state from the cluster manager node. (Default = false)
-     * $params['master_timeout']          = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['s']                       = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['v']                       = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{cluster_manager_timeout?: string, format?: string, h?: mixed, help?: bool, local?: bool, master_timeout?: string, s?: mixed, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - cluster_manager_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - format: A short version of the `Accept` header, such as `json` or `yaml`.
+     * - h: A comma-separated list of column names to display.
+     * - help: Returns help information. (Default: false)
+     * - local: Returns local information but does not retrieve the state from the cluster manager node. (Default: false)
+     * - master_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function plugins(array $params = [])
@@ -491,23 +477,22 @@ class CatNamespace extends AbstractNamespace
     /**
      * Returns all completed and ongoing index and shard recoveries.
      *
-     * $params['index']       = (array) A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
-     * $params['active_only'] = (boolean) If `true`, the response only includes ongoing shard recoveries. (Default = false)
-     * $params['bytes']       = (any) The units used to display byte values.
-     * $params['detailed']    = (boolean) When `true`, includes detailed information about shard recoveries. (Default = false)
-     * $params['format']      = (string) A short version of the `Accept` header, such as `json` or `yaml`.
-     * $params['h']           = (array) A comma-separated list of column names to display.
-     * $params['help']        = (boolean) Returns help information. (Default = false)
-     * $params['s']           = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['time']        = (any) Specifies the time units, for example, `5d` or `7h`. For more information, see [Supported units](https://opensearch.org/docs/latest/api-reference/units/).
-     * $params['v']           = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, active_only?: bool, bytes?: mixed, detailed?: bool, format?: string, h?: mixed, help?: bool, s?: mixed, time?: mixed, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
+     * - active_only: If `true`, the response only includes ongoing shard recoveries. (Default: false)
+     * - bytes: The units used to display byte values.
+     * - detailed: When `true`, includes detailed information about shard recoveries. (Default: false)
+     * - format: A short version of the `Accept` header, such as `json` or `yaml`.
+     * - h: A comma-separated list of column names to display.
+     * - help: Returns help information. (Default: false)
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - time: Specifies the time units, for example, `5d` or `7h`. For more information, see [Supported units](https://opensearch.org/docs/latest/api-reference/units/).
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function recovery(array $params = [])
@@ -524,21 +509,20 @@ class CatNamespace extends AbstractNamespace
     /**
      * Returns information about all snapshot repositories for a cluster.
      *
-     * $params['cluster_manager_timeout'] = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['format']                  = (string) A short version of the `Accept` header, such as `json` or `yaml`.
-     * $params['h']                       = (array) A comma-separated list of column names to display.
-     * $params['help']                    = (boolean) Returns help information. (Default = false)
-     * $params['local']                   = (boolean) Returns local information but does not retrieve the state from the cluster manager node. (Default = false)
-     * $params['master_timeout']          = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['s']                       = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['v']                       = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{cluster_manager_timeout?: string, format?: string, h?: mixed, help?: bool, local?: bool, master_timeout?: string, s?: mixed, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - cluster_manager_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - format: A short version of the `Accept` header, such as `json` or `yaml`.
+     * - h: A comma-separated list of column names to display.
+     * - help: Returns help information. (Default: false)
+     * - local: Returns local information but does not retrieve the state from the cluster manager node. (Default: false)
+     * - master_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function repositories(array $params = [])
@@ -552,30 +536,29 @@ class CatNamespace extends AbstractNamespace
     /**
      * Returns information about active and last-completed segment replication events on each replica shard, including related shard-level metrics. These metrics provide information about how far behind the primary shard the replicas are lagging.
      *
-     * $params['index']              = (array) A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
-     * $params['active_only']        = (boolean) When `true`, the response only includes ongoing segment replication events. (Default = false)
-     * $params['allow_no_indices']   = (boolean) Whether to ignore the index if a wildcard index expression resolves to no concrete indexes. This includes the `_all` string or when no indexes have been specified.
-     * $params['bytes']              = (any) The units used to display byte values.
-     * $params['completed_only']     = (boolean) When `true`, the response only includes the last-completed segment replication events. (Default = false)
-     * $params['detailed']           = (boolean) When `true`, the response includes additional metrics for each stage of a segment replication event. (Default = false)
-     * $params['expand_wildcards']   = (any)
-     * $params['format']             = (string) A short version of the `Accept` header, such as `json` or `yaml`.
-     * $params['h']                  = (array) A comma-separated list of column names to display.
-     * $params['help']               = (boolean) Returns help information. (Default = false)
-     * $params['ignore_throttled']   = (boolean) Whether specified concrete, expanded, or aliased indexes should be ignored when throttled.
-     * $params['ignore_unavailable'] = (boolean) Whether the specified concrete indexes should be ignored when missing or closed.
-     * $params['s']                  = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['shards']             = (array) A comma-separated list of shards to display.
-     * $params['time']               = (any) Specifies the time units, for example, `5d` or `7h`. For more information, see [Supported units](https://opensearch.org/docs/latest/api-reference/units/).
-     * $params['timeout']            = (string) The operation timeout.
-     * $params['v']                  = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']             = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']              = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']        = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']             = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']        = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, active_only?: bool, allow_no_indices?: bool, bytes?: mixed, completed_only?: bool, detailed?: bool, expand_wildcards?: mixed, format?: string, h?: mixed, help?: bool, ignore_throttled?: bool, ignore_unavailable?: bool, s?: mixed, shards?: mixed, time?: mixed, timeout?: string, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
+     * - active_only: When `true`, the response only includes ongoing segment replication events. (Default: false)
+     * - allow_no_indices: Whether to ignore the index if a wildcard index expression resolves to no concrete indexes. This includes the `_all` string or when no indexes have been specified.
+     * - bytes: The units used to display byte values.
+     * - completed_only: When `true`, the response only includes the last-completed segment replication events. (Default: false)
+     * - detailed: When `true`, the response includes additional metrics for each stage of a segment replication event. (Default: false)
+     * - expand_wildcards:
+     * - format: A short version of the `Accept` header, such as `json` or `yaml`.
+     * - h: A comma-separated list of column names to display.
+     * - help: Returns help information. (Default: false)
+     * - ignore_throttled: Whether specified concrete, expanded, or aliased indexes should be ignored when throttled.
+     * - ignore_unavailable: Whether the specified concrete indexes should be ignored when missing or closed.
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - shards: A comma-separated list of shards to display.
+     * - time: Specifies the time units, for example, `5d` or `7h`. For more information, see [Supported units](https://opensearch.org/docs/latest/api-reference/units/).
+     * - timeout: The operation timeout.
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function segmentReplication(array $params = [])
@@ -592,22 +575,21 @@ class CatNamespace extends AbstractNamespace
     /**
      * Provides low-level information about the segments in the shards of an index.
      *
-     * $params['index']                   = (array) A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
-     * $params['bytes']                   = (any) The units used to display byte values.
-     * $params['cluster_manager_timeout'] = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['format']                  = (string) A short version of the `Accept` header, such as `json` or `yaml`.
-     * $params['h']                       = (array) A comma-separated list of column names to display.
-     * $params['help']                    = (boolean) Returns help information. (Default = false)
-     * $params['master_timeout']          = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['s']                       = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['v']                       = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, bytes?: mixed, cluster_manager_timeout?: string, format?: string, h?: mixed, help?: bool, master_timeout?: string, s?: mixed, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
+     * - bytes: The units used to display byte values.
+     * - cluster_manager_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - format: A short version of the `Accept` header, such as `json` or `yaml`.
+     * - h: A comma-separated list of column names to display.
+     * - help: Returns help information. (Default: false)
+     * - master_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function segments(array $params = [])
@@ -624,24 +606,23 @@ class CatNamespace extends AbstractNamespace
     /**
      * Lists the states of all primary and replica shards and how they are distributed.
      *
-     * $params['index']                   = (array)
-     * $params['bytes']                   = (any) The units used to display byte values.
-     * $params['cluster_manager_timeout'] = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['format']                  = (string) A short version of the `Accept` header, such as `json` or `yaml`.
-     * $params['h']                       = (array) A comma-separated list of column names to display.
-     * $params['help']                    = (boolean) Returns help information. (Default = false)
-     * $params['local']                   = (boolean) Returns local information but does not retrieve the state from the cluster manager node. (Default = false)
-     * $params['master_timeout']          = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['s']                       = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['time']                    = (any)
-     * $params['v']                       = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, bytes?: mixed, cluster_manager_timeout?: string, format?: string, h?: mixed, help?: bool, local?: bool, master_timeout?: string, s?: mixed, time?: mixed, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index:
+     * - bytes: The units used to display byte values.
+     * - cluster_manager_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - format: A short version of the `Accept` header, such as `json` or `yaml`.
+     * - h: A comma-separated list of column names to display.
+     * - help: Returns help information. (Default: false)
+     * - local: Returns local information but does not retrieve the state from the cluster manager node. (Default: false)
+     * - master_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - time:
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function shards(array $params = [])
@@ -658,23 +639,22 @@ class CatNamespace extends AbstractNamespace
     /**
      * Lists all of the snapshots stored in a specific repository.
      *
-     * $params['repository']              = (array) A comma-separated list of snapshot repositories used to limit the request. Accepts wildcard expressions. `_all` returns all repositories. If any repository fails during the request, OpenSearch returns an error.
-     * $params['cluster_manager_timeout'] = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['format']                  = (string) A short version of the `Accept` header, such as `json` or `yaml`.
-     * $params['h']                       = (array) A comma-separated list of column names to display.
-     * $params['help']                    = (boolean) Returns help information. (Default = false)
-     * $params['ignore_unavailable']      = (boolean) When `true`, the response does not include information from unavailable snapshots. (Default = false)
-     * $params['master_timeout']          = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['s']                       = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['time']                    = (any) Specifies the time units, for example, `5d` or `7h`. For more information, see [Supported units](https://opensearch.org/docs/latest/api-reference/units/).
-     * $params['v']                       = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{repository?: mixed, cluster_manager_timeout?: string, format?: string, h?: mixed, help?: bool, ignore_unavailable?: bool, master_timeout?: string, s?: mixed, time?: mixed, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - repository: A comma-separated list of snapshot repositories used to limit the request. Accepts wildcard expressions. `_all` returns all repositories. If any repository fails during the request, OpenSearch returns an error.
+     * - cluster_manager_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - format: A short version of the `Accept` header, such as `json` or `yaml`.
+     * - h: A comma-separated list of column names to display.
+     * - help: Returns help information. (Default: false)
+     * - ignore_unavailable: When `true`, the response does not include information from unavailable snapshots. (Default: false)
+     * - master_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - time: Specifies the time units, for example, `5d` or `7h`. For more information, see [Supported units](https://opensearch.org/docs/latest/api-reference/units/).
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function snapshots(array $params = [])
@@ -691,23 +671,22 @@ class CatNamespace extends AbstractNamespace
     /**
      * Lists the progress of all tasks currently running on the cluster.
      *
-     * $params['actions']     = (array) The task action names used to limit the response.
-     * $params['detailed']    = (boolean) If `true`, the response includes detailed information about shard recoveries. (Default = false)
-     * $params['format']      = (string) A short version of the `Accept` header, such as `json` or `yaml`.
-     * $params['h']           = (array) A comma-separated list of column names to display.
-     * $params['help']        = (boolean) Returns help information. (Default = false)
-     * $params['s']           = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['time']        = (any) Specifies the time units, for example, `5d` or `7h`. For more information, see [Supported units](https://opensearch.org/docs/latest/api-reference/units/).
-     * $params['v']           = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['node_id']     = (array) A comma-separated list of node IDs or names used to limit the returned information. Use `_local` to return information from the node to which you're connecting, specify a specific node from which to get information, or keep the parameter empty to get information from all nodes.
-     * $params['parent_task'] = (string) The parent task identifier, which is used to limit the response.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{actions?: mixed, detailed?: bool, format?: string, h?: mixed, help?: bool, s?: mixed, time?: mixed, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, node_id?: mixed, parent_task?: string} $params
+     * - actions: The task action names used to limit the response.
+     * - detailed: If `true`, the response includes detailed information about shard recoveries. (Default: false)
+     * - format: A short version of the `Accept` header, such as `json` or `yaml`.
+     * - h: A comma-separated list of column names to display.
+     * - help: Returns help information. (Default: false)
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - time: Specifies the time units, for example, `5d` or `7h`. For more information, see [Supported units](https://opensearch.org/docs/latest/api-reference/units/).
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - node_id: A comma-separated list of node IDs or names used to limit the returned information. Use `_local` to return information from the node to which you're connecting, specify a specific node from which to get information, or keep the parameter empty to get information from all nodes.
+     * - parent_task: The parent task identifier, which is used to limit the response.
      * @return array
      */
     public function tasks(array $params = [])
@@ -721,22 +700,21 @@ class CatNamespace extends AbstractNamespace
     /**
      * Lists the names, patterns, order numbers, and version numbers of index templates.
      *
-     * $params['name']                    = (string) The name of the template to return. Accepts wildcard expressions. If omitted, all templates are returned.
-     * $params['cluster_manager_timeout'] = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['format']                  = (string) A short version of the `Accept` header, such as `json` or `yaml`.
-     * $params['h']                       = (array) A comma-separated list of column names to display.
-     * $params['help']                    = (boolean) Returns help information. (Default = false)
-     * $params['local']                   = (boolean) Returns local information but does not retrieve the state from the cluster manager node. (Default = false)
-     * $params['master_timeout']          = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['s']                       = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['v']                       = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: string, cluster_manager_timeout?: string, format?: string, h?: mixed, help?: bool, local?: bool, master_timeout?: string, s?: mixed, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name: The name of the template to return. Accepts wildcard expressions. If omitted, all templates are returned.
+     * - cluster_manager_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - format: A short version of the `Accept` header, such as `json` or `yaml`.
+     * - h: A comma-separated list of column names to display.
+     * - help: Returns help information. (Default: false)
+     * - local: Returns local information but does not retrieve the state from the cluster manager node. (Default: false)
+     * - master_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function templates(array $params = [])
@@ -753,23 +731,22 @@ class CatNamespace extends AbstractNamespace
     /**
      * Returns cluster-wide thread pool statistics per node.By default the active, queued, and rejected statistics are returned for all thread pools.
      *
-     * $params['thread_pool_patterns']    = (array) A comma-separated list of thread pool names used to limit the request. Accepts wildcard expressions.
-     * $params['cluster_manager_timeout'] = (string) A timeout for connection to the cluster manager node.
-     * $params['format']                  = (string) A short version of the `Accept` header, such as `json` or `yaml`.
-     * $params['h']                       = (array) A comma-separated list of column names to display.
-     * $params['help']                    = (boolean) Returns help information. (Default = false)
-     * $params['local']                   = (boolean) Returns local information but does not retrieve the state from the cluster manager node. (Default = false)
-     * $params['master_timeout']          = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['s']                       = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['size']                    = (integer) The multiplier in which to display values.
-     * $params['v']                       = (boolean) Enables verbose mode, which displays column headers. (Default = false)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{thread_pool_patterns?: mixed, cluster_manager_timeout?: string, format?: string, h?: mixed, help?: bool, local?: bool, master_timeout?: string, s?: mixed, size?: int, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - thread_pool_patterns: A comma-separated list of thread pool names used to limit the request. Accepts wildcard expressions.
+     * - cluster_manager_timeout: A timeout for connection to the cluster manager node.
+     * - format: A short version of the `Accept` header, such as `json` or `yaml`.
+     * - h: A comma-separated list of column names to display.
+     * - help: Returns help information. (Default: false)
+     * - local: Returns local information but does not retrieve the state from the cluster manager node. (Default: false)
+     * - master_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - size: The multiplier in which to display values.
+     * - v: Enables verbose mode, which displays column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function threadPool(array $params = [])

--- a/src/OpenSearch/Namespaces/ClusterNamespace.php
+++ b/src/OpenSearch/Namespaces/ClusterNamespace.php
@@ -53,16 +53,15 @@ class ClusterNamespace extends AbstractNamespace
     /**
      * Explains how shards are allocated in the current cluster and provides an explanation for why unassigned shards can't be allocated to a node.
      *
-     * $params['include_disk_info']     = (boolean) When `true`, returns information about disk usage and shard sizes. (Default = false)
-     * $params['include_yes_decisions'] = (boolean) When `true`, returns any `YES` decisions in the allocation explanation. `YES` decisions indicate when a particular shard allocation attempt was successful for the given node. (Default = false)
-     * $params['pretty']                = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                 = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']           = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']           = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                  = (array) The index, shard, and primary flag for which to generate an explanation. Leave this empty to generate an explanation for the first unassigned shard.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{include_disk_info?: bool, include_yes_decisions?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - include_disk_info: When `true`, returns information about disk usage and shard sizes. (Default: false)
+     * - include_yes_decisions: When `true`, returns any `YES` decisions in the allocation explanation. `YES` decisions indicate when a particular shard allocation attempt was successful for the given node. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The index, shard, and primary flag for which to generate an explanation. Leave this empty to generate an explanation for the first unassigned shard.
      * @return array
      */
     public function allocationExplain(array $params = [])
@@ -79,17 +78,16 @@ class ClusterNamespace extends AbstractNamespace
     /**
      * Deletes a component template.
      *
-     * $params['name']                    = (string) The name of the component template to delete. Supports wildcard (*) expressions.
-     * $params['cluster_manager_timeout'] = (string) The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
-     * $params['master_timeout']          = (string)
-     * $params['timeout']                 = (string)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: string, cluster_manager_timeout?: string, master_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name: The name of the component template to delete. Supports wildcard (*) expressions.
+     * - cluster_manager_timeout: The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
+     * - master_timeout:
+     * - timeout:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteComponentTemplate(array $params = [])
@@ -106,13 +104,12 @@ class ClusterNamespace extends AbstractNamespace
     /**
      * Recommissions a decommissioned zone.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteDecommissionAwareness(array $params = [])
@@ -126,14 +123,13 @@ class ClusterNamespace extends AbstractNamespace
     /**
      * Clears any cluster voting configuration exclusions.
      *
-     * $params['wait_for_removal'] = (boolean) Specifies whether to wait for all excluded nodes to be removed from the cluster before clearing the voting configuration exclusions list. When `true`, all excluded nodes are removed from the cluster before this API takes any action. When `false`, the voting configuration exclusions list is cleared even if some excluded nodes are still in the cluster. (Default = true)
-     * $params['pretty']           = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']            = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']      = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']           = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']      = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{wait_for_removal?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - wait_for_removal: Specifies whether to wait for all excluded nodes to be removed from the cluster before clearing the voting configuration exclusions list. When `true`, all excluded nodes are removed from the cluster before this API takes any action. When `false`, the voting configuration exclusions list is cleared even if some excluded nodes are still in the cluster. (Default: true)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteVotingConfigExclusions(array $params = [])
@@ -147,13 +143,13 @@ class ClusterNamespace extends AbstractNamespace
     /**
      * Delete weighted shard routing weights.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function deleteWeightedRouting(array $params = [])
@@ -170,17 +166,16 @@ class ClusterNamespace extends AbstractNamespace
     /**
      * Returns information about whether a particular component template exist.
      *
-     * $params['name']                    = (string) The name of the component template. Wildcard (*) expressions are supported.
-     * $params['cluster_manager_timeout'] = (string) The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
-     * $params['local']                   = (boolean) When `true`, the request retrieves information from the local node only. When `false`, information is retrieved from the cluster manager node. (Default = false)
-     * $params['master_timeout']          = (string)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: string, cluster_manager_timeout?: string, local?: bool, master_timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name: The name of the component template. Wildcard (*) expressions are supported.
+     * - cluster_manager_timeout: The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
+     * - local: When `true`, the request retrieves information from the local node only. When `false`, information is retrieved from the cluster manager node. (Default: false)
+     * - master_timeout:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return bool
      */
     public function existsComponentTemplate(array $params = []): bool
@@ -201,18 +196,17 @@ class ClusterNamespace extends AbstractNamespace
     /**
      * Returns one or more component templates.
      *
-     * $params['name']                    = (array) The name of the component template to retrieve. Wildcard (`*`) expressions are supported.
-     * $params['cluster_manager_timeout'] = (string) The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
-     * $params['flat_settings']           = (boolean) Whether to return settings in the flat form, which can improve readability, especially for heavily nested settings. For example, the flat form of `"cluster": { "max_shards_per_node": 500 }` is `"cluster.max_shards_per_node": "500"`. (Default = false)
-     * $params['local']                   = (boolean) When `true`, the request retrieves information from the local node only. When `false`, information is retrieved from the cluster manager node. (Default = false)
-     * $params['master_timeout']          = (string)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: mixed, cluster_manager_timeout?: string, flat_settings?: bool, local?: bool, master_timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name: The name of the component template to retrieve. Wildcard (`*`) expressions are supported.
+     * - cluster_manager_timeout: The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
+     * - flat_settings: Whether to return settings in the flat form, which can improve readability, especially for heavily nested settings. For example, the flat form of `"cluster": { "max_shards_per_node": 500 }` is `"cluster.max_shards_per_node": "500"`. (Default: false)
+     * - local: When `true`, the request retrieves information from the local node only. When `false`, information is retrieved from the cluster manager node. (Default: false)
+     * - master_timeout:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getComponentTemplate(array $params = [])
@@ -229,14 +223,13 @@ class ClusterNamespace extends AbstractNamespace
     /**
      * Retrieves the decommission status for all zones.
      *
-     * $params['awareness_attribute_name'] = (string) The name of the awareness attribute.
-     * $params['pretty']                   = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                    = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']              = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                   = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']              = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{awareness_attribute_name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - awareness_attribute_name: The name of the awareness attribute.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getDecommissionAwareness(array $params = [])
@@ -253,18 +246,17 @@ class ClusterNamespace extends AbstractNamespace
     /**
      * Returns cluster settings.
      *
-     * $params['cluster_manager_timeout'] = (string) The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
-     * $params['flat_settings']           = (boolean) Whether to return settings in the flat form, which can improve readability, especially for heavily nested settings. For example, the flat form of `"cluster": { "max_shards_per_node": 500 }` is `"cluster.max_shards_per_node": "500"`. (Default = false)
-     * $params['include_defaults']        = (boolean) When `true`, returns default cluster settings from the local node. (Default = false)
-     * $params['master_timeout']          = (string)
-     * $params['timeout']                 = (string)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{cluster_manager_timeout?: string, flat_settings?: bool, include_defaults?: bool, master_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - cluster_manager_timeout: The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
+     * - flat_settings: Whether to return settings in the flat form, which can improve readability, especially for heavily nested settings. For example, the flat form of `"cluster": { "max_shards_per_node": 500 }` is `"cluster.max_shards_per_node": "500"`. (Default: false)
+     * - include_defaults: When `true`, returns default cluster settings from the local node. (Default: false)
+     * - master_timeout:
+     * - timeout:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getSettings(array $params = [])
@@ -278,14 +270,13 @@ class ClusterNamespace extends AbstractNamespace
     /**
      * Fetches weighted shard routing weights.
      *
-     * $params['attribute']   = (string) The name of the awareness attribute.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{attribute?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - attribute: The name of the awareness attribute.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getWeightedRouting(array $params = [])
@@ -302,27 +293,26 @@ class ClusterNamespace extends AbstractNamespace
     /**
      * Returns basic information about the health of the cluster.
      *
-     * $params['index']                           = (array)
-     * $params['awareness_attribute']             = (string) The name of the awareness attribute for which to return the cluster health status (for example, `zone`). Applicable only if `level` is set to `awareness_attributes`.
-     * $params['cluster_manager_timeout']         = (string) The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
-     * $params['expand_wildcards']                = (any)
-     * $params['level']                           = (enum)  (Options = awareness_attributes,cluster,indices,shards)
-     * $params['local']                           = (boolean) Whether to return information from the local node only instead of from the cluster manager node. (Default = false)
-     * $params['master_timeout']                  = (string)
-     * $params['timeout']                         = (string) The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
-     * $params['wait_for_active_shards']          = (any)
-     * $params['wait_for_events']                 = (any)
-     * $params['wait_for_no_initializing_shards'] = (boolean) Whether to wait until there are no initializing shards in the cluster. (Default = false)
-     * $params['wait_for_no_relocating_shards']   = (boolean) Whether to wait until there are no relocating shards in the cluster. (Default = false)
-     * $params['wait_for_nodes']                  = (any) Waits until the specified number of nodes (`N`) is available. Accepts `>=N`, `<=N`, `>N`, and `<N`. You can also use `ge(N)`, `le(N)`, `gt(N)`, and `lt(N)` notation.
-     * $params['wait_for_status']                 = (any) Waits until the cluster health reaches the specified status or better.
-     * $params['pretty']                          = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                           = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']                     = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                          = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']                     = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, awareness_attribute?: string, cluster_manager_timeout?: string, expand_wildcards?: mixed, level?: mixed, local?: bool, master_timeout?: string, timeout?: string, wait_for_active_shards?: mixed, wait_for_events?: mixed, wait_for_no_initializing_shards?: bool, wait_for_no_relocating_shards?: bool, wait_for_nodes?: mixed, wait_for_status?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index:
+     * - awareness_attribute: The name of the awareness attribute for which to return the cluster health status (for example, `zone`). Applicable only if `level` is set to `awareness_attributes`.
+     * - cluster_manager_timeout: The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
+     * - expand_wildcards:
+     * - level: (Options: awareness_attributes, cluster, indices, shards)
+     * - local: Whether to return information from the local node only instead of from the cluster manager node. (Default: false)
+     * - master_timeout:
+     * - timeout: The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
+     * - wait_for_active_shards:
+     * - wait_for_events:
+     * - wait_for_no_initializing_shards: Whether to wait until there are no initializing shards in the cluster. (Default: false)
+     * - wait_for_no_relocating_shards: Whether to wait until there are no relocating shards in the cluster. (Default: false)
+     * - wait_for_nodes: Waits until the specified number of nodes (`N`) is available. Accepts `>=N`, `<=N`, `>N`, and `<N`. You can also use `ge(N)`, `le(N)`, `gt(N)`, and `lt(N)` notation.
+     * - wait_for_status: Waits until the cluster health reaches the specified status or better.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function health(array $params = [])
@@ -339,16 +329,15 @@ class ClusterNamespace extends AbstractNamespace
     /**
      * Returns a list of pending cluster-level tasks, such as index creation, mapping updates,or new allocations.
      *
-     * $params['cluster_manager_timeout'] = (string) The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
-     * $params['local']                   = (boolean) When `true`, the request retrieves information from the local node only. When `false`, information is retrieved from the cluster manager node. (Default = false)
-     * $params['master_timeout']          = (string)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{cluster_manager_timeout?: string, local?: bool, master_timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - cluster_manager_timeout: The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
+     * - local: When `true`, the request retrieves information from the local node only. When `false`, information is retrieved from the cluster manager node. (Default: false)
+     * - master_timeout:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function pendingTasks(array $params = [])
@@ -362,16 +351,15 @@ class ClusterNamespace extends AbstractNamespace
     /**
      * Updates the cluster voting configuration by excluding certain node IDs or names.
      *
-     * $params['node_ids']    = (any) A comma-separated list of node IDs to exclude from the voting configuration. When using this setting, you cannot also specify `node_names`. Either `node_ids` or `node_names` are required to receive a valid response.
-     * $params['node_names']  = (any) A comma-separated list of node names to exclude from the voting configuration. When using this setting, you cannot also specify `node_ids`. Either `node_ids` or `node_names` are required to receive a valid response.
-     * $params['timeout']     = (string) When adding a voting configuration exclusion, the API waits for the specified nodes to be excluded from the voting configuration before returning a response. If the timeout expires before the appropriate condition is satisfied, the request fails and returns an error.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{node_ids?: mixed, node_names?: mixed, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - node_ids: A comma-separated list of node IDs to exclude from the voting configuration. When using this setting, you cannot also specify `node_names`. Either `node_ids` or `node_names` are required to receive a valid response.
+     * - node_names: A comma-separated list of node names to exclude from the voting configuration. When using this setting, you cannot also specify `node_ids`. Either `node_ids` or `node_names` are required to receive a valid response.
+     * - timeout: When adding a voting configuration exclusion, the API waits for the specified nodes to be excluded from the voting configuration before returning a response. If the timeout expires before the appropriate condition is satisfied, the request fails and returns an error.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function postVotingConfigExclusions(array $params = [])
@@ -385,19 +373,18 @@ class ClusterNamespace extends AbstractNamespace
     /**
      * Creates or updates a component template.
      *
-     * $params['name']                    = (string) The name of the component template to create. OpenSearch includes the following built-in component templates: `logs-mappings`, `logs-settings`, `metrics-mappings`, `metrics-settings`, `synthetics-mapping`, and `synthetics-settings`. OpenSearch uses these templates to configure backing indexes for its data streams. If you want to overwrite one of these templates, set the replacement template `version` to a higher value than the current version. If you want to disable all built-in component and index templates, set `stack.templates.enabled` to `false` using the [Cluster Update Settings API](https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/).
-     * $params['cluster_manager_timeout'] = (string) The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
-     * $params['create']                  = (boolean) When `true`, this request cannot replace or update existing component templates. (Default = false)
-     * $params['master_timeout']          = (string)
-     * $params['timeout']                 = (string)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) The template definition. (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: string, cluster_manager_timeout?: string, create?: bool, master_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - name: The name of the component template to create. OpenSearch includes the following built-in component templates: `logs-mappings`, `logs-settings`, `metrics-mappings`, `metrics-settings`, `synthetics-mapping`, and `synthetics-settings`. OpenSearch uses these templates to configure backing indexes for its data streams. If you want to overwrite one of these templates, set the replacement template `version` to a higher value than the current version. If you want to disable all built-in component and index templates, set `stack.templates.enabled` to `false` using the [Cluster Update Settings API](https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-settings/).
+     * - cluster_manager_timeout: The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
+     * - create: When `true`, this request cannot replace or update existing component templates. (Default: false)
+     * - master_timeout:
+     * - timeout:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The template definition. (Required)
      * @return array
      */
     public function putComponentTemplate(array $params = [])
@@ -416,15 +403,14 @@ class ClusterNamespace extends AbstractNamespace
     /**
      * Decommissions a cluster zone based on awareness. This can greatly benefit multi-zone deployments, where awareness attributes can aid in applying new upgrades to a cluster in a controlled fashion.
      *
-     * $params['awareness_attribute_name']  = (string) The name of the awareness attribute.
-     * $params['awareness_attribute_value'] = (string) The value of the awareness attribute. For example, if you have shards allocated in two different zones, you can give each zone a value of `zone-a` or `zoneb`. The cluster decommission operation decommissions the zone listed in the method.
-     * $params['pretty']                    = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                     = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']               = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                    = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']               = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{awareness_attribute_name?: string, awareness_attribute_value?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - awareness_attribute_name: The name of the awareness attribute.
+     * - awareness_attribute_value: The value of the awareness attribute. For example, if you have shards allocated in two different zones, you can give each zone a value of `zone-a` or `zoneb`. The cluster decommission operation decommissions the zone listed in the method.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function putDecommissionAwareness(array $params = [])
@@ -443,18 +429,17 @@ class ClusterNamespace extends AbstractNamespace
     /**
      * Updates the cluster settings.
      *
-     * $params['cluster_manager_timeout'] = (string) The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
-     * $params['flat_settings']           = (boolean) Whether to return settings in the flat form, which can improve readability, especially for heavily nested settings. For example, the flat form of `"cluster": { "max_shards_per_node": 500 }` is `"cluster.max_shards_per_node": "500"`. (Default = false)
-     * $params['master_timeout']          = (string)
-     * $params['timeout']                 = (string)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) The cluster settings to update. (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{cluster_manager_timeout?: string, flat_settings?: bool, master_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - cluster_manager_timeout: The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
+     * - flat_settings: Whether to return settings in the flat form, which can improve readability, especially for heavily nested settings. For example, the flat form of `"cluster": { "max_shards_per_node": 500 }` is `"cluster.max_shards_per_node": "500"`. (Default: false)
+     * - master_timeout:
+     * - timeout:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The cluster settings to update. (Required)
      * @return array
      */
     public function putSettings(array $params = [])
@@ -471,14 +456,14 @@ class ClusterNamespace extends AbstractNamespace
     /**
      * Updates weighted shard routing weights.
      *
-     * $params['attribute']   = (string) The name of awareness attribute, usually `zone`.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{attribute?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - attribute: The name of awareness attribute, usually `zone`.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function putWeightedRouting(array $params = [])
@@ -497,13 +482,12 @@ class ClusterNamespace extends AbstractNamespace
     /**
      * Returns the information about configured remote clusters.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function remoteInfo(array $params = [])
@@ -517,21 +501,20 @@ class ClusterNamespace extends AbstractNamespace
     /**
      * Allows to manually change the allocation of individual shards in the cluster.
      *
-     * $params['cluster_manager_timeout'] = (string) The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
-     * $params['dry_run']                 = (boolean) When `true`, the request simulates the operation and returns the resulting state.
-     * $params['explain']                 = (boolean) When `true`, the response contains an explanation of why reroute certain commands can or cannot be executed.
-     * $params['master_timeout']          = (string)
-     * $params['metric']                  = (any) Limits the information returned to the specified metrics.
-     * $params['retry_failed']            = (boolean) When `true`, retries shard allocation if it was blocked because of too many subsequent failures.
-     * $params['timeout']                 = (string)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) The definition of `commands` to perform (`move`, `cancel`, `allocate`)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{cluster_manager_timeout?: string, dry_run?: bool, explain?: bool, master_timeout?: string, metric?: mixed, retry_failed?: bool, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - cluster_manager_timeout: The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
+     * - dry_run: When `true`, the request simulates the operation and returns the resulting state.
+     * - explain: When `true`, the response contains an explanation of why reroute certain commands can or cannot be executed.
+     * - master_timeout:
+     * - metric: Limits the information returned to the specified metrics.
+     * - retry_failed: When `true`, retries shard allocation if it was blocked because of too many subsequent failures.
+     * - timeout:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The definition of `commands` to perform (`move`, `cancel`, `allocate`)
      * @return array
      */
     public function reroute(array $params = [])
@@ -548,24 +531,23 @@ class ClusterNamespace extends AbstractNamespace
     /**
      * Returns comprehensive information about the state of the cluster.
      *
-     * $params['metric']                    = (array) Limits the information returned to only the [specified metric groups](https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-stats/#metric-groups).
-     * $params['index']                     = (array)
-     * $params['allow_no_indices']          = (boolean) Whether to ignore a wildcard index expression that resolves into no concrete indexes. This includes the `_all` string or when no indexes have been specified.
-     * $params['cluster_manager_timeout']   = (string) The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
-     * $params['expand_wildcards']          = (any)
-     * $params['flat_settings']             = (boolean) Whether to return settings in the flat form, which can improve readability, especially for heavily nested settings. For example, the flat form of `"cluster": { "max_shards_per_node": 500 }` is `"cluster.max_shards_per_node": "500"`. (Default = false)
-     * $params['ignore_unavailable']        = (boolean) Whether the specified concrete indexes should be ignored when unavailable (missing or closed).
-     * $params['local']                     = (boolean) Whether to return information from the local node only instead of from the cluster manager node. (Default = false)
-     * $params['master_timeout']            = (string)
-     * $params['wait_for_metadata_version'] = (integer) Wait for the metadata version to be equal or greater than the specified metadata version.
-     * $params['wait_for_timeout']          = (string) The maximum time to wait for `wait_for_metadata_version` before timing out.
-     * $params['pretty']                    = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                     = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']               = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                    = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']               = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{metric?: mixed, index?: mixed, allow_no_indices?: bool, cluster_manager_timeout?: string, expand_wildcards?: mixed, flat_settings?: bool, ignore_unavailable?: bool, local?: bool, master_timeout?: string, wait_for_metadata_version?: int, wait_for_timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - metric: Limits the information returned to only the [specified metric groups](https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-stats/#metric-groups).
+     * - index:
+     * - allow_no_indices: Whether to ignore a wildcard index expression that resolves into no concrete indexes. This includes the `_all` string or when no indexes have been specified.
+     * - cluster_manager_timeout: The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
+     * - expand_wildcards:
+     * - flat_settings: Whether to return settings in the flat form, which can improve readability, especially for heavily nested settings. For example, the flat form of `"cluster": { "max_shards_per_node": 500 }` is `"cluster.max_shards_per_node": "500"`. (Default: false)
+     * - ignore_unavailable: Whether the specified concrete indexes should be ignored when unavailable (missing or closed).
+     * - local: Whether to return information from the local node only instead of from the cluster manager node. (Default: false)
+     * - master_timeout:
+     * - wait_for_metadata_version: Wait for the metadata version to be equal or greater than the specified metadata version.
+     * - wait_for_timeout: The maximum time to wait for `wait_for_metadata_version` before timing out.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function state(array $params = [])
@@ -584,18 +566,17 @@ class ClusterNamespace extends AbstractNamespace
     /**
      * Returns a high-level overview of cluster statistics.
      *
-     * $params['index_metric']  = (array) A comma-separated list of [index metric groups](https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-stats/#index-metric-groups), for example, `docs,store`.
-     * $params['metric']        = (array) Limit the information returned to the specified metrics.
-     * $params['node_id']       = (array)
-     * $params['flat_settings'] = (boolean) Whether to return settings in the flat form, which can improve readability, especially for heavily nested settings. For example, the flat form of `"cluster": { "max_shards_per_node": 500 }` is `"cluster.max_shards_per_node": "500"`. (Default = false)
-     * $params['timeout']       = (string) The amount of time to wait for each node to respond. If a node does not respond before its timeout expires, the response does not include its stats. However, timed out nodes are included in the response's `_nodes.failed` property. Defaults to no timeout.
-     * $params['pretty']        = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']         = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']   = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']        = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']   = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index_metric?: mixed, metric?: mixed, node_id?: mixed, flat_settings?: bool, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index_metric: A comma-separated list of [index metric groups](https://opensearch.org/docs/latest/api-reference/cluster-api/cluster-stats/#index-metric-groups), for example, `docs,store`.
+     * - metric: Limit the information returned to the specified metrics.
+     * - node_id:
+     * - flat_settings: Whether to return settings in the flat form, which can improve readability, especially for heavily nested settings. For example, the flat form of `"cluster": { "max_shards_per_node": 500 }` is `"cluster.max_shards_per_node": "500"`. (Default: false)
+     * - timeout: The amount of time to wait for each node to respond. If a node does not respond before its timeout expires, the response does not include its stats. However, timed out nodes are included in the response's `_nodes.failed` property. Defaults to no timeout.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function stats(array $params = [])

--- a/src/OpenSearch/Namespaces/DanglingIndicesNamespace.php
+++ b/src/OpenSearch/Namespaces/DanglingIndicesNamespace.php
@@ -35,18 +35,17 @@ class DanglingIndicesNamespace extends AbstractNamespace
     /**
      * Deletes the specified dangling index.
      *
-     * $params['index_uuid']              = (string) The UUID of the dangling index.
-     * $params['accept_data_loss']        = (boolean) Must be set to true in order to delete the dangling index.
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['master_timeout']          = (string) Specify timeout for connection to cluster manager.
-     * $params['timeout']                 = (string) Explicit operation timeout.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index_uuid?: string, accept_data_loss?: bool, cluster_manager_timeout?: string, master_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index_uuid: The UUID of the dangling index.
+     * - accept_data_loss: Must be set to true in order to delete the dangling index.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - master_timeout: Specify timeout for connection to cluster manager.
+     * - timeout: Explicit operation timeout.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteDanglingIndex(array $params = [])
@@ -63,18 +62,17 @@ class DanglingIndicesNamespace extends AbstractNamespace
     /**
      * Imports the specified dangling index.
      *
-     * $params['index_uuid']              = (string) The UUID of the dangling index.
-     * $params['accept_data_loss']        = (boolean) Must be set to true in order to import the dangling index.
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['master_timeout']          = (string) Specify timeout for connection to cluster manager.
-     * $params['timeout']                 = (string) Explicit operation timeout.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index_uuid?: string, accept_data_loss?: bool, cluster_manager_timeout?: string, master_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index_uuid: The UUID of the dangling index.
+     * - accept_data_loss: Must be set to true in order to import the dangling index.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - master_timeout: Specify timeout for connection to cluster manager.
+     * - timeout: Explicit operation timeout.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function importDanglingIndex(array $params = [])
@@ -91,13 +89,12 @@ class DanglingIndicesNamespace extends AbstractNamespace
     /**
      * Returns all dangling indexes.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function listDanglingIndices(array $params = [])

--- a/src/OpenSearch/Namespaces/FlowFrameworkNamespace.php
+++ b/src/OpenSearch/Namespaces/FlowFrameworkNamespace.php
@@ -36,18 +36,18 @@ class FlowFrameworkNamespace extends AbstractNamespace
     /**
      * Creates a new workflow template.
      *
-     * $params['provision']     = (boolean)  (Default = false)
-     * $params['reprovision']   = (boolean)  (Default = false)
-     * $params['update_fields'] = (boolean)  (Default = false)
-     * $params['use_case']      = (string) Specifies the workflow template to use.
-     * $params['validation']    = (string)  (Default = all)
-     * $params['pretty']        = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']         = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']   = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']        = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']   = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{provision?: bool, reprovision?: bool, update_fields?: bool, use_case?: string, validation?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - provision: (Default: false)
+     * - reprovision: (Default: false)
+     * - update_fields: (Default: false)
+     * - use_case: Specifies the workflow template to use.
+     * - validation: (Default: all)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function create(array $params = [])
@@ -64,15 +64,14 @@ class FlowFrameworkNamespace extends AbstractNamespace
     /**
      * Deletes a workflow template.
      *
-     * $params['workflow_id']  = (string)
-     * $params['clear_status'] = (boolean)  (Default = false)
-     * $params['pretty']       = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']        = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']  = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']       = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']  = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{workflow_id?: string, clear_status?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - workflow_id:
+     * - clear_status: (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function delete(array $params = [])
@@ -89,15 +88,14 @@ class FlowFrameworkNamespace extends AbstractNamespace
     /**
      * Deprovision workflow's resources when you no longer need them.
      *
-     * $params['workflow_id']  = (string)
-     * $params['allow_delete'] = (string)
-     * $params['pretty']       = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']        = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']  = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']       = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']  = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{workflow_id?: string, allow_delete?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - workflow_id:
+     * - allow_delete:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deprovision(array $params = [])
@@ -114,14 +112,13 @@ class FlowFrameworkNamespace extends AbstractNamespace
     /**
      * Retrieves a workflow template.
      *
-     * $params['workflow_id'] = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{workflow_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - workflow_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function get(array $params = [])
@@ -138,15 +135,14 @@ class FlowFrameworkNamespace extends AbstractNamespace
     /**
      * Retrieves the current workflow provisioning status.
      *
-     * $params['workflow_id'] = (string)
-     * $params['all']         = (boolean) Whether to return all fields in the response. (Default = false)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{workflow_id?: string, all?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - workflow_id:
+     * - all: Whether to return all fields in the response. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getStatus(array $params = [])
@@ -163,14 +159,13 @@ class FlowFrameworkNamespace extends AbstractNamespace
     /**
      * Retrieves available workflow steps.
      *
-     * $params['workflow_step'] = (string)
-     * $params['pretty']        = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']         = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']   = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']        = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']   = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{workflow_step?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - workflow_step:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getSteps(array $params = [])
@@ -184,14 +179,14 @@ class FlowFrameworkNamespace extends AbstractNamespace
     /**
      * Provisioning a workflow. This API is also executed when the Create or Update Workflow API is called with the provision parameter set to true.
      *
-     * $params['workflow_id'] = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{workflow_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - workflow_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function provision(array $params = [])
@@ -210,13 +205,13 @@ class FlowFrameworkNamespace extends AbstractNamespace
     /**
      * Search for workflows by using a query matching a field.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function search(array $params = [])
@@ -233,13 +228,13 @@ class FlowFrameworkNamespace extends AbstractNamespace
     /**
      * Search for workflows by using a query matching a field.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function searchState(array $params = [])
@@ -256,19 +251,19 @@ class FlowFrameworkNamespace extends AbstractNamespace
     /**
      * Updates a workflow template that has not been provisioned.
      *
-     * $params['workflow_id']   = (string)
-     * $params['provision']     = (boolean)  (Default = false)
-     * $params['reprovision']   = (boolean)  (Default = false)
-     * $params['update_fields'] = (boolean)  (Default = false)
-     * $params['use_case']      = (string) Specifies the workflow template to use.
-     * $params['validation']    = (string)  (Default = all)
-     * $params['pretty']        = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']         = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']   = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']        = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']   = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{workflow_id?: string, provision?: bool, reprovision?: bool, update_fields?: bool, use_case?: string, validation?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - workflow_id:
+     * - provision: (Default: false)
+     * - reprovision: (Default: false)
+     * - update_fields: (Default: false)
+     * - use_case: Specifies the workflow template to use.
+     * - validation: (Default: all)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function update(array $params = [])

--- a/src/OpenSearch/Namespaces/GeospatialNamespace.php
+++ b/src/OpenSearch/Namespaces/GeospatialNamespace.php
@@ -33,14 +33,13 @@ class GeospatialNamespace extends AbstractNamespace
     /**
      * Delete a specific IP2Geo data source.
      *
-     * $params['name']        = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteIp2geoDatasource(array $params = [])
@@ -57,13 +56,13 @@ class GeospatialNamespace extends AbstractNamespace
     /**
      * Use an OpenSearch query to upload `GeoJSON`, operation will fail if index exists.- When type is `geo_point`, only Point geometry is allowed- When type is `geo_shape`, all geometry types are allowed (Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon, GeometryCollection, Envelope).
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function geojsonUploadPost(array $params = [])
@@ -80,13 +79,13 @@ class GeospatialNamespace extends AbstractNamespace
     /**
      * Use an OpenSearch query to upload `GeoJSON` regardless if index exists.- When type is `geo_point`, only Point geometry is allowed- When type is `geo_shape`, all geometry types are allowed (Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon, GeometryCollection, Envelope).
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function geojsonUploadPut(array $params = [])
@@ -103,14 +102,13 @@ class GeospatialNamespace extends AbstractNamespace
     /**
      * Get one or more IP2Geo data sources, defaulting to returning all if no names specified.
      *
-     * $params['name']        = (array)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getIp2geoDatasource(array $params = [])
@@ -127,13 +125,12 @@ class GeospatialNamespace extends AbstractNamespace
     /**
      * Retrieves statistics for all geospatial uploads.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getUploadStats(array $params = [])
@@ -147,14 +144,14 @@ class GeospatialNamespace extends AbstractNamespace
     /**
      * Create a specific IP2Geo data source.Default values:  - `endpoint`: `"https://geoip.maps.opensearch.org/v1/geolite2-city/manifest.json"`  - `update_interval_in_days`: 3.
      *
-     * $params['name']        = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - name:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function putIp2geoDatasource(array $params = [])
@@ -173,14 +170,14 @@ class GeospatialNamespace extends AbstractNamespace
     /**
      * Update a specific IP2Geo data source.
      *
-     * $params['name']        = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - name:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function putIp2geoDatasourceSettings(array $params = [])

--- a/src/OpenSearch/Namespaces/IndicesNamespace.php
+++ b/src/OpenSearch/Namespaces/IndicesNamespace.php
@@ -81,21 +81,20 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Adds a block to an index.
      *
-     * $params['block']                   = (string) The block to add (one of `read`, `write`, `read_only` or `metadata`).
-     * $params['index']                   = (array) A comma separated list of indexes to add a block to.
-     * $params['allow_no_indices']        = (boolean) Whether to ignore if a wildcard indexes expression resolves into no concrete indexes. (This includes `_all` string or when no indexes have been specified).
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['expand_wildcards']        = (any) Whether to expand wildcard expression to concrete indexes that are open, closed or both.
-     * $params['ignore_unavailable']      = (boolean) Whether specified concrete indexes should be ignored when unavailable (missing or closed).
-     * $params['master_timeout']          = (string) Specify timeout for connection to cluster manager.
-     * $params['timeout']                 = (string) Explicit operation timeout
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{block?: string, index?: mixed, allow_no_indices?: bool, cluster_manager_timeout?: string, expand_wildcards?: mixed, ignore_unavailable?: bool, master_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - block: The block to add (one of `read`, `write`, `read_only` or `metadata`).
+     * - index: A comma separated list of indexes to add a block to.
+     * - allow_no_indices: Whether to ignore if a wildcard indexes expression resolves into no concrete indexes. (This includes `_all` string or when no indexes have been specified).
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - expand_wildcards: Whether to expand wildcard expression to concrete indexes that are open, closed or both.
+     * - ignore_unavailable: Whether specified concrete indexes should be ignored when unavailable (missing or closed).
+     * - master_timeout: Specify timeout for connection to cluster manager.
+     * - timeout: Explicit operation timeout
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function addBlock(array $params = [])
@@ -114,15 +113,14 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Performs the analysis process on a text and return the tokens breakdown of the text.
      *
-     * $params['index']       = (string) Index used to derive the analyzer. If specified, the `analyzer` or field parameter overrides this value. If no index is specified or the index does not have a default analyzer, the analyze API uses the standard analyzer.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']        = (array) Define analyzer/tokenizer parameters and the text on which the analysis should be performed
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: The name of the index to scope the operation.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: Define analyzer/tokenizer parameters and the text on which the analysis should be performed
      * @return array
      */
     public function analyze(array $params = [])
@@ -141,22 +139,21 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Clears all or specific caches for one or more indexes.
      *
-     * $params['index']              = (array) A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
-     * $params['allow_no_indices']   = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
-     * $params['expand_wildcards']   = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
-     * $params['fielddata']          = (boolean) If `true`, clears the fields cache. Use the `fields` parameter to clear the cache of specific fields only.
-     * $params['fields']             = (any) A comma-separated list of field names used to limit the `fielddata` parameter.
-     * $params['file']               = (boolean) If `true`, clears the unused entries from the file cache on nodes with the Search role. (Default = false)
-     * $params['ignore_unavailable'] = (boolean) If `false`, the request returns an error if it targets a missing or closed index.
-     * $params['query']              = (boolean) If `true`, clears the query cache.
-     * $params['request']            = (boolean) If `true`, clears the request cache.
-     * $params['pretty']             = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']              = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']        = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']             = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']        = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_no_indices?: bool, expand_wildcards?: mixed, fielddata?: bool, fields?: mixed, file?: bool, ignore_unavailable?: bool, query?: bool, request?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of indexes; use `_all` or empty string to perform the operation on all indexes.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * - fielddata: If `true`, clears the fields cache. Use the `fields` parameter to clear the cache of specific fields only.
+     * - fields: A comma-separated list of field names used to limit the `fielddata` parameter.
+     * - file: If `true`, clears the unused entries from the file cache on nodes with the Search role. (Default: false)
+     * - ignore_unavailable: If `false`, the request returns an error if it targets a missing or closed index.
+     * - query: If `true`, clears the query cache.
+     * - request: If `true`, clears the request cache.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function clearCache(array $params = [])
@@ -173,22 +170,21 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Clones an index.
      *
-     * $params['index']                   = (string) Name of the source index to clone.
-     * $params['target']                  = (string) Name of the target index to create.
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['task_execution_timeout']  = (string) Explicit task execution timeout, only useful when `wait_for_completion` is false, defaults to `1h`.
-     * $params['timeout']                 = (string) Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['wait_for_active_shards']  = (any) The number of shard copies that must be active before proceeding with the operation. Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
-     * $params['wait_for_completion']     = (boolean) Should this request wait until the operation has completed before returning. (Default = true)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) The configuration for the target index (`settings` and `aliases`)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, target?: string, cluster_manager_timeout?: string, master_timeout?: string, task_execution_timeout?: string, timeout?: string, wait_for_active_shards?: mixed, wait_for_completion?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: Name of the source index to clone.
+     * - target: Name of the target index to create.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - task_execution_timeout: Explicit task execution timeout, only useful when `wait_for_completion` is false, defaults to `1h`.
+     * - timeout: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * - wait_for_active_shards: The number of shard copies that must be active before proceeding with the operation. Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+     * - wait_for_completion: Should this request wait until the operation has completed before returning. (Default: true)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The configuration for the target index (`settings` and `aliases`)
      * @return array
      */
     public function clone(array $params = [])
@@ -209,21 +205,20 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Closes an index.
      *
-     * $params['index']                   = (array) A comma-separated list or wildcard expression of index names used to limit the request.
-     * $params['allow_no_indices']        = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['expand_wildcards']        = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
-     * $params['ignore_unavailable']      = (boolean) If `false`, the request returns an error if it targets a missing or closed index.
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['timeout']                 = (string) Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['wait_for_active_shards']  = (any) The number of shard copies that must be active before proceeding with the operation. Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_no_indices?: bool, cluster_manager_timeout?: string, expand_wildcards?: mixed, ignore_unavailable?: bool, master_timeout?: string, timeout?: string, wait_for_active_shards?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list or wildcard expression of index names used to limit the request.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * - ignore_unavailable: If `false`, the request returns an error if it targets a missing or closed index.
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - timeout: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * - wait_for_active_shards: The number of shard copies that must be active before proceeding with the operation. Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function close(array $params = [])
@@ -240,19 +235,18 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Creates an index with optional settings and mappings.
      *
-     * $params['index']                   = (string) The name of the index you wish to create.
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['timeout']                 = (string) Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['wait_for_active_shards']  = (any) The number of shard copies that must be active before proceeding with the operation. Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) The configuration for the index (`settings` and `mappings`)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, cluster_manager_timeout?: string, master_timeout?: string, timeout?: string, wait_for_active_shards?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: The name of the index you wish to create.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - timeout: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * - wait_for_active_shards: The number of shard copies that must be active before proceeding with the operation. Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The configuration for the index (`settings` and `mappings`)
      * @return array
      */
     public function create(array $params = [])
@@ -271,15 +265,14 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Creates or updates a data stream.
      *
-     * $params['name']        = (string) Name of the data stream, which must meet the following criteria: Lowercase only; Cannot include `\`, `/`, `*`, `?`, `"`, `<`, `>`, `|`, `,`, `#`, `:`, or a space character; Cannot start with `-`, `_`, `+`, or `.ds-`; Cannot be `.` or `..`; Cannot be longer than 255 bytes. Multi-byte characters count towards this limit faster.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']        = (array) The data stream definition
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - name: Name of the data stream, which must meet the following criteria: Lowercase only; Cannot include `\`, `/`, `*`, `?`, `"`, `<`, `>`, `|`, `,`, `#`, `:`, or a space character; Cannot start with `-`, `_`, `+`, or `.ds-`; Cannot be `.` or `..`; Cannot be longer than 255 bytes. Multi-byte characters count towards this limit faster.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The data stream definition
      * @return array
      */
     public function createDataStream(array $params = [])
@@ -298,14 +291,13 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Provides statistics on operations happening in a data stream.
      *
-     * $params['name']        = (array) A comma-separated list of data streams used to limit the request. Wildcard expressions (`*`) are supported. To target all data streams in a cluster, omit this parameter or use `*`.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name: A comma-separated list of data streams used to limit the request. Wildcard expressions (`*`) are supported. To target all data streams in a cluster, omit this parameter or use `*`.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function dataStreamsStats(array $params = [])
@@ -322,20 +314,19 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Deletes an index.
      *
-     * $params['index']                   = (array) A comma-separated list of indexes to delete. You cannot specify index aliases. By default, this parameter does not support wildcards (`*`) or `_all`. To use wildcards or `_all`, set the `action.destructive_requires_name` cluster setting to `false`.
-     * $params['allow_no_indices']        = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. (Default = false)
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['expand_wildcards']        = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
-     * $params['ignore_unavailable']      = (boolean) If `false`, the request returns an error if it targets a missing or closed index. (Default = false)
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['timeout']                 = (string) Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_no_indices?: bool, cluster_manager_timeout?: string, expand_wildcards?: mixed, ignore_unavailable?: bool, master_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of indexes to delete. You cannot specify index aliases. By default, this parameter does not support wildcards (`*`) or `_all`. To use wildcards or `_all`, set the `action.destructive_requires_name` cluster setting to `false`.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. (Default: false)
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * - ignore_unavailable: If `false`, the request returns an error if it targets a missing or closed index. (Default: false)
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - timeout: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function delete(array $params = [])
@@ -352,18 +343,17 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Deletes an alias.
      *
-     * $params['index']                   = (array) A comma-separated list of data streams or indexes used to limit the request. Supports wildcards (`*`). (Required)
-     * $params['name']                    = (array) A comma-separated list of aliases to remove. Supports wildcards (`*`). To remove all aliases, use `*` or `_all`. (Required)
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['timeout']                 = (string) Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, name?: mixed, cluster_manager_timeout?: string, master_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of data streams or indexes used to limit the request. Supports wildcards (`*`).
+     * - name: A comma-separated list of aliases to remove. Supports wildcards (`*`). To remove all aliases, use `*` or `_all`.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - timeout: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteAlias(array $params = [])
@@ -382,14 +372,13 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Deletes a data stream.
      *
-     * $params['name']        = (array) A comma-separated list of data streams to delete. Wildcard (`*`) expressions are supported.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name: A comma-separated list of data streams to delete. Wildcard (`*`) expressions are supported.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteDataStream(array $params = [])
@@ -406,17 +395,16 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Deletes an index template.
      *
-     * $params['name']                    = (string) The name of the index template to delete. Wildcard (*) expressions are supported.
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['timeout']                 = (string) Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: string, cluster_manager_timeout?: string, master_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name: The name of the index template to delete. Wildcard (*) expressions are supported.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - timeout: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteIndexTemplate(array $params = [])
@@ -433,17 +421,16 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Deletes an index template.
      *
-     * $params['name']                    = (string) The name of the legacy index template to delete. Wildcard (`*`) expressions are supported.
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['timeout']                 = (string) Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: string, cluster_manager_timeout?: string, master_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name: The name of the legacy index template to delete. Wildcard (`*`) expressions are supported.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - timeout: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteTemplate(array $params = [])
@@ -460,21 +447,20 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Returns information about whether a particular index exists.
      *
-     * $params['index']                   = (array) A comma-separated list of data streams, indexes, and aliases. Supports wildcards (`*`).
-     * $params['allow_no_indices']        = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. (Default = false)
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['expand_wildcards']        = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
-     * $params['flat_settings']           = (boolean) If `true`, returns settings in flat format. (Default = false)
-     * $params['ignore_unavailable']      = (boolean) If `false`, the request returns an error if it targets a missing or closed index. (Default = false)
-     * $params['include_defaults']        = (boolean) If `true`, return all default settings in the response. (Default = false)
-     * $params['local']                   = (boolean) If `true`, the request retrieves information from the local node only. (Default = false)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_no_indices?: bool, cluster_manager_timeout?: string, expand_wildcards?: mixed, flat_settings?: bool, ignore_unavailable?: bool, include_defaults?: bool, local?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases. Supports wildcards (`*`).
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. (Default: false)
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * - flat_settings: If `true`, returns settings in flat format. (Default: false)
+     * - ignore_unavailable: If `false`, the request returns an error if it targets a missing or closed index. (Default: false)
+     * - include_defaults: If `true`, return all default settings in the response. (Default: false)
+     * - local: If `true`, the request retrieves information from the local node only. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return bool
      */
     public function exists(array $params = []): bool
@@ -495,19 +481,18 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Returns information about whether a particular alias exists.
      *
-     * $params['name']               = (array) A comma-separated list of aliases to check. Supports wildcards (`*`). (Required)
-     * $params['index']              = (array) A comma-separated list of data streams or indexes used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
-     * $params['allow_no_indices']   = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
-     * $params['expand_wildcards']   = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
-     * $params['ignore_unavailable'] = (boolean) If `false`, requests that include a missing data stream or index in the target indexes or data streams return an error.
-     * $params['local']              = (boolean) If `true`, the request retrieves information from the local node only. (Default = false)
-     * $params['pretty']             = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']              = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']        = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']             = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']        = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: mixed, index?: mixed, allow_no_indices?: bool, expand_wildcards?: mixed, ignore_unavailable?: bool, local?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name: A comma-separated list of aliases to check. Supports wildcards (`*`).
+     * - index: A comma-separated list of data streams or indexes used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * - ignore_unavailable: If `false`, requests that include a missing data stream or index in the target indexes or data streams return an error.
+     * - local: If `true`, the request retrieves information from the local node only. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return bool
      */
     public function existsAlias(array $params = []): bool
@@ -530,18 +515,17 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Returns information about whether a particular index template exists.
      *
-     * $params['name']                    = (string) The name of the index template to check existence of. Wildcard (*) expressions are supported.
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['flat_settings']           = (boolean) Return settings in flat format. (Default = false)
-     * $params['local']                   = (boolean) Return local information, do not retrieve the state from cluster-manager node. (Default = false)
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: string, cluster_manager_timeout?: string, flat_settings?: bool, local?: bool, master_timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name: The name of the index template to check existence of. Wildcard (*) expressions are supported.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - flat_settings: Return settings in flat format. (Default: false)
+     * - local: Return local information, do not retrieve the state from cluster-manager node. (Default: false)
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return bool
      */
     public function existsIndexTemplate(array $params = []): bool
@@ -562,18 +546,17 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Returns information about whether a particular index template exists.
      *
-     * $params['name']                    = (array) The comma separated names of the index templates
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['flat_settings']           = (boolean) Return settings in flat format. (Default = false)
-     * $params['local']                   = (boolean) Return local information, do not retrieve the state from cluster-manager node. (Default = false)
-     * $params['master_timeout']          = (string) Explicit operation timeout for connection to cluster-manager node
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: mixed, cluster_manager_timeout?: string, flat_settings?: bool, local?: bool, master_timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name: The comma separated names of the index templates
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - flat_settings: Return settings in flat format. (Default: false)
+     * - local: Return local information, do not retrieve the state from cluster-manager node. (Default: false)
+     * - master_timeout: Explicit operation timeout for connection to cluster-manager node
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return bool
      */
     public function existsTemplate(array $params = []): bool
@@ -594,19 +577,18 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Performs the flush operation on one or more indexes.
      *
-     * $params['index']              = (array) A comma-separated list of data streams, indexes, and aliases to flush. Supports wildcards (`*`). To flush all data streams and indexes, omit this parameter or use `*` or `_all`.
-     * $params['allow_no_indices']   = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
-     * $params['expand_wildcards']   = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
-     * $params['force']              = (boolean) If `true`, the request forces a flush even if there are no changes to commit to the index.
-     * $params['ignore_unavailable'] = (boolean) If `false`, the request returns an error if it targets a missing or closed index.
-     * $params['wait_if_ongoing']    = (boolean) If `true`, the flush operation blocks until execution when another flush operation is running. If `false`, OpenSearch returns an error if you request a flush when another flush operation is running. (Default = true)
-     * $params['pretty']             = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']              = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']        = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']             = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']        = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_no_indices?: bool, expand_wildcards?: mixed, force?: bool, ignore_unavailable?: bool, wait_if_ongoing?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases to flush. Supports wildcards (`*`). To flush all data streams and indexes, omit this parameter or use `*` or `_all`.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * - force: If `true`, the request forces a flush even if there are no changes to commit to the index.
+     * - ignore_unavailable: If `false`, the request returns an error if it targets a missing or closed index.
+     * - wait_if_ongoing: If `true`, the flush operation blocks until execution when another flush operation is running. If `false`, OpenSearch returns an error if you request a flush when another flush operation is running. (Default: true)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function flush(array $params = [])
@@ -623,22 +605,21 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Performs the force merge operation on one or more indexes.
      *
-     * $params['index']                = (array) A comma-separated list of index names; use `_all` or empty string to perform the operation on all indexes
-     * $params['allow_no_indices']     = (boolean) Whether to ignore if a wildcard indexes expression resolves into no concrete indexes. (This includes `_all` string or when no indexes have been specified)
-     * $params['expand_wildcards']     = (any) Whether to expand wildcard expression to concrete indexes that are open, closed or both.
-     * $params['flush']                = (boolean) Specify whether the index should be flushed after performing the operation. (Default = true)
-     * $params['ignore_unavailable']   = (boolean) Whether specified concrete indexes should be ignored when unavailable (missing or closed)
-     * $params['max_num_segments']     = (integer) The number of larger segments into which smaller segments are merged. Set this parameter to 1 to merge all segments into one segment. The default behavior is to perform the merge as necessary.
-     * $params['only_expunge_deletes'] = (boolean) Specify whether the operation should only expunge deleted documents
-     * $params['primary_only']         = (boolean) Specify whether the operation should only perform on primary shards. Defaults to false. (Default = false)
-     * $params['wait_for_completion']  = (boolean) Should the request wait until the force merge is completed. (Default = true)
-     * $params['pretty']               = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']          = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']               = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']          = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_no_indices?: bool, expand_wildcards?: mixed, flush?: bool, ignore_unavailable?: bool, max_num_segments?: int, only_expunge_deletes?: bool, primary_only?: bool, wait_for_completion?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of index names; use `_all` or empty string to perform the operation on all indexes
+     * - allow_no_indices: Whether to ignore if a wildcard indexes expression resolves into no concrete indexes. (This includes `_all` string or when no indexes have been specified)
+     * - expand_wildcards: Whether to expand wildcard expression to concrete indexes that are open, closed or both.
+     * - flush: Specify whether the index should be flushed after performing the operation. (Default: true)
+     * - ignore_unavailable: Whether specified concrete indexes should be ignored when unavailable (missing or closed)
+     * - max_num_segments: The number of larger segments into which smaller segments are merged. Set this parameter to 1 to merge all segments into one segment. The default behavior is to perform the merge as necessary.
+     * - only_expunge_deletes: Specify whether the operation should only expunge deleted documents
+     * - primary_only: Specify whether the operation should only perform on primary shards. Defaults to false. (Default: false)
+     * - wait_for_completion: Should the request wait until the force merge is completed. (Default: true)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function forcemerge(array $params = [])
@@ -655,22 +636,21 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Returns information about one or more indexes.
      *
-     * $params['index']                   = (array) A comma-separated list of data streams, indexes, and index aliases used to limit the request. Wildcard expressions (*) are supported.
-     * $params['allow_no_indices']        = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. For example, a request targeting foo*,bar* returns an error if an index starts with foo but no index starts with bar. (Default = false)
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['expand_wildcards']        = (any) Type of index that wildcard expressions can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`.
-     * $params['flat_settings']           = (boolean) If `true`, returns settings in flat format. (Default = false)
-     * $params['ignore_unavailable']      = (boolean) If `false`, requests that target a missing index return an error. (Default = false)
-     * $params['include_defaults']        = (boolean) If `true`, return all default settings in the response. (Default = false)
-     * $params['local']                   = (boolean) If `true`, the request retrieves information from the local node only. Defaults to false, which means information is retrieved from the cluster-manager node. (Default = false)
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_no_indices?: bool, cluster_manager_timeout?: string, expand_wildcards?: mixed, flat_settings?: bool, ignore_unavailable?: bool, include_defaults?: bool, local?: bool, master_timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and index aliases used to limit the request. Wildcard expressions (*) are supported.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. For example, a request targeting foo*,bar* returns an error if an index starts with foo but no index starts with bar. (Default: false)
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - expand_wildcards: Type of index that wildcard expressions can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`.
+     * - flat_settings: If `true`, returns settings in flat format. (Default: false)
+     * - ignore_unavailable: If `false`, requests that target a missing index return an error. (Default: false)
+     * - include_defaults: If `true`, return all default settings in the response. (Default: false)
+     * - local: If `true`, the request retrieves information from the local node only. Defaults to false, which means information is retrieved from the cluster-manager node. (Default: false)
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function get(array $params = [])
@@ -687,19 +667,18 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Returns an alias.
      *
-     * $params['name']               = (array) A comma-separated list of aliases to retrieve. Supports wildcards (`*`). To retrieve all aliases, omit this parameter or use `*` or `_all`.
-     * $params['index']              = (array) A comma-separated list of data streams or indexes used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
-     * $params['allow_no_indices']   = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
-     * $params['expand_wildcards']   = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
-     * $params['ignore_unavailable'] = (boolean) If `false`, the request returns an error if it targets a missing or closed index.
-     * $params['local']              = (boolean) If `true`, the request retrieves information from the local node only. (Default = false)
-     * $params['pretty']             = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']              = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']        = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']             = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']        = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: mixed, index?: mixed, allow_no_indices?: bool, expand_wildcards?: mixed, ignore_unavailable?: bool, local?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name: A comma-separated list of aliases to retrieve. Supports wildcards (`*`). To retrieve all aliases, omit this parameter or use `*` or `_all`.
+     * - index: A comma-separated list of data streams or indexes used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * - ignore_unavailable: If `false`, the request returns an error if it targets a missing or closed index.
+     * - local: If `true`, the request retrieves information from the local node only. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getAlias(array $params = [])
@@ -718,14 +697,13 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Returns data streams.
      *
-     * $params['name']        = (array) A comma-separated list of data stream names used to limit the request. Wildcard (`*`) expressions are supported. If omitted, all data streams are returned.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name: A comma-separated list of data stream names used to limit the request. Wildcard (`*`) expressions are supported. If omitted, all data streams are returned.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getDataStream(array $params = [])
@@ -742,20 +720,19 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Returns mapping for one or more fields.
      *
-     * $params['fields']             = (array) A comma-separated list or wildcard expression of fields used to limit returned information. (Required)
-     * $params['index']              = (array) A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
-     * $params['allow_no_indices']   = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
-     * $params['expand_wildcards']   = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
-     * $params['ignore_unavailable'] = (boolean) If `false`, the request returns an error if it targets a missing or closed index.
-     * $params['include_defaults']   = (boolean) If `true`, return all default settings in the response.
-     * $params['local']              = (boolean) If `true`, the request retrieves information from the local node only. (Default = false)
-     * $params['pretty']             = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']              = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']        = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']             = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']        = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{fields?: mixed, index?: mixed, allow_no_indices?: bool, expand_wildcards?: mixed, ignore_unavailable?: bool, include_defaults?: bool, local?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - fields: A comma-separated list or wildcard expression of fields used to limit returned information.
+     * - index: A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * - ignore_unavailable: If `false`, the request returns an error if it targets a missing or closed index.
+     * - include_defaults: If `true`, return all default settings in the response.
+     * - local: If `true`, the request retrieves information from the local node only. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getFieldMapping(array $params = [])
@@ -774,18 +751,17 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Returns an index template.
      *
-     * $params['name']                    = (array) The name of the index template to retrieve. Wildcard (*) expressions are supported.
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['flat_settings']           = (boolean) If `true`, returns settings in flat format. (Default = false)
-     * $params['local']                   = (boolean) If `true`, the request retrieves information from the local node only. Defaults to false, which means information is retrieved from the cluster-manager node. (Default = false)
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: mixed, cluster_manager_timeout?: string, flat_settings?: bool, local?: bool, master_timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name: The name of the index template to retrieve. Wildcard (*) expressions are supported.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - flat_settings: If `true`, returns settings in flat format. (Default: false)
+     * - local: If `true`, the request retrieves information from the local node only. Defaults to false, which means information is retrieved from the cluster-manager node. (Default: false)
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getIndexTemplate(array $params = [])
@@ -802,20 +778,19 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Returns mappings for one or more indexes.
      *
-     * $params['index']                   = (array) A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
-     * $params['allow_no_indices']        = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['expand_wildcards']        = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
-     * $params['ignore_unavailable']      = (boolean) If `false`, the request returns an error if it targets a missing or closed index.
-     * $params['local']                   = (boolean) If `true`, the request retrieves information from the local node only. (Default = false)
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_no_indices?: bool, cluster_manager_timeout?: string, expand_wildcards?: mixed, ignore_unavailable?: bool, local?: bool, master_timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * - ignore_unavailable: If `false`, the request returns an error if it targets a missing or closed index.
+     * - local: If `true`, the request retrieves information from the local node only. (Default: false)
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getMapping(array $params = [])
@@ -832,23 +807,22 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Returns settings for one or more indexes.
      *
-     * $params['name']                    = (array) A comma-separated list or wildcard expression of settings to retrieve.
-     * $params['index']                   = (array) A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
-     * $params['allow_no_indices']        = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. For example, a request targeting `foo*,bar*` returns an error if an index starts with foo but no index starts with `bar`.
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['expand_wildcards']        = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`.
-     * $params['flat_settings']           = (boolean) If `true`, returns settings in flat format. (Default = false)
-     * $params['ignore_unavailable']      = (boolean) If `false`, the request returns an error if it targets a missing or closed index.
-     * $params['include_defaults']        = (boolean) If `true`, return all default settings in the response. (Default = false)
-     * $params['local']                   = (boolean) If `true`, the request retrieves information from the local node only. If `false`, information is retrieved from the cluster-manager node. (Default = false)
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: mixed, index?: mixed, allow_no_indices?: bool, cluster_manager_timeout?: string, expand_wildcards?: mixed, flat_settings?: bool, ignore_unavailable?: bool, include_defaults?: bool, local?: bool, master_timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name: A comma-separated list or wildcard expression of settings to retrieve.
+     * - index: A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. For example, a request targeting `foo*,bar*` returns an error if an index starts with foo but no index starts with `bar`.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`.
+     * - flat_settings: If `true`, returns settings in flat format. (Default: false)
+     * - ignore_unavailable: If `false`, the request returns an error if it targets a missing or closed index.
+     * - include_defaults: If `true`, return all default settings in the response. (Default: false)
+     * - local: If `true`, the request retrieves information from the local node only. If `false`, information is retrieved from the cluster-manager node. (Default: false)
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getSettings(array $params = [])
@@ -867,18 +841,17 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Returns an index template.
      *
-     * $params['name']                    = (array) A comma-separated list of index template names used to limit the request. Wildcard (`*`) expressions are supported. To return all index templates, omit this parameter or use a value of `_all` or `*`.
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['flat_settings']           = (boolean) If `true`, returns settings in flat format. (Default = false)
-     * $params['local']                   = (boolean) If `true`, the request retrieves information from the local node only. (Default = false)
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: mixed, cluster_manager_timeout?: string, flat_settings?: bool, local?: bool, master_timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name: A comma-separated list of index template names used to limit the request. Wildcard (`*`) expressions are supported. To return all index templates, omit this parameter or use a value of `_all` or `*`.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - flat_settings: If `true`, returns settings in flat format. (Default: false)
+     * - local: If `true`, the request retrieves information from the local node only. (Default: false)
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getTemplate(array $params = [])
@@ -895,17 +868,16 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * The `_upgrade` API is no longer useful and will be removed.
      *
-     * $params['index']              = (array) A comma-separated list of indexes; use `_all` or empty string to perform the operation on all indexes.
-     * $params['allow_no_indices']   = (boolean) Whether to ignore if a wildcard indexes expression resolves into no concrete indexes. (This includes `_all` string or when no indexes have been specified).
-     * $params['expand_wildcards']   = (any) Whether to expand wildcard expression to concrete indexes that are open, closed or both.
-     * $params['ignore_unavailable'] = (boolean) Whether specified concrete indexes should be ignored when unavailable (missing or closed).
-     * $params['pretty']             = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']              = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']        = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']             = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']        = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_no_indices?: bool, expand_wildcards?: mixed, ignore_unavailable?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of indexes; use `_all` or empty string to perform the operation on all indexes.
+     * - allow_no_indices: Whether to ignore if a wildcard indexes expression resolves into no concrete indexes. (This includes `_all` string or when no indexes have been specified).
+     * - expand_wildcards: Whether to expand wildcard expression to concrete indexes that are open, closed or both.
+     * - ignore_unavailable: Whether specified concrete indexes should be ignored when unavailable (missing or closed).
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getUpgrade(array $params = [])
@@ -922,23 +894,22 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Opens an index.
      *
-     * $params['index']                   = (array) A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). By default, you must explicitly name the indexes you using to limit the request. To limit a request using `_all`, `*`, or other wildcard expressions, change the `action.destructive_requires_name` setting to false. You can update this setting in the `opensearch.yml` file or using the cluster update settings API.
-     * $params['allow_no_indices']        = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['expand_wildcards']        = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
-     * $params['ignore_unavailable']      = (boolean) If `false`, the request returns an error if it targets a missing or closed index.
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['task_execution_timeout']  = (string) Explicit task execution timeout, only useful when `wait_for_completion` is false, defaults to `1h`.
-     * $params['timeout']                 = (string) Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['wait_for_active_shards']  = (any) The number of shard copies that must be active before proceeding with the operation. Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
-     * $params['wait_for_completion']     = (boolean) Should this request wait until the operation has completed before returning. (Default = true)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_no_indices?: bool, cluster_manager_timeout?: string, expand_wildcards?: mixed, ignore_unavailable?: bool, master_timeout?: string, task_execution_timeout?: string, timeout?: string, wait_for_active_shards?: mixed, wait_for_completion?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). By default, you must explicitly name the indexes you using to limit the request. To limit a request using `_all`, `*`, or other wildcard expressions, change the `action.destructive_requires_name` setting to false. You can update this setting in the `opensearch.yml` file or using the cluster update settings API.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * - ignore_unavailable: If `false`, the request returns an error if it targets a missing or closed index.
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - task_execution_timeout: Explicit task execution timeout, only useful when `wait_for_completion` is false, defaults to `1h`.
+     * - timeout: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * - wait_for_active_shards: The number of shard copies that must be active before proceeding with the operation. Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+     * - wait_for_completion: Should this request wait until the operation has completed before returning. (Default: true)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function open(array $params = [])
@@ -955,19 +926,18 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Creates or updates an alias.
      *
-     * $params['name']                    = (string) Alias to update. If the alias doesn't exist, the request creates it. Index alias names support date math.
-     * $params['index']                   = (array) A comma-separated list of data streams or indexes to add. Supports wildcards (`*`). Wildcard patterns that match both data streams and indexes return an error.
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['timeout']                 = (string) Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) The settings for the alias, such as `routing` or `filter`
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: string, index?: mixed, cluster_manager_timeout?: string, master_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - name: Alias to update. If the alias doesn't exist, the request creates it. Index alias names support date math.
+     * - index: A comma-separated list of data streams or indexes to add. Supports wildcards (`*`). Wildcard patterns that match both data streams and indexes return an error.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - timeout: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The settings for the alias, such as `routing` or `filter`
      * @return array
      */
     public function putAlias(array $params = [])
@@ -988,19 +958,18 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Creates or updates an index template.
      *
-     * $params['name']                    = (string) Index or template name
-     * $params['cause']                   = (string) User defined reason for creating/updating the index template. (Default = false)
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['create']                  = (boolean) If `true`, this request cannot replace or update existing index templates. (Default = false)
-     * $params['master_timeout']          = (string) Operation timeout for connection to cluster-manager node.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) The template definition (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: string, cause?: string, cluster_manager_timeout?: string, create?: bool, master_timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - name: Index or template name
+     * - cause: User defined reason for creating/updating the index template. (Default: false)
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - create: If `true`, this request cannot replace or update existing index templates. (Default: false)
+     * - master_timeout: Operation timeout for connection to cluster-manager node.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The template definition (Required)
      * @return array
      */
     public function putIndexTemplate(array $params = [])
@@ -1019,22 +988,21 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Updates the index mappings.
      *
-     * $params['index']                   = (array) A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indexes.
-     * $params['allow_no_indices']        = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['expand_wildcards']        = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
-     * $params['ignore_unavailable']      = (boolean) If `false`, the request returns an error if it targets a missing or closed index.
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['timeout']                 = (string) Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['write_index_only']        = (boolean) If `true`, the mappings are applied only to the current write index for the target. (Default = false)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) The mapping definition (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_no_indices?: bool, cluster_manager_timeout?: string, expand_wildcards?: mixed, ignore_unavailable?: bool, master_timeout?: string, timeout?: string, write_index_only?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indexes.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * - ignore_unavailable: If `false`, the request returns an error if it targets a missing or closed index.
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - timeout: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * - write_index_only: If `true`, the mappings are applied only to the current write index for the target. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The mapping definition (Required)
      * @return array
      */
     public function putMapping(array $params = [])
@@ -1053,22 +1021,22 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Updates the index settings.
      *
-     * $params['index']                   = (array) A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
-     * $params['allow_no_indices']        = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['expand_wildcards']        = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`.
-     * $params['flat_settings']           = (boolean) If `true`, returns settings in flat format. (Default = false)
-     * $params['ignore_unavailable']      = (boolean) Whether specified concrete indexes should be ignored when unavailable (missing or closed).
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['preserve_existing']       = (boolean) If `true`, existing index settings remain unchanged. (Default = false)
-     * $params['timeout']                 = (string) Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_no_indices?: bool, cluster_manager_timeout?: string, expand_wildcards?: mixed, flat_settings?: bool, ignore_unavailable?: bool, master_timeout?: string, preserve_existing?: bool, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`.
+     * - flat_settings: If `true`, returns settings in flat format. (Default: false)
+     * - ignore_unavailable: Whether specified concrete indexes should be ignored when unavailable (missing or closed).
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - preserve_existing: If `true`, existing index settings remain unchanged. (Default: false)
+     * - timeout: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function putSettings(array $params = [])
@@ -1087,19 +1055,18 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Creates or updates an index template.
      *
-     * $params['name']                    = (string) The name of the template
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['create']                  = (boolean) If `true`, this request cannot replace or update existing index templates. (Default = false)
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['order']                   = (integer) Order in which OpenSearch applies this template if index matches multiple templates. Templates with lower 'order' values are merged first. Templates with higher 'order' values are merged later, overriding templates with lower values.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) The template definition (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: string, cluster_manager_timeout?: string, create?: bool, master_timeout?: string, order?: int, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - name: The name of the template
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - create: If `true`, this request cannot replace or update existing index templates. (Default: false)
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - order: Order in which OpenSearch applies this template if index matches multiple templates. Templates with lower 'order' values are merged first. Templates with higher 'order' values are merged later, overriding templates with lower values.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The template definition (Required)
      * @return array
      */
     public function putTemplate(array $params = [])
@@ -1118,16 +1085,15 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Returns information about ongoing index shard recoveries.
      *
-     * $params['index']       = (array) A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
-     * $params['active_only'] = (boolean) If `true`, the response only includes ongoing shard recoveries. (Default = false)
-     * $params['detailed']    = (boolean) If `true`, the response includes detailed information about shard recoveries. (Default = false)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, active_only?: bool, detailed?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
+     * - active_only: If `true`, the response only includes ongoing shard recoveries. (Default: false)
+     * - detailed: If `true`, the response includes detailed information about shard recoveries. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function recovery(array $params = [])
@@ -1144,17 +1110,16 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Performs the refresh operation in one or more indexes.
      *
-     * $params['index']              = (array) A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
-     * $params['allow_no_indices']   = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
-     * $params['expand_wildcards']   = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
-     * $params['ignore_unavailable'] = (boolean) If `false`, the request returns an error if it targets a missing or closed index.
-     * $params['pretty']             = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']              = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']        = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']             = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']        = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_no_indices?: bool, expand_wildcards?: mixed, ignore_unavailable?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * - ignore_unavailable: If `false`, the request returns an error if it targets a missing or closed index.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function refresh(array $params = [])
@@ -1171,15 +1136,14 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Returns information about any matching indexes, aliases, and data streams.
      *
-     * $params['name']             = (array) Comma-separated name(s) or index pattern(s) of the indexes, aliases, and data streams to resolve. Resources on remote clusters can be specified using the `<cluster>`:`<name>` syntax.
-     * $params['expand_wildcards'] = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
-     * $params['pretty']           = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']            = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']      = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']           = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']      = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: mixed, expand_wildcards?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name: Comma-separated name(s) or index pattern(s) of the indexes, aliases, and data streams to resolve. Resources on remote clusters can be specified using the `<cluster>`:`<name>` syntax.
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function resolveIndex(array $params = [])
@@ -1196,21 +1160,20 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Updates an alias to point to a new index when the existing indexis considered to be too large or too old.
      *
-     * $params['alias']                   = (string) Name of the data stream or index alias to roll over. (Required)
-     * $params['new_index']               = (string) The name of the index to create. Supports date math. Data streams do not support this parameter.
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['dry_run']                 = (boolean) If `true`, checks whether the current index satisfies the specified conditions but does not perform a rollover. (Default = false)
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['timeout']                 = (string) Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['wait_for_active_shards']  = (any) The number of shard copies that must be active before proceeding with the operation. Set to all or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) The conditions that needs to be met for executing rollover
-     *
-     * @param array $params Associative array of parameters
+     * @param array{alias?: string, new_index?: string, cluster_manager_timeout?: string, dry_run?: bool, master_timeout?: string, timeout?: string, wait_for_active_shards?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - alias: Name of the data stream or index alias to roll over.
+     * - new_index: The name of the index to create. Supports date math. Data streams do not support this parameter.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - dry_run: If `true`, checks whether the current index satisfies the specified conditions but does not perform a rollover. (Default: false)
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - timeout: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * - wait_for_active_shards: The number of shard copies that must be active before proceeding with the operation. Set to all or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The conditions that needs to be met for executing rollover
      * @return array
      */
     public function rollover(array $params = [])
@@ -1231,18 +1194,17 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Provides low-level information about segments in a Lucene index.
      *
-     * $params['index']              = (array) A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
-     * $params['allow_no_indices']   = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
-     * $params['expand_wildcards']   = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
-     * $params['ignore_unavailable'] = (boolean) If `false`, the request returns an error if it targets a missing or closed index.
-     * $params['verbose']            = (boolean) If `true`, the request returns a verbose response. (Default = false)
-     * $params['pretty']             = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']              = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']        = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']             = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']        = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_no_indices?: bool, expand_wildcards?: mixed, ignore_unavailable?: bool, verbose?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * - ignore_unavailable: If `false`, the request returns an error if it targets a missing or closed index.
+     * - verbose: If `true`, the request returns a verbose response. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function segments(array $params = [])
@@ -1259,18 +1221,17 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Provides store information for shard copies of indexes.
      *
-     * $params['index']              = (array) Limits health reporting to a specific source. Can be a single source or a comma-separated list of sources (comprised of data streams, indexes, and aliases).
-     * $params['allow_no_indices']   = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. (Default = false)
-     * $params['expand_wildcards']   = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-     * $params['ignore_unavailable'] = (boolean) If `true`, missing or closed indexes are not included in the response. (Default = false)
-     * $params['status']             = (any) A list of shard health statuses used to limit the request. (Default = yellow,red)
-     * $params['pretty']             = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']              = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']        = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']             = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']        = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_no_indices?: bool, expand_wildcards?: mixed, ignore_unavailable?: bool, status?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: Limits health reporting to a specific source. Can be a single source or a comma-separated list of sources (comprised of data streams, indexes, and aliases).
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes. (Default: false)
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
+     * - ignore_unavailable: If `true`, missing or closed indexes are not included in the response. (Default: false)
+     * - status: A list of shard health statuses used to limit the request. (Default: yellow, red)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function shardStores(array $params = [])
@@ -1287,23 +1248,22 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Allow to shrink an existing index into a new index with fewer primary shards.
      *
-     * $params['index']                   = (string) Name of the source index to shrink.
-     * $params['target']                  = (string) Name of the target index to create.
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['copy_settings']           = (boolean) whether or not to copy settings from the source index. (Default = false)
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['task_execution_timeout']  = (string) Explicit task execution timeout, only useful when `wait_for_completion` is false, defaults to `1h`.
-     * $params['timeout']                 = (string) Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['wait_for_active_shards']  = (any) The number of shard copies that must be active before proceeding with the operation. Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
-     * $params['wait_for_completion']     = (boolean) Should this request wait until the operation has completed before returning. (Default = true)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) The configuration for the target index (`settings` and `aliases`)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, target?: string, cluster_manager_timeout?: string, copy_settings?: bool, master_timeout?: string, task_execution_timeout?: string, timeout?: string, wait_for_active_shards?: mixed, wait_for_completion?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: Name of the source index to shrink.
+     * - target: Name of the target index to create.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - copy_settings: whether or not to copy settings from the source index. (Default: false)
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - task_execution_timeout: Explicit task execution timeout, only useful when `wait_for_completion` is false, defaults to `1h`.
+     * - timeout: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * - wait_for_active_shards: The number of shard copies that must be active before proceeding with the operation. Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+     * - wait_for_completion: Should this request wait until the operation has completed before returning. (Default: true)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The configuration for the target index (`settings` and `aliases`)
      * @return array
      */
     public function shrink(array $params = [])
@@ -1324,17 +1284,16 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Simulate matching the given index name against the index templates in the system.
      *
-     * $params['name']                    = (string) Index or template name to simulate
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) New index template definition, which will be included in the simulation, as if it already exists in the system
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: string, cluster_manager_timeout?: string, master_timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - name: Index or template name to simulate
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: New index template definition, which will be included in the simulation, as if it already exists in the system
      * @return array
      */
     public function simulateIndexTemplate(array $params = [])
@@ -1353,18 +1312,18 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Simulate resolving the given template name or body.
      *
-     * $params['name']                    = (string) The name of the index template to simulate. To test a template configuration before you add it to the cluster, omit this parameter and specify the template configuration in the request body.
-     * $params['cause']                   = (string) User defined reason for dry-run creating the new template for simulation purposes. (Default = false)
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['create']                  = (boolean) If `true`, the template passed in the body is only used if no existing templates match the same index patterns. If `false`, the simulation uses the template with the highest priority. Note that the template is not permanently added or updated in either case; it is only used for the simulation. (Default = false)
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: string, cause?: string, cluster_manager_timeout?: string, create?: bool, master_timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - name: The name of the index template to simulate. To test a template configuration before you add it to the cluster, omit this parameter and specify the template configuration in the request body.
+     * - cause: User defined reason for dry-run creating the new template for simulation purposes. (Default: false)
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - create: If `true`, the template passed in the body is only used if no existing templates match the same index patterns. If `false`, the simulation uses the template with the highest priority. Note that the template is not permanently added or updated in either case; it is only used for the simulation. (Default: false)
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function simulateTemplate(array $params = [])
@@ -1383,23 +1342,22 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Allows you to split an existing index into a new index with more primary shards.
      *
-     * $params['index']                   = (string) Name of the source index to split.
-     * $params['target']                  = (string) Name of the target index to create.
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['copy_settings']           = (boolean) whether or not to copy settings from the source index. (Default = false)
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['task_execution_timeout']  = (string) Explicit task execution timeout, only useful when `wait_for_completion` is false, defaults to `1h`.
-     * $params['timeout']                 = (string) Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['wait_for_active_shards']  = (any) The number of shard copies that must be active before proceeding with the operation. Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
-     * $params['wait_for_completion']     = (boolean) Should this request wait until the operation has completed before returning. (Default = true)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) The configuration for the target index (`settings` and `aliases`)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, target?: string, cluster_manager_timeout?: string, copy_settings?: bool, master_timeout?: string, task_execution_timeout?: string, timeout?: string, wait_for_active_shards?: mixed, wait_for_completion?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: Name of the source index to split.
+     * - target: Name of the target index to create.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - copy_settings: whether or not to copy settings from the source index. (Default: false)
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - task_execution_timeout: Explicit task execution timeout, only useful when `wait_for_completion` is false, defaults to `1h`.
+     * - timeout: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * - wait_for_active_shards: The number of shard copies that must be active before proceeding with the operation. Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+     * - wait_for_completion: Should this request wait until the operation has completed before returning. (Default: true)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The configuration for the target index (`settings` and `aliases`)
      * @return array
      */
     public function split(array $params = [])
@@ -1420,24 +1378,23 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Provides statistics on operations happening in an index.
      *
-     * $params['metric']                     = (array) Limit the information returned the specific metrics.
-     * $params['index']                      = (array) A comma-separated list of index names; use `_all` or empty string to perform the operation on all indexes
-     * $params['completion_fields']          = (any) A comma-separated list or wildcard expressions of fields to include in field data and suggest statistics.
-     * $params['expand_wildcards']           = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`.
-     * $params['fielddata_fields']           = (any) A comma-separated list or wildcard expressions of fields to include in field data statistics.
-     * $params['fields']                     = (any) A comma-separated list or wildcard expressions of fields to include in the statistics.
-     * $params['forbid_closed_indices']      = (boolean) If `true`, statistics are not collected from closed indexes. (Default = true)
-     * $params['groups']                     = (any) A comma-separated list of search groups to include in the search statistics.
-     * $params['include_segment_file_sizes'] = (boolean) If `true`, the call reports the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested). (Default = false)
-     * $params['include_unloaded_segments']  = (boolean) If `true`, the response includes information from segments that are not loaded into memory. (Default = false)
-     * $params['level']                      = (enum) Indicates whether statistics are aggregated at the cluster, index, or shard level. (Options = cluster,indices,shards)
-     * $params['pretty']                     = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                      = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']                = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                     = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']                = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{metric?: mixed, index?: mixed, completion_fields?: mixed, expand_wildcards?: mixed, fielddata_fields?: mixed, fields?: mixed, forbid_closed_indices?: bool, groups?: mixed, include_segment_file_sizes?: bool, include_unloaded_segments?: bool, level?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - metric: Limit the information returned the specific metrics.
+     * - index: A comma-separated list of index names; use `_all` or empty string to perform the operation on all indexes
+     * - completion_fields: A comma-separated list or wildcard expressions of fields to include in field data and suggest statistics.
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`.
+     * - fielddata_fields: A comma-separated list or wildcard expressions of fields to include in field data statistics.
+     * - fields: A comma-separated list or wildcard expressions of fields to include in the statistics.
+     * - forbid_closed_indices: If `true`, statistics are not collected from closed indexes. (Default: true)
+     * - groups: A comma-separated list of search groups to include in the search statistics.
+     * - include_segment_file_sizes: If `true`, the call reports the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested). (Default: false)
+     * - include_unloaded_segments: If `true`, the response includes information from segments that are not loaded into memory. (Default: false)
+     * - level: Indicates whether statistics are aggregated at the cluster, index, or shard level. (Options: cluster, indices, shards)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function stats(array $params = [])
@@ -1456,17 +1413,16 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Updates index aliases.
      *
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['timeout']                 = (string) Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) The definition of `actions` to perform (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{cluster_manager_timeout?: string, master_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - timeout: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The definition of `actions` to perform (Required)
      * @return array
      */
     public function updateAliases(array $params = [])
@@ -1483,19 +1439,18 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * The `_upgrade` API is no longer useful and will be removed.
      *
-     * $params['index']                 = (array) A comma-separated list of indexes; use `_all` or empty string to perform the operation on all indexes.
-     * $params['allow_no_indices']      = (boolean) Whether to ignore if a wildcard indexes expression resolves into no concrete indexes. (This includes `_all` string or when no indexes have been specified).
-     * $params['expand_wildcards']      = (any) Whether to expand wildcard expression to concrete indexes that are open, closed or both.
-     * $params['ignore_unavailable']    = (boolean) Whether specified concrete indexes should be ignored when unavailable (missing or closed).
-     * $params['only_ancient_segments'] = (boolean) If `true`, only ancient (an older Lucene major release) segments will be upgraded.
-     * $params['wait_for_completion']   = (boolean) Should this request wait until the operation has completed before returning. (Default = false)
-     * $params['pretty']                = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                 = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']           = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']           = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, allow_no_indices?: bool, expand_wildcards?: mixed, ignore_unavailable?: bool, only_ancient_segments?: bool, wait_for_completion?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of indexes; use `_all` or empty string to perform the operation on all indexes.
+     * - allow_no_indices: Whether to ignore if a wildcard indexes expression resolves into no concrete indexes. (This includes `_all` string or when no indexes have been specified).
+     * - expand_wildcards: Whether to expand wildcard expression to concrete indexes that are open, closed or both.
+     * - ignore_unavailable: Whether specified concrete indexes should be ignored when unavailable (missing or closed).
+     * - only_ancient_segments: If `true`, only ancient (an older Lucene major release) segments will be upgraded.
+     * - wait_for_completion: Should this request wait until the operation has completed before returning. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function upgrade(array $params = [])
@@ -1512,27 +1467,26 @@ class IndicesNamespace extends AbstractNamespace
     /**
      * Allows a user to validate a potentially expensive query without executing it.
      *
-     * $params['index']              = (array) A comma-separated list of data streams, indexes, and aliases to search. Supports wildcards (`*`). To search all data streams or indexes, omit this parameter or use `*` or `_all`.
-     * $params['all_shards']         = (boolean) If `true`, the validation is executed on all shards instead of one random shard per index.
-     * $params['allow_no_indices']   = (boolean) If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
-     * $params['analyze_wildcard']   = (boolean) If `true`, wildcard and prefix queries are analyzed. (Default = false)
-     * $params['analyzer']           = (string) Analyzer to use for the query string. This parameter can only be used when the `q` query string parameter is specified.
-     * $params['default_operator']   = (enum) The default operator for query string query: `AND` or `OR`. (Options = and,AND,or,OR)
-     * $params['df']                 = (string) Field to use as default where no field prefix is given in the query string. This parameter can only be used when the `q` query string parameter is specified.
-     * $params['expand_wildcards']   = (any) Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
-     * $params['explain']            = (boolean) If `true`, the response returns detailed information if an error has occurred.
-     * $params['ignore_unavailable'] = (boolean) If `false`, the request returns an error if it targets a missing or closed index.
-     * $params['lenient']            = (boolean) If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
-     * $params['q']                  = (string) Query in the Lucene query string syntax.
-     * $params['rewrite']            = (boolean) If `true`, returns a more detailed explanation showing the actual Lucene query that will be executed.
-     * $params['pretty']             = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']              = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']        = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']             = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']        = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']               = (array) The query definition specified with the Query DSL
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, all_shards?: bool, allow_no_indices?: bool, analyze_wildcard?: bool, analyzer?: string, default_operator?: mixed, df?: string, expand_wildcards?: mixed, explain?: bool, ignore_unavailable?: bool, lenient?: bool, q?: string, rewrite?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases to search. Supports wildcards (`*`). To search all data streams or indexes, omit this parameter or use `*` or `_all`.
+     * - all_shards: If `true`, the validation is executed on all shards instead of one random shard per index.
+     * - allow_no_indices: If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indexes. This behavior applies even if the request targets other open indexes.
+     * - analyze_wildcard: If `true`, wildcard and prefix queries are analyzed. (Default: false)
+     * - analyzer: Analyzer to use for the query string. This parameter can only be used when the `q` query string parameter is specified.
+     * - default_operator: The default operator for query string query: `AND` or `OR`. (Options: and, AND, or, OR)
+     * - df: Field to use as default where no field prefix is given in the query string. This parameter can only be used when the `q` query string parameter is specified.
+     * - expand_wildcards: Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * - explain: If `true`, the response returns detailed information if an error has occurred.
+     * - ignore_unavailable: If `false`, the request returns an error if it targets a missing or closed index.
+     * - lenient: If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
+     * - q: Query in the Lucene query string syntax.
+     * - rewrite: If `true`, returns a more detailed explanation showing the actual Lucene query that will be executed.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The query definition specified with the Query DSL
      * @return array
      */
     public function validateQuery(array $params = [])

--- a/src/OpenSearch/Namespaces/IngestNamespace.php
+++ b/src/OpenSearch/Namespaces/IngestNamespace.php
@@ -37,17 +37,16 @@ class IngestNamespace extends AbstractNamespace
     /**
      * Deletes an ingest pipeline.
      *
-     * $params['id']                      = (string) The pipeline ID or wildcard expression of pipeline IDs used to limit the request. To delete all ingest pipelines in a cluster, use a value of `*`.
-     * $params['cluster_manager_timeout'] = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['timeout']                 = (string) The amount of time to wait for a response.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, cluster_manager_timeout?: string, master_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: The pipeline ID or wildcard expression of pipeline IDs used to limit the request. To delete all ingest pipelines in a cluster, use a value of `*`. (Required)
+     * - cluster_manager_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - timeout: The amount of time to wait for a response.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deletePipeline(array $params = [])
@@ -64,16 +63,15 @@ class IngestNamespace extends AbstractNamespace
     /**
      * Returns an ingest pipeline.
      *
-     * $params['id']                      = (string) A comma-separated list of pipeline IDs to retrieve. Wildcard (`*`) expressions are supported. To get all ingest pipelines, omit this parameter or use `*`.
-     * $params['cluster_manager_timeout'] = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, cluster_manager_timeout?: string, master_timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: A comma-separated list of pipeline IDs to retrieve. Wildcard (`*`) expressions are supported. To get all ingest pipelines, omit this parameter or use `*`. (Required)
+     * - cluster_manager_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getPipeline(array $params = [])
@@ -90,14 +88,13 @@ class IngestNamespace extends AbstractNamespace
     /**
      * Returns a list of built-in grok patterns.
      *
-     * $params['s']           = (boolean) Determines how to sort returned grok patterns by key name. (Default = false)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{s?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - s: Determines how to sort returned grok patterns by key name. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function processorGrok(array $params = [])
@@ -111,18 +108,17 @@ class IngestNamespace extends AbstractNamespace
     /**
      * Creates or updates an ingest pipeline.
      *
-     * $params['id']                      = (string) The ID of the ingest pipeline.
-     * $params['cluster_manager_timeout'] = (string) The amount of time allowed to establish a connection to the cluster manager node.
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['timeout']                 = (string) The amount of time to wait for a response.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) The ingest definition. (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, cluster_manager_timeout?: string, master_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - id: The ID of the ingest pipeline. (Required)
+     * - cluster_manager_timeout: The amount of time allowed to establish a connection to the cluster manager node.
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - timeout: The amount of time to wait for a response.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The ingest definition. (Required)
      * @return array
      */
     public function putPipeline(array $params = [])
@@ -141,16 +137,15 @@ class IngestNamespace extends AbstractNamespace
     /**
      * Simulates an ingest pipeline with example documents.
      *
-     * $params['id']          = (string) The pipeline to test. If you don't specify a `pipeline` in the request body, this parameter is required.
-     * $params['verbose']     = (boolean) When `true`, the response includes output data for each processor in the pipeline (Default = false)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']        = (array) The simulate definition (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, verbose?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - id: The pipeline to test. If you don't specify a `pipeline` in the request body, this parameter is required. (Required)
+     * - verbose: When `true`, the response includes output data for each processor in the pipeline (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The simulate definition (Required)
      * @return array
      */
     public function simulate(array $params = [])

--- a/src/OpenSearch/Namespaces/IngestionNamespace.php
+++ b/src/OpenSearch/Namespaces/IngestionNamespace.php
@@ -29,17 +29,16 @@ class IngestionNamespace extends AbstractNamespace
     /**
      * Use this API to retrieve the ingestion state for a given index.
      *
-     * $params['index']       = (string) Index for which ingestion state should be retrieved.
-     * $params['next_token']  = (string) Token to retrieve the next page of results.
-     * $params['size']        = (integer) Number of results to return per page.
-     * $params['timeout']     = (string) Timeout for the request.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, next_token?: string, size?: int, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: Index for which ingestion state should be retrieved.
+     * - next_token: Token to retrieve the next page of results.
+     * - size: Number of results to return per page.
+     * - timeout: Timeout for the request.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getState(array $params = [])
@@ -56,16 +55,15 @@ class IngestionNamespace extends AbstractNamespace
     /**
      * Use this API to pause ingestion for a given index.
      *
-     * $params['index']                   = (string) Index for which ingestion should be paused.
-     * $params['cluster_manager_timeout'] = (string) Time to wait for cluster manager connection.
-     * $params['timeout']                 = (string) Timeout for the request.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, cluster_manager_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: Index for which ingestion should be paused.
+     * - cluster_manager_timeout: Time to wait for cluster manager connection.
+     * - timeout: Timeout for the request.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function pause(array $params = [])
@@ -82,16 +80,16 @@ class IngestionNamespace extends AbstractNamespace
     /**
      * Use this API to resume ingestion for the given index.
      *
-     * $params['index']                   = (string) Index for which ingestion should be resumed.
-     * $params['cluster_manager_timeout'] = (string) Time to wait for cluster manager connection.
-     * $params['timeout']                 = (string) Timeout for the request.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, cluster_manager_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: Index for which ingestion should be resumed.
+     * - cluster_manager_timeout: Time to wait for cluster manager connection.
+     * - timeout: Timeout for the request.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function resume(array $params = [])

--- a/src/OpenSearch/Namespaces/InsightsNamespace.php
+++ b/src/OpenSearch/Namespaces/InsightsNamespace.php
@@ -27,13 +27,12 @@ class InsightsNamespace extends AbstractNamespace
     /**
      * Retrieves the top queries based on the given metric type (latency, CPU, or memory).
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function topQueries(array $params = [])

--- a/src/OpenSearch/Namespaces/IsmNamespace.php
+++ b/src/OpenSearch/Namespaces/IsmNamespace.php
@@ -38,14 +38,14 @@ class IsmNamespace extends AbstractNamespace
     /**
      * Adds a policy to an index.
      *
-     * $params['index']       = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function addPolicy(array $params = [])
@@ -64,14 +64,14 @@ class IsmNamespace extends AbstractNamespace
     /**
      * Updates the managed index policy to a new policy.
      *
-     * $params['index']       = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function changePolicy(array $params = [])
@@ -90,14 +90,13 @@ class IsmNamespace extends AbstractNamespace
     /**
      * Deletes a policy.
      *
-     * $params['policy_id']   = (string)  (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{policy_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - policy_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deletePolicy(array $params = [])
@@ -114,14 +113,13 @@ class IsmNamespace extends AbstractNamespace
     /**
      * Checks for the existence of a policy.
      *
-     * $params['policy_id']   = (string)  (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{policy_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - policy_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return bool
      */
     public function existsPolicy(array $params = []): bool
@@ -142,14 +140,14 @@ class IsmNamespace extends AbstractNamespace
     /**
      * Retrieves the currently applied policy on the specified indexes.
      *
-     * $params['index']       = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function explainPolicy(array $params = [])
@@ -168,13 +166,12 @@ class IsmNamespace extends AbstractNamespace
     /**
      * Retrieves the policies.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getPolicies(array $params = [])
@@ -188,14 +185,13 @@ class IsmNamespace extends AbstractNamespace
     /**
      * Retrieves a specific policy.
      *
-     * $params['policy_id']   = (string)  (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{policy_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - policy_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getPolicy(array $params = [])
@@ -212,16 +208,16 @@ class IsmNamespace extends AbstractNamespace
     /**
      * Creates or updates policies.
      *
-     * $params['if_primary_term'] = (number) Only perform the operation if the document has this primary term.
-     * $params['if_seq_no']       = (integer) Only perform the operation if the document has this sequence number.
-     * $params['policyID']        = (string)
-     * $params['pretty']          = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']           = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']     = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']          = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']     = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{if_primary_term?: int|float, if_seq_no?: int, policyID?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - if_primary_term: Only perform the operation if the document has this primary term.
+     * - if_seq_no: Only perform the operation if the document has this sequence number.
+     * - policyID:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function putPolicies(array $params = [])
@@ -238,16 +234,16 @@ class IsmNamespace extends AbstractNamespace
     /**
      * Creates or updates a policy.
      *
-     * $params['policy_id']       = (string)  (Required)
-     * $params['if_primary_term'] = (number) Only perform the operation if the document has this primary term.
-     * $params['if_seq_no']       = (integer) Only perform the operation if the document has this sequence number.
-     * $params['pretty']          = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']           = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']     = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']          = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']     = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{policy_id?: string, if_primary_term?: int|float, if_seq_no?: int, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - policy_id:
+     * - if_primary_term: Only perform the operation if the document has this primary term.
+     * - if_seq_no: Only perform the operation if the document has this sequence number.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function putPolicy(array $params = [])
@@ -266,14 +262,13 @@ class IsmNamespace extends AbstractNamespace
     /**
      * Refreshes search analyzers in real time.
      *
-     * $params['index']       = (string)  (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function refreshSearchAnalyzers(array $params = [])
@@ -290,14 +285,13 @@ class IsmNamespace extends AbstractNamespace
     /**
      * Removes a policy from an index.
      *
-     * $params['index']       = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function removePolicy(array $params = [])
@@ -314,14 +308,14 @@ class IsmNamespace extends AbstractNamespace
     /**
      * Retries the failed action for an index.
      *
-     * $params['index']       = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function retryIndex(array $params = [])

--- a/src/OpenSearch/Namespaces/KnnNamespace.php
+++ b/src/OpenSearch/Namespaces/KnnNamespace.php
@@ -32,14 +32,13 @@ class KnnNamespace extends AbstractNamespace
     /**
      * Used to delete a particular model in the cluster.
      *
-     * $params['model_id']    = (string) The id of the model.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{model_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - model_id: The id of the model.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteModel(array $params = [])
@@ -56,14 +55,13 @@ class KnnNamespace extends AbstractNamespace
     /**
      * Used to retrieve information about models present in the cluster.
      *
-     * $params['model_id']    = (string) The id of the model.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{model_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - model_id: The id of the model.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getModel(array $params = [])
@@ -80,55 +78,55 @@ class KnnNamespace extends AbstractNamespace
     /**
      * Use an OpenSearch query to search for models in the index.
      *
-     * $params['_source']                       = (array) Set to `true` or `false` to return the `_source` field or not, or a list of fields to return.
-     * $params['_source_excludes']              = (array) List of fields to exclude from the returned `_source` field.
-     * $params['_source_includes']              = (array) List of fields to extract and return from the `_source` field.
-     * $params['allow_no_indices']              = (boolean) Whether to ignore if a wildcard indexes expression resolves into no concrete indexes. (This includes `_all` string or when no indexes have been specified).
-     * $params['allow_partial_search_results']  = (boolean) Indicate if an error should be returned if there is a partial search failure or timeout. (Default = true)
-     * $params['analyze_wildcard']              = (boolean) Specify whether wildcard and prefix queries should be analyzed. (Default = false)
-     * $params['analyzer']                      = (string) The analyzer to use for the query string.
-     * $params['batched_reduce_size']           = (integer) The number of shard results that should be reduced at once on the coordinating node. This value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large. (Default = 512)
-     * $params['ccs_minimize_roundtrips']       = (boolean) Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution. (Default = true)
-     * $params['default_operator']              = (enum) The default operator for query string query (AND or OR). (Options = and,AND,or,OR)
-     * $params['df']                            = (string) The field to use as default where no field prefix is given in the query string.
-     * $params['docvalue_fields']               = (array) A comma-separated list of fields to return as the docvalue representation of a field for each hit.
-     * $params['expand_wildcards']              = (any) Whether to expand wildcard expression to concrete indexes that are open, closed or both.
-     * $params['explain']                       = (boolean) Specify whether to return detailed information about score computation as part of a hit.
-     * $params['from']                          = (integer) Starting offset. (Default = 0)
-     * $params['ignore_throttled']              = (boolean) Whether specified concrete, expanded or aliased indexes should be ignored when throttled.
-     * $params['ignore_unavailable']            = (boolean) Whether specified concrete indexes should be ignored when unavailable (missing or closed).
-     * $params['lenient']                       = (boolean) Specify whether format-based query failures (such as providing text to a numeric field) should be ignored.
-     * $params['max_concurrent_shard_requests'] = (integer) The number of concurrent shard requests per node this search executes concurrently. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests. (Default = 5)
-     * $params['pre_filter_shard_size']         = (integer) Threshold that enforces a pre-filter round-trip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter round-trip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method, that is if date filters are mandatory to match but the shard bounds and the query are disjoint.
-     * $params['preference']                    = (string) Specify the node or shard the operation should be performed on. (Default = random)
-     * $params['q']                             = (string) Query in the Lucene query string syntax.
-     * $params['request_cache']                 = (boolean) Specify if request cache should be used for this request or not, defaults to index level setting.
-     * $params['rest_total_hits_as_int']        = (boolean) Indicates whether `hits.total` should be rendered as an integer or an object in the rest search response. (Default = false)
-     * $params['routing']                       = (any) A comma-separated list of specific routing values.
-     * $params['scroll']                        = (string) Specify how long a consistent view of the index should be maintained for scrolled search.
-     * $params['search_type']                   = (any) Search operation type.
-     * $params['seq_no_primary_term']           = (boolean) Specify whether to return sequence number and primary term of the last modification of each hit.
-     * $params['size']                          = (integer) Number of hits to return. (Default = 10)
-     * $params['sort']                          = (array) A comma-separated list of <field>:<direction> pairs.
-     * $params['stats']                         = (array) Specific 'tag' of the request for logging and statistical purposes.
-     * $params['stored_fields']                 = (array) A comma-separated list of stored fields to return.
-     * $params['suggest_field']                 = (string) Specify which field to use for suggestions.
-     * $params['suggest_mode']                  = (enum) Specify suggest mode. (Options = always,missing,popular)
-     * $params['suggest_size']                  = (integer) How many suggestions to return in response.
-     * $params['suggest_text']                  = (string) The source text for which the suggestions should be returned.
-     * $params['terminate_after']               = (integer) The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.
-     * $params['timeout']                       = (string) Operation timeout.
-     * $params['track_scores']                  = (boolean) Whether to calculate and return scores even if they are not used for sorting.
-     * $params['track_total_hits']              = (boolean) Indicate if the number of documents that match the query should be tracked.
-     * $params['typed_keys']                    = (boolean) Specify whether aggregation and suggester names should be prefixed by their respective types in the response.
-     * $params['version']                       = (boolean) Whether to return document version as part of a hit.
-     * $params['pretty']                        = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                         = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']                   = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                        = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']                   = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{_source?: mixed, _source_excludes?: mixed, _source_includes?: mixed, allow_no_indices?: bool, allow_partial_search_results?: bool, analyze_wildcard?: bool, analyzer?: string, batched_reduce_size?: int, ccs_minimize_roundtrips?: bool, default_operator?: mixed, df?: string, docvalue_fields?: mixed, expand_wildcards?: mixed, explain?: bool, from?: int, ignore_throttled?: bool, ignore_unavailable?: bool, lenient?: bool, max_concurrent_shard_requests?: int, pre_filter_shard_size?: int, preference?: string, q?: string, request_cache?: bool, rest_total_hits_as_int?: bool, routing?: mixed, scroll?: string, search_type?: mixed, seq_no_primary_term?: bool, size?: int, sort?: mixed, stats?: mixed, stored_fields?: mixed, suggest_field?: string, suggest_mode?: mixed, suggest_size?: int, suggest_text?: string, terminate_after?: int, timeout?: string, track_scores?: bool, track_total_hits?: bool, typed_keys?: bool, version?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - _source: Set to `true` or `false` to return the `_source` field or not, or a list of fields to return.
+     * - _source_excludes: List of fields to exclude from the returned `_source` field.
+     * - _source_includes: List of fields to extract and return from the `_source` field.
+     * - allow_no_indices: Whether to ignore if a wildcard indexes expression resolves into no concrete indexes. (This includes `_all` string or when no indexes have been specified).
+     * - allow_partial_search_results: Indicate if an error should be returned if there is a partial search failure or timeout. (Default: true)
+     * - analyze_wildcard: Specify whether wildcard and prefix queries should be analyzed. (Default: false)
+     * - analyzer: The analyzer to use for the query string.
+     * - batched_reduce_size: The number of shard results that should be reduced at once on the coordinating node. This value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large. (Default: 512)
+     * - ccs_minimize_roundtrips: Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution. (Default: true)
+     * - default_operator: The default operator for query string query (AND or OR). (Options: and, AND, or, OR)
+     * - df: The field to use as default where no field prefix is given in the query string.
+     * - docvalue_fields: A comma-separated list of fields to return as the docvalue representation of a field for each hit.
+     * - expand_wildcards: Whether to expand wildcard expression to concrete indexes that are open, closed or both.
+     * - explain: Specify whether to return detailed information about score computation as part of a hit.
+     * - from: Starting offset. (Default: 0)
+     * - ignore_throttled: Whether specified concrete, expanded or aliased indexes should be ignored when throttled.
+     * - ignore_unavailable: Whether specified concrete indexes should be ignored when unavailable (missing or closed).
+     * - lenient: Specify whether format-based query failures (such as providing text to a numeric field) should be ignored.
+     * - max_concurrent_shard_requests: The number of concurrent shard requests per node this search executes concurrently. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests. (Default: 5)
+     * - pre_filter_shard_size: Threshold that enforces a pre-filter round-trip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter round-trip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method, that is if date filters are mandatory to match but the shard bounds and the query are disjoint.
+     * - preference: Specify the node or shard the operation should be performed on. (Default: random)
+     * - q: Query in the Lucene query string syntax.
+     * - request_cache: Specify if request cache should be used for this request or not, defaults to index level setting.
+     * - rest_total_hits_as_int: Indicates whether `hits.total` should be rendered as an integer or an object in the rest search response. (Default: false)
+     * - routing: A comma-separated list of specific routing values.
+     * - scroll: Specify how long a consistent view of the index should be maintained for scrolled search.
+     * - search_type: Search operation type.
+     * - seq_no_primary_term: Specify whether to return sequence number and primary term of the last modification of each hit.
+     * - size: Number of hits to return. (Default: 10)
+     * - sort: A comma-separated list of <field>:<direction> pairs.
+     * - stats: Specific 'tag' of the request for logging and statistical purposes.
+     * - stored_fields: A comma-separated list of stored fields to return.
+     * - suggest_field: Specify which field to use for suggestions.
+     * - suggest_mode: Specify suggest mode. (Options: always, missing, popular)
+     * - suggest_size: How many suggestions to return in response.
+     * - suggest_text: The source text for which the suggestions should be returned.
+     * - terminate_after: The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.
+     * - timeout: Operation timeout.
+     * - track_scores: Whether to calculate and return scores even if they are not used for sorting.
+     * - track_total_hits: Indicate if the number of documents that match the query should be tracked.
+     * - typed_keys: Specify whether aggregation and suggester names should be prefixed by their respective types in the response.
+     * - version: Whether to return document version as part of a hit.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function searchModels(array $params = [])
@@ -145,16 +143,15 @@ class KnnNamespace extends AbstractNamespace
     /**
      * Provides information about the current status of the k-NN plugin.
      *
-     * $params['node_id']     = (array) A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.
-     * $params['stat']        = (array) A comma-separated list of stats to retrieve; use `_all` or empty string to retrieve all stats.
-     * $params['timeout']     = (string) Operation timeout.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{node_id?: mixed, stat?: mixed, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - node_id: A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.
+     * - stat: A comma-separated list of stats to retrieve; use `_all` or empty string to retrieve all stats.
+     * - timeout: Operation timeout.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function stats(array $params = [])
@@ -173,15 +170,15 @@ class KnnNamespace extends AbstractNamespace
     /**
      * Create and train a model that can be used for initializing k-NN native library indexes during indexing.
      *
-     * $params['model_id']    = (string) The id of the model.
-     * $params['preference']  = (string) Preferred node to execute training.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{model_id?: string, preference?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - model_id: The id of the model.
+     * - preference: Preferred node to execute training.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function trainModel(array $params = [])
@@ -200,14 +197,13 @@ class KnnNamespace extends AbstractNamespace
     /**
      * Preloads native library files into memory, reducing initial search latency for specified indexes.
      *
-     * $params['index']       = (array) A comma-separated list of indexes; use `_all` or empty string to perform the operation on all indexes. (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of indexes; use `_all` or empty string to perform the operation on all indexes.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function warmup(array $params = [])

--- a/src/OpenSearch/Namespaces/ListNamespace.php
+++ b/src/OpenSearch/Namespaces/ListNamespace.php
@@ -29,13 +29,12 @@ class ListNamespace extends AbstractNamespace
     /**
      * Returns help for the List APIs.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function help(array $params = [])
@@ -49,31 +48,30 @@ class ListNamespace extends AbstractNamespace
     /**
      * Returns paginated information about indexes including number of primaries and replicas, document counts, disk size.
      *
-     * $params['index']                     = (array) A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
-     * $params['bytes']                     = (any) The unit used to display byte values.
-     * $params['cluster_manager_timeout']   = (string) Operation timeout for connection to cluster-manager node.
-     * $params['expand_wildcards']          = (any) The type of index that wildcard patterns can match.
-     * $params['format']                    = (string) A short version of the Accept header, such as `JSON`, `YAML`.
-     * $params['h']                         = (array) A comma-separated list of column names to display.
-     * $params['health']                    = (any) The health status used to limit returned indexes. By default, the response includes indexes of any health status.
-     * $params['help']                      = (boolean) Return help information. (Default = false)
-     * $params['include_unloaded_segments'] = (boolean) If `true`, the response includes information from segments that are not loaded into memory. (Default = false)
-     * $params['local']                     = (boolean) Return local information, do not retrieve the state from cluster-manager node. (Default = false)
-     * $params['master_timeout']            = (string) Operation timeout for connection to cluster-manager node.
-     * $params['next_token']                = (null|string) Token to retrieve next page of indexes.
-     * $params['pri']                       = (boolean) If `true`, the response only includes information from primary shards. (Default = false)
-     * $params['s']                         = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['size']                      = (integer) Maximum number of indexes to be displayed in a page.
-     * $params['sort']                      = (enum) Defines order in which indexes will be displayed. Accepted values are `asc` and `desc`. If `desc`, most recently created indexes would be displayed first. (Options = asc,desc)
-     * $params['time']                      = (any) The unit used to display time values.
-     * $params['v']                         = (boolean) Verbose mode. Display column headers. (Default = false)
-     * $params['pretty']                    = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                     = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']               = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                    = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']               = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, bytes?: mixed, cluster_manager_timeout?: string, expand_wildcards?: mixed, format?: string, h?: mixed, health?: mixed, help?: bool, include_unloaded_segments?: bool, local?: bool, master_timeout?: string, next_token?: array, pri?: bool, s?: mixed, size?: int, sort?: mixed, time?: mixed, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
+     * - bytes: The unit used to display byte values.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - expand_wildcards: The type of index that wildcard patterns can match.
+     * - format: A short version of the Accept header, such as `JSON`, `YAML`.
+     * - h: A comma-separated list of column names to display.
+     * - health: The health status used to limit returned indexes. By default, the response includes indexes of any health status.
+     * - help: Return help information. (Default: false)
+     * - include_unloaded_segments: If `true`, the response includes information from segments that are not loaded into memory. (Default: false)
+     * - local: Return local information, do not retrieve the state from cluster-manager node. (Default: false)
+     * - master_timeout: Operation timeout for connection to cluster-manager node.
+     * - next_token: Token to retrieve next page of indexes.
+     * - pri: If `true`, the response only includes information from primary shards. (Default: false)
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - size: Maximum number of indexes to be displayed in a page.
+     * - sort: Defines order in which indexes will be displayed. Accepted values are `asc` and `desc`. If `desc`, most recently created indexes would be displayed first. (Options: asc, desc)
+     * - time: The unit used to display time values.
+     * - v: Verbose mode. Display column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function indices(array $params = [])
@@ -90,27 +88,26 @@ class ListNamespace extends AbstractNamespace
     /**
      * Returns paginated details of shard allocation on nodes.
      *
-     * $params['index']                   = (array) A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
-     * $params['bytes']                   = (any) The unit used to display byte values.
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['format']                  = (string) A short version of the Accept header, such as `JSON`, `YAML`.
-     * $params['h']                       = (array) A comma-separated list of column names to display.
-     * $params['help']                    = (boolean) Return help information. (Default = false)
-     * $params['local']                   = (boolean) Return local information, do not retrieve the state from cluster-manager node. (Default = false)
-     * $params['master_timeout']          = (string) Operation timeout for connection to cluster-manager node.
-     * $params['next_token']              = (null|string) Token to retrieve next page of shards.
-     * $params['s']                       = (array) A comma-separated list of column names or column aliases to sort by.
-     * $params['size']                    = (integer) Maximum number of shards to be displayed in a page.
-     * $params['sort']                    = (enum) Defines order in which shards will be displayed. Accepted values are `asc` and `desc`. If `desc`, most recently created shards would be displayed first. (Options = asc,desc)
-     * $params['time']                    = (any) The unit in which to display time values.
-     * $params['v']                       = (boolean) Verbose mode. Display column headers. (Default = false)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: mixed, bytes?: mixed, cluster_manager_timeout?: string, format?: string, h?: mixed, help?: bool, local?: bool, master_timeout?: string, next_token?: array, s?: mixed, size?: int, sort?: mixed, time?: mixed, v?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`.
+     * - bytes: The unit used to display byte values.
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - format: A short version of the Accept header, such as `JSON`, `YAML`.
+     * - h: A comma-separated list of column names to display.
+     * - help: Return help information. (Default: false)
+     * - local: Return local information, do not retrieve the state from cluster-manager node. (Default: false)
+     * - master_timeout: Operation timeout for connection to cluster-manager node.
+     * - next_token: Token to retrieve next page of shards.
+     * - s: A comma-separated list of column names or column aliases to sort by.
+     * - size: Maximum number of shards to be displayed in a page.
+     * - sort: Defines order in which shards will be displayed. Accepted values are `asc` and `desc`. If `desc`, most recently created shards would be displayed first. (Options: asc, desc)
+     * - time: The unit in which to display time values.
+     * - v: Verbose mode. Display column headers. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function shards(array $params = [])

--- a/src/OpenSearch/Namespaces/LtrNamespace.php
+++ b/src/OpenSearch/Namespaces/LtrNamespace.php
@@ -52,18 +52,18 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Add features to an existing feature set in the default feature store.
      *
-     * $params['name']        = (string) The name of the feature set to add features to. (Required)
-     * $params['store']       = (string) The name of the feature store.
-     * $params['merge']       = (boolean) Whether to merge the feature list or append only. (Default = false)
-     * $params['routing']     = (string) Specific routing value.
-     * $params['version']     = (integer) Version check to ensure feature set is modified with expected version.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: string, store?: string, merge?: bool, routing?: string, version?: int, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - name: The name of the feature set to add features to.
+     * - store: The name of the feature store.
+     * - merge: Whether to merge the feature list or append only. (Default: false)
+     * - routing: Specific routing value.
+     * - version: Version check to ensure feature set is modified with expected version.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function addFeaturesToSet(array $params = [])
@@ -84,19 +84,18 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Add features to an existing feature set in the default feature store.
      *
-     * $params['name']        = (string) The name of the feature set to add features to. (Required)
-     * $params['query']       = (string) Query string to filter existing features from the store by name. When provided, only features matching this query will be added to the feature set, and no request body should be included. (Required)
-     * $params['store']       = (string) The name of the feature store.
-     * $params['merge']       = (boolean) Whether to merge the feature list or append only. (Default = false)
-     * $params['routing']     = (string) Specific routing value.
-     * $params['version']     = (integer) Version check to ensure feature set is modified with expected version.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: string, query?: string, store?: string, merge?: bool, routing?: string, version?: int, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name: The name of the feature set to add features to.
+     * - query: Query string to filter existing features from the store by name. When provided, only features matching this query will be added to the feature set, and no request body should be included.
+     * - store: The name of the feature store.
+     * - merge: Whether to merge the feature list or append only. (Default: false)
+     * - routing: Specific routing value.
+     * - version: Version check to ensure feature set is modified with expected version.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function addFeaturesToSetByQuery(array $params = [])
@@ -117,13 +116,12 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Retrieves cache statistics for all feature stores.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function cacheStats(array $params = [])
@@ -137,14 +135,13 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Clears the store caches.
      *
-     * $params['store']       = (string) The name of the feature store for which to clear the cache.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{store?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - store: The name of the feature store for which to clear the cache.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function clearCache(array $params = [])
@@ -161,13 +158,12 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Creates the default feature store.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function createDefaultStore(array $params = [])
@@ -181,16 +177,16 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Create or update a feature in the default feature store.
      *
-     * $params['id']          = (string) The name of the feature. (Required)
-     * $params['store']       = (string) The name of the feature store.
-     * $params['routing']     = (string) Specific routing value.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, store?: string, routing?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - id: The name of the feature. (Required)
+     * - store: The name of the feature store.
+     * - routing: Specific routing value.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function createFeature(array $params = [])
@@ -211,16 +207,16 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Create or update a feature set in the default feature store.
      *
-     * $params['id']          = (string) The name of the feature set. (Required)
-     * $params['store']       = (string) The name of the feature store.
-     * $params['routing']     = (string) Specific routing value.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, store?: string, routing?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - id: The name of the feature set. (Required)
+     * - store: The name of the feature store.
+     * - routing: Specific routing value.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function createFeatureset(array $params = [])
@@ -241,16 +237,16 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Create or update a model in the default feature store.
      *
-     * $params['id']          = (string) The name of the model. (Required)
-     * $params['store']       = (string) The name of the feature store.
-     * $params['routing']     = (string) Specific routing value.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, store?: string, routing?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - id: The name of the model. (Required)
+     * - store: The name of the feature store.
+     * - routing: Specific routing value.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function createModel(array $params = [])
@@ -271,16 +267,16 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Create a model from an existing feature set in the default feature store.
      *
-     * $params['name']        = (string) The name of the feature set to use for creating the model. (Required)
-     * $params['store']       = (string) The name of the feature store.
-     * $params['routing']     = (string) Specific routing value.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: string, store?: string, routing?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - name: The name of the feature set to use for creating the model.
+     * - store: The name of the feature store.
+     * - routing: Specific routing value.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function createModelFromSet(array $params = [])
@@ -301,14 +297,13 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Creates a new feature store with the specified name.
      *
-     * $params['store']       = (string) The name of the feature store.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{store?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - store: The name of the feature store.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function createStore(array $params = [])
@@ -325,13 +320,12 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Deletes the default feature store.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteDefaultStore(array $params = [])
@@ -345,15 +339,14 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Delete a feature from the default feature store.
      *
-     * $params['id']          = (string) The name of the feature. (Required)
-     * $params['store']       = (string) The name of the feature store.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, store?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: The name of the feature. (Required)
+     * - store: The name of the feature store.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteFeature(array $params = [])
@@ -372,15 +365,14 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Delete a feature set from the default feature store.
      *
-     * $params['id']          = (string) The name of the feature set. (Required)
-     * $params['store']       = (string) The name of the feature store.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, store?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: The name of the feature set. (Required)
+     * - store: The name of the feature store.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteFeatureset(array $params = [])
@@ -399,15 +391,14 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Delete a model from the default feature store.
      *
-     * $params['id']          = (string) The name of the model. (Required)
-     * $params['store']       = (string) The name of the feature store.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, store?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: The name of the model. (Required)
+     * - store: The name of the feature store.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteModel(array $params = [])
@@ -426,14 +417,13 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Deletes a feature store with the specified name.
      *
-     * $params['store']       = (string) The name of the feature store.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{store?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - store: The name of the feature store.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteStore(array $params = [])
@@ -450,15 +440,14 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Get a feature from the default feature store.
      *
-     * $params['id']          = (string) The name of the feature. (Required)
-     * $params['store']       = (string) The name of the feature store.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, store?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: The name of the feature. (Required)
+     * - store: The name of the feature store.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getFeature(array $params = [])
@@ -477,15 +466,14 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Get a feature set from the default feature store.
      *
-     * $params['id']          = (string) The name of the feature set. (Required)
-     * $params['store']       = (string) The name of the feature store.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, store?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: The name of the feature set. (Required)
+     * - store: The name of the feature store.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getFeatureset(array $params = [])
@@ -504,15 +492,14 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Get a model from the default feature store.
      *
-     * $params['id']          = (string) The name of the model. (Required)
-     * $params['store']       = (string) The name of the feature store.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, store?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: The name of the model. (Required)
+     * - store: The name of the feature store.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getModel(array $params = [])
@@ -531,14 +518,13 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Checks if a store exists.
      *
-     * $params['store']       = (string) The name of the feature store.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{store?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - store: The name of the feature store.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getStore(array $params = [])
@@ -555,13 +541,12 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Lists all available feature stores.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function listStores(array $params = [])
@@ -575,17 +560,16 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Search for features in a feature store.
      *
-     * $params['store']       = (string) The name of the feature store.
-     * $params['from']        = (integer) The offset from the first result (for pagination). (Default = 0)
-     * $params['prefix']      = (string) A name prefix to filter features by.
-     * $params['size']        = (integer) The number of features to return. (Default = 20)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{store?: string, from?: int, prefix?: string, size?: int, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - store: The name of the feature store.
+     * - from: The offset from the first result (for pagination). (Default: 0)
+     * - prefix: A name prefix to filter features by.
+     * - size: The number of features to return. (Default: 20)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function searchFeatures(array $params = [])
@@ -602,17 +586,16 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Search for feature sets in a feature store.
      *
-     * $params['store']       = (string) The name of the feature store.
-     * $params['from']        = (integer) The offset from the first result (for pagination). (Default = 0)
-     * $params['prefix']      = (string) A name prefix to filter feature sets by.
-     * $params['size']        = (integer) The number of feature sets to return. (Default = 20)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{store?: string, from?: int, prefix?: string, size?: int, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - store: The name of the feature store.
+     * - from: The offset from the first result (for pagination). (Default: 0)
+     * - prefix: A name prefix to filter feature sets by.
+     * - size: The number of feature sets to return. (Default: 20)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function searchFeaturesets(array $params = [])
@@ -629,17 +612,16 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Search for models in a feature store.
      *
-     * $params['store']       = (string) The name of the feature store.
-     * $params['from']        = (integer) The offset from the first result (for pagination). (Default = 0)
-     * $params['prefix']      = (string) A name prefix to filter models by.
-     * $params['size']        = (integer) The number of models to return. (Default = 20)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{store?: string, from?: int, prefix?: string, size?: int, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - store: The name of the feature store.
+     * - from: The offset from the first result (for pagination). (Default: 0)
+     * - prefix: A name prefix to filter models by.
+     * - size: The number of models to return. (Default: 20)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function searchModels(array $params = [])
@@ -656,16 +638,15 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Provides information about the current status of the LTR plugin.
      *
-     * $params['node_id']     = (array) A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.
-     * $params['stat']        = (array) A comma-separated list of stats to retrieve; use `_all` or empty string to retrieve all stats.
-     * $params['timeout']     = (string) The time in milliseconds to wait for a response.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{node_id?: mixed, stat?: mixed, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - node_id: A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.
+     * - stat: A comma-separated list of stats to retrieve; use `_all` or empty string to retrieve all stats.
+     * - timeout: The time in milliseconds to wait for a response.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function stats(array $params = [])
@@ -684,16 +665,16 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Update a feature in the default feature store.
      *
-     * $params['id']          = (string) The name of the feature. (Required)
-     * $params['store']       = (string) The name of the feature store.
-     * $params['routing']     = (string) Specific routing value.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, store?: string, routing?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - id: The name of the feature. (Required)
+     * - store: The name of the feature store.
+     * - routing: Specific routing value.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function updateFeature(array $params = [])
@@ -714,16 +695,16 @@ class LtrNamespace extends AbstractNamespace
     /**
      * Update a feature set in the default feature store.
      *
-     * $params['id']          = (string) The name of the feature set. (Required)
-     * $params['store']       = (string) The name of the feature store.
-     * $params['routing']     = (string) Specific routing value.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, store?: string, routing?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - id: The name of the feature set. (Required)
+     * - store: The name of the feature store.
+     * - routing: Specific routing value.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function updateFeatureset(array $params = [])

--- a/src/OpenSearch/Namespaces/MlNamespace.php
+++ b/src/OpenSearch/Namespaces/MlNamespace.php
@@ -102,14 +102,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Add agentic memory to a memory container.
      *
-     * $params['memory_container_id'] = (string)
-     * $params['pretty']              = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']               = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']         = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']              = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']         = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{memory_container_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - memory_container_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function addAgenticMemory(array $params = [])
@@ -128,15 +128,15 @@ class MlNamespace extends AbstractNamespace
     /**
      * Uploads model chunk.
      *
-     * $params['chunk_number'] = (integer)
-     * $params['model_id']     = (string)
-     * $params['pretty']       = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']        = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']  = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']       = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']  = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{chunk_number?: int, model_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - chunk_number:
+     * - model_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function chunkModel(array $params = [])
@@ -157,14 +157,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Creates a controller.
      *
-     * $params['model_id']    = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{model_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - model_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function createController(array $params = [])
@@ -183,13 +183,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Create a memory.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function createMemory(array $params = [])
@@ -206,13 +206,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Create a memory container.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function createMemoryContainer(array $params = [])
@@ -229,14 +229,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Create session in a memory container.
      *
-     * $params['memory_container_id'] = (string)
-     * $params['pretty']              = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']               = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']         = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']              = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']         = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{memory_container_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - memory_container_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function createMemoryContainerSession(array $params = [])
@@ -255,14 +255,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Create a message.
      *
-     * $params['memory_id']   = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{memory_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - memory_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function createMessage(array $params = [])
@@ -281,13 +281,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Registers model metadata.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function createModelMeta(array $params = [])
@@ -304,14 +304,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Delete an agent.
      *
-     * $params['agent_id']    = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{agent_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - agent_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteAgent(array $params = [])
@@ -328,16 +327,15 @@ class MlNamespace extends AbstractNamespace
     /**
      * Delete a specific memory by its type and ID.
      *
-     * $params['id']                  = (string)
-     * $params['memory_container_id'] = (string)
-     * $params['type']                = DEPRECATED (string)
-     * $params['pretty']              = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']               = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']         = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']              = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']         = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, memory_container_id?: string, type?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: (Required)
+     * - memory_container_id:
+     * - type:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteAgenticMemory(array $params = [])
@@ -358,15 +356,15 @@ class MlNamespace extends AbstractNamespace
     /**
      * Delete multiple memories using a query to match specific criteria.
      *
-     * $params['memory_container_id'] = (string)
-     * $params['type']                = DEPRECATED (string)
-     * $params['pretty']              = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']               = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']         = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']              = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']         = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{memory_container_id?: string, type?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - memory_container_id:
+     * - type:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function deleteAgenticMemoryQuery(array $params = [])
@@ -387,14 +385,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Deletes a controller.
      *
-     * $params['model_id']    = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{model_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - model_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteController(array $params = [])
@@ -411,14 +408,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Delete a memory.
      *
-     * $params['memory_id']   = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{memory_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - memory_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteMemory(array $params = [])
@@ -435,16 +431,15 @@ class MlNamespace extends AbstractNamespace
     /**
      * Delete a memory container.
      *
-     * $params['memory_container_id'] = (string)
-     * $params['delete_all_memories'] = (boolean)  (Default = false)
-     * $params['delete_memories']     = (array)
-     * $params['pretty']              = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']               = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']         = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']              = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']         = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{memory_container_id?: string, delete_all_memories?: bool, delete_memories?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - memory_container_id:
+     * - delete_all_memories: (Default: false)
+     * - delete_memories:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteMemoryContainer(array $params = [])
@@ -461,14 +456,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Deletes a model.
      *
-     * $params['id']          = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: (Required)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteModel(array $params = [])
@@ -485,14 +479,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Deletes a model group.
      *
-     * $params['id']          = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: (Required)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteModelGroup(array $params = [])
@@ -509,14 +502,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Deletes a task.
      *
-     * $params['task_id']     = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{task_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - task_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteTask(array $params = [])
@@ -533,14 +525,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Execute an agent.
      *
-     * $params['agent_id']    = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{agent_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - agent_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function executeAgent(array $params = [])
@@ -559,14 +551,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Execute an agent in streaming mode.
      *
-     * $params['agent_id']    = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{agent_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - agent_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function executeAgentStream(array $params = [])
@@ -585,14 +577,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Execute an algorithm.
      *
-     * $params['algorithm_name'] = (string)
-     * $params['pretty']         = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']          = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']    = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']         = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']    = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{algorithm_name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - algorithm_name:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function executeAlgorithm(array $params = [])
@@ -611,14 +603,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Execute a tool.
      *
-     * $params['tool_name']   = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{tool_name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - tool_name:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function executeTool(array $params = [])
@@ -637,14 +629,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Get an agent.
      *
-     * $params['agent_id']    = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{agent_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - agent_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getAgent(array $params = [])
@@ -661,16 +652,15 @@ class MlNamespace extends AbstractNamespace
     /**
      * Get a specific memory by its type and ID.
      *
-     * $params['id']                  = (string)
-     * $params['memory_container_id'] = (string)
-     * $params['type']                = DEPRECATED (string)
-     * $params['pretty']              = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']               = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']         = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']              = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']         = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, memory_container_id?: string, type?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: (Required)
+     * - memory_container_id:
+     * - type:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getAgenticMemory(array $params = [])
@@ -691,15 +681,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Get all memories.
      *
-     * $params['max_results'] = (integer)
-     * $params['next_token']  = (integer)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{max_results?: int, next_token?: int, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - max_results:
+     * - next_token:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getAllMemories(array $params = [])
@@ -713,16 +702,15 @@ class MlNamespace extends AbstractNamespace
     /**
      * Get all messages in a memory.
      *
-     * $params['memory_id']   = (string)
-     * $params['max_results'] = (integer)
-     * $params['next_token']  = (integer)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{memory_id?: string, max_results?: int, next_token?: int, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - memory_id:
+     * - max_results:
+     * - next_token:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getAllMessages(array $params = [])
@@ -739,13 +727,12 @@ class MlNamespace extends AbstractNamespace
     /**
      * Get tools.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getAllTools(array $params = [])
@@ -759,14 +746,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Retrieves a controller.
      *
-     * $params['model_id']    = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{model_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - model_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getController(array $params = [])
@@ -783,14 +769,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Get a memory.
      *
-     * $params['memory_id']   = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{memory_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - memory_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getMemory(array $params = [])
@@ -807,14 +792,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Get a memory container.
      *
-     * $params['memory_container_id'] = (string)
-     * $params['pretty']              = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']               = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']         = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']              = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']         = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{memory_container_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - memory_container_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getMemoryContainer(array $params = [])
@@ -831,14 +815,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Get a message.
      *
-     * $params['message_id']  = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{message_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - message_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getMessage(array $params = [])
@@ -855,16 +838,15 @@ class MlNamespace extends AbstractNamespace
     /**
      * Get a message traces.
      *
-     * $params['message_id']  = (string)
-     * $params['max_results'] = (integer)
-     * $params['next_token']  = (integer)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{message_id?: string, max_results?: int, next_token?: int, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - message_id:
+     * - max_results:
+     * - next_token:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getMessageTraces(array $params = [])
@@ -881,14 +863,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Retrieves a model group.
      *
-     * $params['model_group_id'] = (string)
-     * $params['pretty']         = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']          = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']    = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']         = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']    = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{model_group_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - model_group_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getModelGroup(array $params = [])
@@ -905,13 +886,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Get a profile.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function getProfile(array $params = [])
@@ -928,14 +909,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Get a profile models.
      *
-     * $params['model_id']    = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{model_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - model_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function getProfileModels(array $params = [])
@@ -954,14 +935,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Get a profile tasks.
      *
-     * $params['task_id']     = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{task_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - task_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function getProfileTasks(array $params = [])
@@ -980,15 +961,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Get stats.
      *
-     * $params['node_id']     = (string)
-     * $params['stat']        = (array)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{node_id?: string, stat?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - node_id:
+     * - stat:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getStats(array $params = [])
@@ -1007,14 +987,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Retrieves a task.
      *
-     * $params['id']          = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: (Required)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getTask(array $params = [])
@@ -1031,14 +1010,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Get tools.
      *
-     * $params['tool_name']   = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{tool_name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - tool_name:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getTool(array $params = [])
@@ -1055,14 +1033,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Deploys a model.
      *
-     * $params['model_id']    = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{model_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - model_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function loadModel(array $params = [])
@@ -1079,14 +1056,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Predicts a model.
      *
-     * $params['model_id']    = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{model_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - model_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function predictModel(array $params = [])
@@ -1105,14 +1082,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Predicts a model in streaming mode.
      *
-     * $params['model_id']    = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{model_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - model_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function predictModelStream(array $params = [])
@@ -1131,13 +1108,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Register an agent.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function registerAgents(array $params = [])
@@ -1154,13 +1131,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Registers a model.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function registerModel(array $params = [])
@@ -1177,13 +1154,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Registers a model group.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function registerModelGroup(array $params = [])
@@ -1200,13 +1177,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Registers model metadata.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function registerModelMeta(array $params = [])
@@ -1223,15 +1200,15 @@ class MlNamespace extends AbstractNamespace
     /**
      * Search for memories of a specific type within a memory container.
      *
-     * $params['memory_container_id'] = (string)
-     * $params['type']                = DEPRECATED (string)
-     * $params['pretty']              = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']               = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']         = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']              = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']         = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{memory_container_id?: string, type?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - memory_container_id:
+     * - type:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function searchAgenticMemory(array $params = [])
@@ -1252,13 +1229,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Search agents.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function searchAgents(array $params = [])
@@ -1275,13 +1252,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Searches for standalone connectors.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function searchConnectors(array $params = [])
@@ -1298,13 +1275,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Search memory.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function searchMemory(array $params = [])
@@ -1321,13 +1298,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Search memory containers.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function searchMemoryContainer(array $params = [])
@@ -1344,14 +1321,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Search messages.
      *
-     * $params['memory_id']   = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{memory_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - memory_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function searchMessage(array $params = [])
@@ -1370,13 +1347,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Searches for model groups.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function searchModelGroup(array $params = [])
@@ -1393,13 +1370,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Searches for models.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function searchModels(array $params = [])
@@ -1416,13 +1393,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Searches for tasks.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function searchTasks(array $params = [])
@@ -1439,14 +1416,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Trains a model synchronously.
      *
-     * $params['algorithm_name'] = (string)
-     * $params['pretty']         = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']          = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']    = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']         = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']    = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{algorithm_name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - algorithm_name:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function train(array $params = [])
@@ -1465,14 +1442,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Trains a model and predicts against the same training dataset.
      *
-     * $params['algorithm_name'] = (string)
-     * $params['pretty']         = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']          = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']    = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']         = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']    = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{algorithm_name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - algorithm_name:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function trainPredict(array $params = [])
@@ -1491,14 +1468,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Unloads a model.
      *
-     * $params['model_id']    = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{model_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - model_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function unloadModel(array $params = [])
@@ -1517,16 +1494,16 @@ class MlNamespace extends AbstractNamespace
     /**
      * Update a specific memory by its type and ID.
      *
-     * $params['id']                  = (string)
-     * $params['memory_container_id'] = (string)
-     * $params['type']                = DEPRECATED (string)
-     * $params['pretty']              = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']               = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']         = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']              = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']         = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, memory_container_id?: string, type?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - id: (Required)
+     * - memory_container_id:
+     * - type:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function updateAgenticMemory(array $params = [])
@@ -1549,14 +1526,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Updates a standalone connector.
      *
-     * $params['connector_id'] = (string)
-     * $params['pretty']       = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']        = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']  = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']       = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']  = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{connector_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - connector_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function updateConnector(array $params = [])
@@ -1575,14 +1552,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Updates a controller.
      *
-     * $params['model_id']    = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{model_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - model_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function updateController(array $params = [])
@@ -1601,14 +1578,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Update a memory.
      *
-     * $params['memory_id']   = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{memory_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - memory_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function updateMemory(array $params = [])
@@ -1627,14 +1604,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Update a memory container.
      *
-     * $params['memory_container_id'] = (string)
-     * $params['pretty']              = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']               = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']         = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']              = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']         = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{memory_container_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - memory_container_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function updateMemoryContainer(array $params = [])
@@ -1653,14 +1630,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Update a message.
      *
-     * $params['message_id']  = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{message_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - message_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function updateMessage(array $params = [])
@@ -1679,14 +1656,14 @@ class MlNamespace extends AbstractNamespace
     /**
      * Updates a model.
      *
-     * $params['model_id']    = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{model_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - model_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function updateModel(array $params = [])
@@ -1705,15 +1682,15 @@ class MlNamespace extends AbstractNamespace
     /**
      * Uploads model chunk.
      *
-     * $params['chunk_number'] = (integer)
-     * $params['model_id']     = (string)
-     * $params['pretty']       = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']        = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']  = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']       = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']  = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{chunk_number?: int, model_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - chunk_number:
+     * - model_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function uploadChunk(array $params = [])
@@ -1734,13 +1711,13 @@ class MlNamespace extends AbstractNamespace
     /**
      * Registers a model.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function uploadModel(array $params = [])

--- a/src/OpenSearch/Namespaces/NeuralNamespace.php
+++ b/src/OpenSearch/Namespaces/NeuralNamespace.php
@@ -27,20 +27,19 @@ class NeuralNamespace extends AbstractNamespace
     /**
      * Provides information about the current status of the neural-search plugin.
      *
-     * $params['node_id']                  = (string) A comma-separated list of node IDs or names to limit the returned information; leave empty to get information from all nodes.
-     * $params['stat']                     = (array) A comma-separated list of stats to retrieve; use empty string to retrieve all stats.
-     * $params['flat_stat_paths']          = (boolean) Whether to return stats in the flat form, which can improve readability, especially for heavily nested stats. For example, the flat form of `"processors": { "ingest": { "text_embedding_executions": 20181212 } }` is `"processors.ingest.text_embedding_executions": "20181212"`. (Default = false)
-     * $params['include_all_nodes']        = (boolean) When `true` includes aggregated statistics across all nodes in the `all_nodes` category. When `false`, excludes the `all_nodes` category from the response. (Default = true)
-     * $params['include_individual_nodes'] = (boolean) When `true` includes statistics for individual nodes in the `nodes` category. When `false`, excludes the `nodes` category from the response. (Default = true)
-     * $params['include_info']             = (boolean) When `true` includes cluster-wide information in the `info` category. When `false`, excludes the `info` category from the response. (Default = true)
-     * $params['include_metadata']         = (boolean) Whether to return stat metadata instead of the raw stat value, includes additional information about the stat. These can include things like type hints, time since last stats being recorded, or recent rolling interval values (Default = false)
-     * $params['pretty']                   = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                    = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']              = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                   = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']              = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{node_id?: string, stat?: mixed, flat_stat_paths?: bool, include_all_nodes?: bool, include_individual_nodes?: bool, include_info?: bool, include_metadata?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - node_id: A comma-separated list of node IDs or names to limit the returned information; leave empty to get information from all nodes.
+     * - stat: A comma-separated list of stats to retrieve; use empty string to retrieve all stats.
+     * - flat_stat_paths: Whether to return stats in the flat form, which can improve readability, especially for heavily nested stats. For example, the flat form of `"processors": { "ingest": { "text_embedding_executions": 20181212 } }` is `"processors.ingest.text_embedding_executions": "20181212"`. (Default: false)
+     * - include_all_nodes: When `true` includes aggregated statistics across all nodes in the `all_nodes` category. When `false`, excludes the `all_nodes` category from the response. (Default: true)
+     * - include_individual_nodes: When `true` includes statistics for individual nodes in the `nodes` category. When `false`, excludes the `nodes` category from the response. (Default: true)
+     * - include_info: When `true` includes cluster-wide information in the `info` category. When `false`, excludes the `info` category from the response. (Default: true)
+     * - include_metadata: Whether to return stat metadata instead of the raw stat value, includes additional information about the stat. These can include things like type hints, time since last stats being recorded, or recent rolling interval values (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function stats(array $params = [])

--- a/src/OpenSearch/Namespaces/NodesNamespace.php
+++ b/src/OpenSearch/Namespaces/NodesNamespace.php
@@ -37,20 +37,19 @@ class NodesNamespace extends AbstractNamespace
     /**
      * Returns information about hot threads on each node in the cluster.
      *
-     * $params['node_id']             = (array) A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.
-     * $params['ignore_idle_threads'] = (boolean) Whether to show threads that are in known-idle places, such as waiting on a socket select or pulling from an empty task queue. (Default = true)
-     * $params['interval']            = (string) The time interval between thread stack trace samples.
-     * $params['snapshots']           = (integer) The number of thread stack trace samples to collect. (Default = 10)
-     * $params['threads']             = (integer) The number of threads to provide information for. (Default = 3)
-     * $params['timeout']             = (string) The amount of time to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['type']                = (string) The type to sample.
-     * $params['pretty']              = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']               = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']         = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']              = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']         = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{node_id?: mixed, ignore_idle_threads?: bool, interval?: string, snapshots?: int, threads?: int, timeout?: string, type?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - node_id: A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes.
+     * - ignore_idle_threads: Whether to show threads that are in known-idle places, such as waiting on a socket select or pulling from an empty task queue. (Default: true)
+     * - interval: The time interval between thread stack trace samples.
+     * - snapshots: The number of thread stack trace samples to collect. (Default: 10)
+     * - threads: The number of threads to provide information for. (Default: 3)
+     * - timeout: The amount of time to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * - type: The type to sample.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function hotThreads(array $params = [])
@@ -67,18 +66,17 @@ class NodesNamespace extends AbstractNamespace
     /**
      * Returns information about nodes in the cluster.
      *
-     * $params['node_id_or_metric'] = (any) Limits the information returned to a list of node IDs or specific metrics. Supports a comma-separated list, such as `node1,node2` or `http,ingest`.
-     * $params['metric']            = (array) Limits the information returned to the specific metrics. Supports a comma-separated list, such as http,ingest.
-     * $params['node_id']           = (array) Comma-separated list of node IDs or names used to limit returned information.
-     * $params['flat_settings']     = (boolean) When `true`, returns settings in flat format. (Default = false)
-     * $params['timeout']           = (string) The amount of time to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['pretty']            = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']             = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']       = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']            = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']       = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{node_id_or_metric?: mixed, metric?: mixed, node_id?: mixed, flat_settings?: bool, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - node_id_or_metric: Limits the information returned to a list of node IDs or specific metrics. Supports a comma-separated list, such as `node1,node2` or `http,ingest`.
+     * - metric: Limits the information returned to the specific metrics. Supports a comma-separated list, such as http,ingest.
+     * - node_id: Comma-separated list of node IDs or names used to limit returned information.
+     * - flat_settings: When `true`, returns settings in flat format. (Default: false)
+     * - timeout: The amount of time to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function info(array $params = [])
@@ -99,16 +97,15 @@ class NodesNamespace extends AbstractNamespace
     /**
      * Reloads secure settings.
      *
-     * $params['node_id']     = (array) The names of particular nodes in the cluster to target.
-     * $params['timeout']     = (string) The amount of time to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']        = (array) An object containing the password for the OpenSearch keystore.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{node_id?: mixed, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - node_id: The names of particular nodes in the cluster to target.
+     * - timeout: The amount of time to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: An object containing the password for the OpenSearch keystore.
      * @return array
      */
     public function reloadSecureSettings(array $params = [])
@@ -127,24 +124,23 @@ class NodesNamespace extends AbstractNamespace
     /**
      * Returns statistical information about nodes in the cluster.
      *
-     * $params['node_id']                    = (array) A comma-separated list of node IDs or names used to limit returned information.
-     * $params['metric']                     = (array) Limit the information returned to the specified metrics.
-     * $params['index_metric']               = (array) Limit the information returned for indexes metric to the specified index metrics. It can be used only if indexes (or all) metric is specified.
-     * $params['completion_fields']          = (any) A comma-separated list or wildcard expressions of fields to include in field data and suggest statistics.
-     * $params['fielddata_fields']           = (any) A comma-separated list or wildcard expressions of fields to include in field data statistics.
-     * $params['fields']                     = (any) A comma-separated list or wildcard expressions of fields to include in the statistics.
-     * $params['groups']                     = (array) A comma-separated list of search groups to include in the search statistics.
-     * $params['include_segment_file_sizes'] = (boolean) When `true`, reports the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested). (Default = false)
-     * $params['level']                      = (enum) Indicates whether statistics are aggregated at the cluster, index, or shard level. (Options = cluster,indices,shards)
-     * $params['timeout']                    = (string) The amount of time to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['types']                      = (array) A comma-separated list of document types for the indexing index metric.
-     * $params['pretty']                     = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                      = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']                = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                     = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']                = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{node_id?: mixed, metric?: mixed, index_metric?: mixed, completion_fields?: mixed, fielddata_fields?: mixed, fields?: mixed, groups?: mixed, include_segment_file_sizes?: bool, level?: mixed, timeout?: string, types?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - node_id: A comma-separated list of node IDs or names used to limit returned information.
+     * - metric: Limit the information returned to the specified metrics.
+     * - index_metric: Limit the information returned for indexes metric to the specified index metrics. It can be used only if indexes (or all) metric is specified.
+     * - completion_fields: A comma-separated list or wildcard expressions of fields to include in field data and suggest statistics.
+     * - fielddata_fields: A comma-separated list or wildcard expressions of fields to include in field data statistics.
+     * - fields: A comma-separated list or wildcard expressions of fields to include in the statistics.
+     * - groups: A comma-separated list of search groups to include in the search statistics.
+     * - include_segment_file_sizes: When `true`, reports the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested). (Default: false)
+     * - level: Indicates whether statistics are aggregated at the cluster, index, or shard level. (Options: cluster, indices, shards)
+     * - timeout: The amount of time to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * - types: A comma-separated list of document types for the indexing index metric.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function stats(array $params = [])
@@ -165,16 +161,15 @@ class NodesNamespace extends AbstractNamespace
     /**
      * Returns low-level information about REST actions usage on nodes.
      *
-     * $params['node_id']     = (array) A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
-     * $params['metric']      = (array) Limits the information returned to the specific metrics. A comma-separated list of the following options: `_all`, `rest_actions`.
-     * $params['timeout']     = (string) Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{node_id?: mixed, metric?: mixed, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - node_id: A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes
+     * - metric: Limits the information returned to the specific metrics. A comma-separated list of the following options: `_all`, `rest_actions`.
+     * - timeout: Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function usage(array $params = [])

--- a/src/OpenSearch/Namespaces/NotificationsNamespace.php
+++ b/src/OpenSearch/Namespaces/NotificationsNamespace.php
@@ -35,13 +35,13 @@ class NotificationsNamespace extends AbstractNamespace
     /**
      * Create channel configuration.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function createConfig(array $params = [])
@@ -58,14 +58,13 @@ class NotificationsNamespace extends AbstractNamespace
     /**
      * Delete a channel configuration.
      *
-     * $params['config_id']   = (string) The ID of the channel configuration to delete.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{config_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - config_id: The ID of the channel configuration to delete.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteConfig(array $params = [])
@@ -82,15 +81,14 @@ class NotificationsNamespace extends AbstractNamespace
     /**
      * Delete multiple channel configurations.
      *
-     * $params['config_id']      = (string) The ID of the channel configuration to delete.
-     * $params['config_id_list'] = (string) A comma-separated list of channel IDs to delete.
-     * $params['pretty']         = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']          = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']    = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']         = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']    = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{config_id?: string, config_id_list?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - config_id: The ID of the channel configuration to delete.
+     * - config_id_list: A comma-separated list of channel IDs to delete.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteConfigs(array $params = [])
@@ -104,14 +102,13 @@ class NotificationsNamespace extends AbstractNamespace
     /**
      * Get a specific channel configuration.
      *
-     * $params['config_id']   = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{config_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - config_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getConfig(array $params = [])
@@ -128,53 +125,53 @@ class NotificationsNamespace extends AbstractNamespace
     /**
      * Get multiple channel configurations with filtering.
      *
-     * $params['chime.url']                                    = (string)
-     * $params['chime.url.keyword']                            = (string)
-     * $params['config_id']                                    = (string) Notification configuration ID.
-     * $params['config_id_list']                               = (array) Notification configuration IDs.
-     * $params['config_type']                                  = (enum) Type of notification configuration. (Options = chime,email,email_group,microsoft_teams,ses_account,slack,smtp_account,sns,webhook)
-     * $params['created_time_ms']                              = (integer)
-     * $params['description']                                  = (string)
-     * $params['description.keyword']                          = (string)
-     * $params['email.email_account_id']                       = (string)
-     * $params['email.email_group_id_list']                    = (string)
-     * $params['email.recipient_list.recipient']               = (string)
-     * $params['email.recipient_list.recipient.keyword']       = (string)
-     * $params['email_group.recipient_list.recipient']         = (string)
-     * $params['email_group.recipient_list.recipient.keyword'] = (string)
-     * $params['is_enabled']                                   = (boolean)
-     * $params['last_updated_time_ms']                         = (integer)
-     * $params['microsoft_teams.url']                          = (string)
-     * $params['microsoft_teams.url.keyword']                  = (string)
-     * $params['name']                                         = (string)
-     * $params['name.keyword']                                 = (string)
-     * $params['query']                                        = (string)
-     * $params['ses_account.from_address']                     = (string)
-     * $params['ses_account.from_address.keyword']             = (string)
-     * $params['ses_account.region']                           = (string)
-     * $params['ses_account.role_arn']                         = (string)
-     * $params['ses_account.role_arn.keyword']                 = (string)
-     * $params['slack.url']                                    = (string)
-     * $params['slack.url.keyword']                            = (string)
-     * $params['smtp_account.from_address']                    = (string)
-     * $params['smtp_account.from_address.keyword']            = (string)
-     * $params['smtp_account.host']                            = (string)
-     * $params['smtp_account.host.keyword']                    = (string)
-     * $params['smtp_account.method']                          = (string)
-     * $params['sns.role_arn']                                 = (string)
-     * $params['sns.role_arn.keyword']                         = (string)
-     * $params['sns.topic_arn']                                = (string)
-     * $params['sns.topic_arn.keyword']                        = (string)
-     * $params['text_query']                                   = (string)
-     * $params['webhook.url']                                  = (string)
-     * $params['webhook.url.keyword']                          = (string)
-     * $params['pretty']                                       = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                                        = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']                                  = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                                       = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']                                  = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{'chime.url'?: string, 'chime.url.keyword'?: string, config_id?: string, config_id_list?: mixed, config_type?: mixed, created_time_ms?: int, description?: string, 'description.keyword'?: string, 'email.email_account_id'?: string, 'email.email_group_id_list'?: string, 'email.recipient_list.recipient'?: string, 'email.recipient_list.recipient.keyword'?: string, 'email_group.recipient_list.recipient'?: string, 'email_group.recipient_list.recipient.keyword'?: string, is_enabled?: bool, last_updated_time_ms?: int, 'microsoft_teams.url'?: string, 'microsoft_teams.url.keyword'?: string, name?: string, 'name.keyword'?: string, query?: string, 'ses_account.from_address'?: string, 'ses_account.from_address.keyword'?: string, 'ses_account.region'?: string, 'ses_account.role_arn'?: string, 'ses_account.role_arn.keyword'?: string, 'slack.url'?: string, 'slack.url.keyword'?: string, 'smtp_account.from_address'?: string, 'smtp_account.from_address.keyword'?: string, 'smtp_account.host'?: string, 'smtp_account.host.keyword'?: string, 'smtp_account.method'?: string, 'sns.role_arn'?: string, 'sns.role_arn.keyword'?: string, 'sns.topic_arn'?: string, 'sns.topic_arn.keyword'?: string, text_query?: string, 'webhook.url'?: string, 'webhook.url.keyword'?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - chime.url:
+     * - chime.url.keyword:
+     * - config_id: Notification configuration ID.
+     * - config_id_list: Notification configuration IDs.
+     * - config_type: Type of notification configuration. (Options: chime, email, email_group, microsoft_teams, ses_account, slack, smtp_account, sns, webhook)
+     * - created_time_ms:
+     * - description:
+     * - description.keyword:
+     * - email.email_account_id:
+     * - email.email_group_id_list:
+     * - email.recipient_list.recipient:
+     * - email.recipient_list.recipient.keyword:
+     * - email_group.recipient_list.recipient:
+     * - email_group.recipient_list.recipient.keyword:
+     * - is_enabled:
+     * - last_updated_time_ms:
+     * - microsoft_teams.url:
+     * - microsoft_teams.url.keyword:
+     * - name:
+     * - name.keyword:
+     * - query:
+     * - ses_account.from_address:
+     * - ses_account.from_address.keyword:
+     * - ses_account.region:
+     * - ses_account.role_arn:
+     * - ses_account.role_arn.keyword:
+     * - slack.url:
+     * - slack.url.keyword:
+     * - smtp_account.from_address:
+     * - smtp_account.from_address.keyword:
+     * - smtp_account.host:
+     * - smtp_account.host.keyword:
+     * - smtp_account.method:
+     * - sns.role_arn:
+     * - sns.role_arn.keyword:
+     * - sns.topic_arn:
+     * - sns.topic_arn.keyword:
+     * - text_query:
+     * - webhook.url:
+     * - webhook.url.keyword:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function getConfigs(array $params = [])
@@ -191,13 +188,12 @@ class NotificationsNamespace extends AbstractNamespace
     /**
      * List created notification channels.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function listChannels(array $params = [])
@@ -211,13 +207,12 @@ class NotificationsNamespace extends AbstractNamespace
     /**
      * List supported channel configurations.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function listFeatures(array $params = [])
@@ -231,14 +226,13 @@ class NotificationsNamespace extends AbstractNamespace
     /**
      * Send a test notification.
      *
-     * $params['config_id']   = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{config_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - config_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function sendTest(array $params = [])
@@ -255,14 +249,14 @@ class NotificationsNamespace extends AbstractNamespace
     /**
      * Update channel configuration.
      *
-     * $params['config_id']   = (string)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{config_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - config_id:
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function updateConfig(array $params = [])

--- a/src/OpenSearch/Namespaces/ObservabilityNamespace.php
+++ b/src/OpenSearch/Namespaces/ObservabilityNamespace.php
@@ -33,13 +33,13 @@ class ObservabilityNamespace extends AbstractNamespace
     /**
      * Creates a new observability object.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function createObject(array $params = [])
@@ -56,14 +56,13 @@ class ObservabilityNamespace extends AbstractNamespace
     /**
      * Deletes specific observability object specified by ID.
      *
-     * $params['object_id']   = (string) The ID of the observability object to delete.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{object_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - object_id: The ID of the observability object to delete.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteObject(array $params = [])
@@ -80,15 +79,14 @@ class ObservabilityNamespace extends AbstractNamespace
     /**
      * Deletes specific observability objects specified by ID or a list of IDs.
      *
-     * $params['objectId']     = (string) The ID of a single observability object to delete.
-     * $params['objectIdList'] = (string) A comma-separated list of observability object IDs to delete.
-     * $params['pretty']       = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']        = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']  = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']       = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']  = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{objectId?: string, objectIdList?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - objectId: The ID of a single observability object to delete.
+     * - objectIdList: A comma-separated list of observability object IDs to delete.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteObjects(array $params = [])
@@ -102,13 +100,12 @@ class ObservabilityNamespace extends AbstractNamespace
     /**
      * Retrieves local stats of all observability objects.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getLocalstats(array $params = [])
@@ -122,14 +119,13 @@ class ObservabilityNamespace extends AbstractNamespace
     /**
      * Retrieves specific observability object specified by ID.
      *
-     * $params['object_id']   = (string) The ID of the observability object to retrieve.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{object_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - object_id: The ID of the observability object to retrieve.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getObject(array $params = [])
@@ -146,13 +142,12 @@ class ObservabilityNamespace extends AbstractNamespace
     /**
      * Retrieves list of all observability objects.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function listObjects(array $params = [])
@@ -166,14 +161,14 @@ class ObservabilityNamespace extends AbstractNamespace
     /**
      * Updates an existing observability object.
      *
-     * $params['object_id']   = (string) The ID of the observability object to update.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{object_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - object_id: The ID of the observability object to update.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function updateObject(array $params = [])

--- a/src/OpenSearch/Namespaces/PplNamespace.php
+++ b/src/OpenSearch/Namespaces/PplNamespace.php
@@ -30,15 +30,15 @@ class PplNamespace extends AbstractNamespace
     /**
      * Returns the execution plan for a PPL query.
      *
-     * $params['format']      = (string) Specifies the response format (JSON, YAML).
-     * $params['sanitize']    = (boolean) Whether to escape special characters in the results. (Default = true)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{format?: string, sanitize?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - format: Specifies the response format (JSON, YAML).
+     * - sanitize: Whether to escape special characters in the results. (Default: true)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function explain(array $params = [])
@@ -55,15 +55,14 @@ class PplNamespace extends AbstractNamespace
     /**
      * Retrieves performance metrics for the PPL plugin.
      *
-     * $params['format']      = (string) Specifies the response format (JSON, YAML).
-     * $params['sanitize']    = (boolean) Whether to escape special characters in the results. (Default = true)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{format?: string, sanitize?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - format: Specifies the response format (JSON, YAML).
+     * - sanitize: Whether to escape special characters in the results. (Default: true)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getStats(array $params = [])
@@ -77,15 +76,15 @@ class PplNamespace extends AbstractNamespace
     /**
      * Retrieves filtered performance metrics for the PPL plugin.
      *
-     * $params['format']      = (string) Specifies the response format (JSON, YAML).
-     * $params['sanitize']    = (boolean) Whether to escape special characters in the results. (Default = true)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{format?: string, sanitize?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - format: Specifies the response format (JSON, YAML).
+     * - sanitize: Whether to escape special characters in the results. (Default: true)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function postStats(array $params = [])
@@ -102,15 +101,15 @@ class PplNamespace extends AbstractNamespace
     /**
      * Executes a PPL query against OpenSearch indexes.
      *
-     * $params['format']      = (string) Specifies the response format (JSON OR YAML).
-     * $params['sanitize']    = (boolean) Whether to sanitize special characters in the results. (Default = true)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{format?: string, sanitize?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - format: Specifies the response format (JSON OR YAML).
+     * - sanitize: Whether to sanitize special characters in the results. (Default: true)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function query(array $params = [])

--- a/src/OpenSearch/Namespaces/QueryNamespace.php
+++ b/src/OpenSearch/Namespaces/QueryNamespace.php
@@ -31,14 +31,13 @@ class QueryNamespace extends AbstractNamespace
     /**
      * Deletes a specific data source by name.
      *
-     * $params['datasource_name'] = (string) The name of the data source to delete.
-     * $params['pretty']          = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']           = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']     = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']          = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']     = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{datasource_name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - datasource_name: The name of the data source to delete.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function datasourceDelete(array $params = [])
@@ -55,14 +54,13 @@ class QueryNamespace extends AbstractNamespace
     /**
      * Retrieves a specific data source by name.
      *
-     * $params['datasource_name'] = (string) The name of the data source to retrieve.
-     * $params['pretty']          = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']           = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']     = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']          = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']     = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{datasource_name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - datasource_name: The name of the data source to retrieve.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function datasourceRetrieve(array $params = [])
@@ -79,13 +77,13 @@ class QueryNamespace extends AbstractNamespace
     /**
      * Creates a new query data source.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function datasourcesCreate(array $params = [])
@@ -102,13 +100,12 @@ class QueryNamespace extends AbstractNamespace
     /**
      * Retrieves a list of all available data sources.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function datasourcesList(array $params = [])
@@ -122,13 +119,13 @@ class QueryNamespace extends AbstractNamespace
     /**
      * Updates an existing query data source.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function datasourcesUpdate(array $params = [])

--- a/src/OpenSearch/Namespaces/RemoteStoreNamespace.php
+++ b/src/OpenSearch/Namespaces/RemoteStoreNamespace.php
@@ -27,16 +27,15 @@ class RemoteStoreNamespace extends AbstractNamespace
     /**
      * Restores from remote store.
      *
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['wait_for_completion']     = (boolean) Should this request wait until the operation has completed before returning. (Default = false)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) Comma-separated list of index IDs (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{cluster_manager_timeout?: string, wait_for_completion?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - wait_for_completion: Should this request wait until the operation has completed before returning. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: Comma-separated list of index IDs (Required)
      * @return array
      */
     public function restore(array $params = [])

--- a/src/OpenSearch/Namespaces/ReplicationNamespace.php
+++ b/src/OpenSearch/Namespaces/ReplicationNamespace.php
@@ -37,13 +37,12 @@ class ReplicationNamespace extends AbstractNamespace
     /**
      * Retrieves information about any auto-follow activity and any replication rules configured on the specified cluster.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function autofollowStats(array $params = [])
@@ -57,13 +56,13 @@ class ReplicationNamespace extends AbstractNamespace
     /**
      * Automatically starts the replication on indexes matching a specified pattern.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function createReplicationRule(array $params = [])
@@ -80,13 +79,13 @@ class ReplicationNamespace extends AbstractNamespace
     /**
      * Deletes the specified replication rule.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function deleteReplicationRule(array $params = [])
@@ -103,13 +102,12 @@ class ReplicationNamespace extends AbstractNamespace
     /**
      * Retrieves information about any follower (syncing) indexes on a specified cluster.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function followerStats(array $params = [])
@@ -123,13 +121,12 @@ class ReplicationNamespace extends AbstractNamespace
     /**
      * Retrieves information about any replicated leader indexes on a specified cluster.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function leaderStats(array $params = [])
@@ -143,14 +140,14 @@ class ReplicationNamespace extends AbstractNamespace
     /**
      * Pauses the replication of the leader index.
      *
-     * $params['index']       = (string) The name of the data stream, index, or index alias to perform bulk actions on.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: The name of the data stream, index, or index alias to perform bulk actions on.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function pause(array $params = [])
@@ -169,14 +166,14 @@ class ReplicationNamespace extends AbstractNamespace
     /**
      * Resumes replication of the leader index.
      *
-     * $params['index']       = (string) The name of the data stream, index, or index alias to perform bulk actions on.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: The name of the data stream, index, or index alias to perform bulk actions on.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function resume(array $params = [])
@@ -195,14 +192,14 @@ class ReplicationNamespace extends AbstractNamespace
     /**
      * Initiates the replication of an index from the leader cluster to the follower cluster.
      *
-     * $params['index']       = (string) The name of the data stream, index, or index alias to perform bulk actions on.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: The name of the data stream, index, or index alias to perform bulk actions on.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function start(array $params = [])
@@ -221,14 +218,13 @@ class ReplicationNamespace extends AbstractNamespace
     /**
      * Retrieves the the status of an index replication.
      *
-     * $params['index']       = (string) The name of the data stream, index, or index alias to perform bulk actions on.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - index: The name of the data stream, index, or index alias to perform bulk actions on.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function status(array $params = [])
@@ -245,14 +241,14 @@ class ReplicationNamespace extends AbstractNamespace
     /**
      * Terminates the replication and converts the follower index to a standard index.
      *
-     * $params['index']       = (string) The name of the data stream, index, or index alias to perform bulk actions on.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: The name of the data stream, index, or index alias to perform bulk actions on.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function stop(array $params = [])
@@ -271,14 +267,14 @@ class ReplicationNamespace extends AbstractNamespace
     /**
      * Updates any settings on the follower index.
      *
-     * $params['index']       = (string) The name of the data stream, index, or index alias to perform bulk actions on.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{index?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - index: The name of the data stream, index, or index alias to perform bulk actions on.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function updateSettings(array $params = [])

--- a/src/OpenSearch/Namespaces/RollupsNamespace.php
+++ b/src/OpenSearch/Namespaces/RollupsNamespace.php
@@ -32,14 +32,13 @@ class RollupsNamespace extends AbstractNamespace
     /**
      * Deletes an index rollup job configuration.
      *
-     * $params['id']          = (string) The ID of the rollup job. (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: The ID of the rollup job. (Required)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function delete(array $params = [])
@@ -56,14 +55,13 @@ class RollupsNamespace extends AbstractNamespace
     /**
      * Retrieves the execution status information for an index rollup job.
      *
-     * $params['id']          = (string) The ID of the rollup job. (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: The ID of the rollup job. (Required)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function explain(array $params = [])
@@ -80,14 +78,13 @@ class RollupsNamespace extends AbstractNamespace
     /**
      * Retrieves an index rollup job configuration by ID.
      *
-     * $params['id']          = (string) The ID of the rollup job. (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: The ID of the rollup job. (Required)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function get(array $params = [])
@@ -104,16 +101,16 @@ class RollupsNamespace extends AbstractNamespace
     /**
      * Creates or updates an index rollup job configuration.
      *
-     * $params['id']              = (string) The ID of the rollup job. (Required)
-     * $params['if_primary_term'] = (number) Only performs the operation if the document has the specified primary term.
-     * $params['if_seq_no']       = (integer) Only performs the operation if the document has the specified sequence number.
-     * $params['pretty']          = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']           = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']     = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']          = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']     = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, if_primary_term?: int|float, if_seq_no?: int, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - id: The ID of the rollup job. (Required)
+     * - if_primary_term: Only performs the operation if the document has the specified primary term.
+     * - if_seq_no: Only performs the operation if the document has the specified sequence number.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function put(array $params = [])
@@ -132,14 +129,13 @@ class RollupsNamespace extends AbstractNamespace
     /**
      * Starts the execution of an index rollup job.
      *
-     * $params['id']          = (string) The ID of the rollup job. (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: The ID of the rollup job. (Required)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function start(array $params = [])
@@ -156,14 +152,13 @@ class RollupsNamespace extends AbstractNamespace
     /**
      * Stops the execution of an index rollup job.
      *
-     * $params['id']          = (string) The ID of the rollup job. (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: The ID of the rollup job. (Required)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function stop(array $params = [])

--- a/src/OpenSearch/Namespaces/SearchPipelineNamespace.php
+++ b/src/OpenSearch/Namespaces/SearchPipelineNamespace.php
@@ -29,16 +29,15 @@ class SearchPipelineNamespace extends AbstractNamespace
     /**
      * Deletes the specified search pipeline.
      *
-     * $params['id']                      = (string) Pipeline ID.
-     * $params['cluster_manager_timeout'] = (string) Operation timeout for connection to cluster-manager node.
-     * $params['timeout']                 = (string) Operation timeout.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, cluster_manager_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: Pipeline ID. (Required)
+     * - cluster_manager_timeout: Operation timeout for connection to cluster-manager node.
+     * - timeout: Operation timeout.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function delete(array $params = [])
@@ -55,15 +54,14 @@ class SearchPipelineNamespace extends AbstractNamespace
     /**
      * Retrieves information about a specified search pipeline.
      *
-     * $params['id']                      = (string) Comma-separated list of search pipeline ids. Wildcards supported.
-     * $params['cluster_manager_timeout'] = (string) operation timeout for connection to cluster-manager node.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, cluster_manager_timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: Comma-separated list of search pipeline ids. Wildcards supported. (Required)
+     * - cluster_manager_timeout: operation timeout for connection to cluster-manager node.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function get(array $params = [])
@@ -80,16 +78,16 @@ class SearchPipelineNamespace extends AbstractNamespace
     /**
      * Creates or replaces the specified search pipeline.
      *
-     * $params['id']                      = (string) Pipeline ID.
-     * $params['cluster_manager_timeout'] = (string) operation timeout for connection to cluster-manager node.
-     * $params['timeout']                 = (string) Operation timeout.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, cluster_manager_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - id: Pipeline ID. (Required)
+     * - cluster_manager_timeout: operation timeout for connection to cluster-manager node.
+     * - timeout: Operation timeout.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function put(array $params = [])

--- a/src/OpenSearch/Namespaces/SearchRelevanceNamespace.php
+++ b/src/OpenSearch/Namespaces/SearchRelevanceNamespace.php
@@ -44,14 +44,13 @@ class SearchRelevanceNamespace extends AbstractNamespace
     /**
      * Deletes a specified experiment.
      *
-     * $params['experiment_id'] = (string) The experiment id
-     * $params['pretty']        = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']         = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']   = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']        = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']   = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{experiment_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - experiment_id: The experiment id
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteExperiments(array $params = [])
@@ -68,14 +67,13 @@ class SearchRelevanceNamespace extends AbstractNamespace
     /**
      * Deletes a specified judgment.
      *
-     * $params['judgment_id'] = (string) The judgment id
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{judgment_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - judgment_id: The judgment id
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteJudgments(array $params = [])
@@ -92,14 +90,13 @@ class SearchRelevanceNamespace extends AbstractNamespace
     /**
      * Deletes a query set.
      *
-     * $params['query_set_id'] = (string) The query set id
-     * $params['pretty']       = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']        = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']  = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']       = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']  = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{query_set_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - query_set_id: The query set id
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteQuerySets(array $params = [])
@@ -116,14 +113,13 @@ class SearchRelevanceNamespace extends AbstractNamespace
     /**
      * Deletes a specified scheduled experiment.
      *
-     * $params['experiment_id'] = (string) The experiment id
-     * $params['pretty']        = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']         = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']   = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']        = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']   = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{experiment_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - experiment_id: The experiment id
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteScheduledExperiments(array $params = [])
@@ -140,14 +136,13 @@ class SearchRelevanceNamespace extends AbstractNamespace
     /**
      * Deletes a specified search configuration.
      *
-     * $params['search_configuration_id'] = (string) The search configuration id
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{search_configuration_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - search_configuration_id: The search configuration id
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteSearchConfigurations(array $params = [])
@@ -164,14 +159,13 @@ class SearchRelevanceNamespace extends AbstractNamespace
     /**
      * Gets experiments.
      *
-     * $params['experiment_id'] = (string) The experiment id
-     * $params['pretty']        = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']         = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']   = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']        = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']   = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{experiment_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - experiment_id: The experiment id
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getExperiments(array $params = [])
@@ -188,14 +182,13 @@ class SearchRelevanceNamespace extends AbstractNamespace
     /**
      * Gets judgments.
      *
-     * $params['judgment_id'] = (string) The judgment id
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{judgment_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - judgment_id: The judgment id
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getJudgments(array $params = [])
@@ -212,20 +205,19 @@ class SearchRelevanceNamespace extends AbstractNamespace
     /**
      * Gets stats by node.
      *
-     * $params['node_id']                  = (string) The node id (Required)
-     * $params['stat']                     = (string) The statistic to return
-     * $params['flat_stat_paths']          = (string) Requests flattened stat paths as keys
-     * $params['include_all_nodes']        = (string) Whether to include all nodes
-     * $params['include_individual_nodes'] = (string) Whether to include individual nodes
-     * $params['include_info']             = (string) Whether to include info
-     * $params['include_metadata']         = (string) Whether to include metadata
-     * $params['pretty']                   = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                    = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']              = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                   = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']              = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{node_id?: string, stat?: string, flat_stat_paths?: string, include_all_nodes?: string, include_individual_nodes?: string, include_info?: string, include_metadata?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - node_id: The node id
+     * - stat: The statistic to return
+     * - flat_stat_paths: Requests flattened stat paths as keys
+     * - include_all_nodes: Whether to include all nodes
+     * - include_individual_nodes: Whether to include individual nodes
+     * - include_info: Whether to include info
+     * - include_metadata: Whether to include metadata
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getNodeStats(array $params = [])
@@ -244,14 +236,13 @@ class SearchRelevanceNamespace extends AbstractNamespace
     /**
      * Lists the current query sets available.
      *
-     * $params['query_set_id'] = (string) The query set id
-     * $params['pretty']       = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']        = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']  = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']       = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']  = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{query_set_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - query_set_id: The query set id
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getQuerySets(array $params = [])
@@ -268,14 +259,13 @@ class SearchRelevanceNamespace extends AbstractNamespace
     /**
      * Gets the scheduled experiments.
      *
-     * $params['experiment_id'] = (string) The experiment id
-     * $params['pretty']        = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']         = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']   = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']        = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']   = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{experiment_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - experiment_id: The experiment id
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getScheduledExperiments(array $params = [])
@@ -292,14 +282,13 @@ class SearchRelevanceNamespace extends AbstractNamespace
     /**
      * Gets the search configurations.
      *
-     * $params['search_configuration_id'] = (string) The search configuration id
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{search_configuration_id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - search_configuration_id: The search configuration id
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getSearchConfigurations(array $params = [])
@@ -316,19 +305,18 @@ class SearchRelevanceNamespace extends AbstractNamespace
     /**
      * Gets stats.
      *
-     * $params['stat']                     = (string) The statistic to return
-     * $params['flat_stat_paths']          = (string) Requests flattened stat paths as keys
-     * $params['include_all_nodes']        = (string) Whether to include all nodes
-     * $params['include_individual_nodes'] = (string) Whether to include individual nodes
-     * $params['include_info']             = (string) Whether to include info
-     * $params['include_metadata']         = (string) Whether to include metadata
-     * $params['pretty']                   = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                    = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']              = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                   = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']              = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{stat?: string, flat_stat_paths?: string, include_all_nodes?: string, include_individual_nodes?: string, include_info?: string, include_metadata?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - stat: The statistic to return
+     * - flat_stat_paths: Requests flattened stat paths as keys
+     * - include_all_nodes: Whether to include all nodes
+     * - include_individual_nodes: Whether to include individual nodes
+     * - include_info: Whether to include info
+     * - include_metadata: Whether to include metadata
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getStats(array $params = [])
@@ -345,13 +333,13 @@ class SearchRelevanceNamespace extends AbstractNamespace
     /**
      * Creates a new query set by sampling queries from the user behavior data.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function postQuerySets(array $params = [])
@@ -368,13 +356,13 @@ class SearchRelevanceNamespace extends AbstractNamespace
     /**
      * Creates a scheduled experiment.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function postScheduledExperiments(array $params = [])
@@ -391,13 +379,13 @@ class SearchRelevanceNamespace extends AbstractNamespace
     /**
      * Creates an experiment.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function putExperiments(array $params = [])
@@ -414,13 +402,13 @@ class SearchRelevanceNamespace extends AbstractNamespace
     /**
      * Creates a judgment.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function putJudgments(array $params = [])
@@ -437,13 +425,13 @@ class SearchRelevanceNamespace extends AbstractNamespace
     /**
      * Creates a new query set by uploading manually.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function putQuerySets(array $params = [])
@@ -460,13 +448,13 @@ class SearchRelevanceNamespace extends AbstractNamespace
     /**
      * Creates a search configuration.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function putSearchConfigurations(array $params = [])

--- a/src/OpenSearch/Namespaces/SecurityAnalyticsNamespace.php
+++ b/src/OpenSearch/Namespaces/SecurityAnalyticsNamespace.php
@@ -29,25 +29,24 @@ class SecurityAnalyticsNamespace extends AbstractNamespace
     /**
      * Retrieve alerts related to a specific detector type or detector ID.
      *
-     * $params['alertState']    = (enum) Used to filter by alert state. Optional. (Options = ACKNOWLEDGED,ACTIVE,COMPLETED,DELETED,ERROR)
-     * $params['detectorType']  = (string) The type of detector used to fetch alerts. Optional when `detector_id` is specified. Otherwise required.
-     * $params['detector_id']   = (string) The ID of the detector used to fetch alerts. Optional when `detectorType` is specified. Otherwise required.
-     * $params['endTime']       = (integer) The end timestamp (in ms) of the time window in which you want to retrieve alerts. Optional.
-     * $params['missing']       = (string) Used to sort by whether the field `missing` exists or not in the documents associated with the alert. Optional.
-     * $params['searchString']  = (string) The alert attribute you want returned in the search. Optional.
-     * $params['severityLevel'] = (enum) Used to filter by alert severity level. Optional. (Options = 1,2,3,4,5,ALL)
-     * $params['size']          = (integer) The maximum number of results returned in the response. Optional. (Default = 20)
-     * $params['sortOrder']     = (enum) The order used to sort the list of findings. Possible values are `asc` or `desc`. Optional. (Options = asc,desc)
-     * $params['sortString']    = (string) The string used by Security Analytics to sort the alerts. Optional. (Default = start_time)
-     * $params['startIndex']    = (integer) The pagination index. Optional. (Default = 0)
-     * $params['startTime']     = (integer) The beginning timestamp (in ms) of the time window in which you want to retrieve alerts. Optional.
-     * $params['pretty']        = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']         = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']   = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']        = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']   = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{alertState?: mixed, detectorType?: string, detector_id?: string, endTime?: int, missing?: string, searchString?: string, severityLevel?: mixed, size?: int, sortOrder?: mixed, sortString?: string, startIndex?: int, startTime?: int, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - alertState: Used to filter by alert state. Optional. (Options: ACKNOWLEDGED, ACTIVE, COMPLETED, DELETED, ERROR)
+     * - detectorType: The type of detector used to fetch alerts. Optional when `detector_id` is specified. Otherwise required.
+     * - detector_id: The ID of the detector used to fetch alerts. Optional when `detectorType` is specified. Otherwise required.
+     * - endTime: The end timestamp (in ms) of the time window in which you want to retrieve alerts. Optional.
+     * - missing: Used to sort by whether the field `missing` exists or not in the documents associated with the alert. Optional.
+     * - searchString: The alert attribute you want returned in the search. Optional.
+     * - severityLevel: Used to filter by alert severity level. Optional. (Options: 1, 2, 3, 4, 5, ALL)
+     * - size: The maximum number of results returned in the response. Optional. (Default: 20)
+     * - sortOrder: The order used to sort the list of findings. Possible values are `asc` or `desc`. Optional. (Options: asc, desc)
+     * - sortString: The string used by Security Analytics to sort the alerts. Optional. (Default: start_time)
+     * - startIndex: The pagination index. Optional. (Default: 0)
+     * - startTime: The beginning timestamp (in ms) of the time window in which you want to retrieve alerts. Optional.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getAlerts(array $params = [])
@@ -61,26 +60,25 @@ class SecurityAnalyticsNamespace extends AbstractNamespace
     /**
      * Retrieve findings related to a specific detector type or detector ID.
      *
-     * $params['detectionType'] = (enum) The detection type that dictates the retrieval type for the findings. When the detection type is `threat`, it fetches threat intelligence feeds. When the detection type is `rule`, findings are fetched based on the detector’s rule. Optional. (Options = rule,threat)
-     * $params['detectorType']  = (string) The type of detector used to fetch alerts. Optional when the `detector_id` is specified. Otherwise required.
-     * $params['detector_id']   = (string) The ID of the detector used to fetch alerts. Optional when the `detectorType` is specified. Otherwise required.
-     * $params['endTime']       = (string) The end timestamp (in ms) of the time window in which you want to retrieve findings. Optional.
-     * $params['findingIds']    = (string) The comma-separated id list of findings for which you want retrieve details. Optional.
-     * $params['missing']       = (string) Used to sort by whether the field `missing` exists or not in the documents associated with the finding. Optional.
-     * $params['searchString']  = (string) The finding attribute you want returned in the search. To search in a specific index, specify the index name in the request path. For example, to search findings in the indexABC index, use `searchString=indexABC’. Optional.
-     * $params['severity']      = (enum) The rule severity for which retrieve findings. Severity can be `critical`, `high`, `medium`, or `low`. Optional. (Options = critical,high,low,medium)
-     * $params['size']          = (integer) The maximum number of results returned in the response. Optional. (Default = 20)
-     * $params['sortOrder']     = (enum) The order used to sort the list of findings. Possible values are `asc` or `desc`. Optional. (Options = asc,desc)
-     * $params['sortString']    = (string) The string used by the Alerting plugin to sort the findings. Optional. (Default = timestamp)
-     * $params['startIndex']    = (integer) The pagination index. Optional. (Default = 0)
-     * $params['startTime']     = (integer) The beginning timestamp (in ms) of the time window in which you want to retrieve findings. Optional.
-     * $params['pretty']        = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']         = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']   = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']        = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']   = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{detectionType?: mixed, detectorType?: string, detector_id?: string, endTime?: string, findingIds?: string, missing?: string, searchString?: string, severity?: mixed, size?: int, sortOrder?: mixed, sortString?: string, startIndex?: int, startTime?: int, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - detectionType: The detection type that dictates the retrieval type for the findings. When the detection type is `threat`, it fetches threat intelligence feeds. When the detection type is `rule`, findings are fetched based on the detector’s rule. Optional. (Options: rule, threat)
+     * - detectorType: The type of detector used to fetch alerts. Optional when the `detector_id` is specified. Otherwise required.
+     * - detector_id: The ID of the detector used to fetch alerts. Optional when the `detectorType` is specified. Otherwise required.
+     * - endTime: The end timestamp (in ms) of the time window in which you want to retrieve findings. Optional.
+     * - findingIds: The comma-separated id list of findings for which you want retrieve details. Optional.
+     * - missing: Used to sort by whether the field `missing` exists or not in the documents associated with the finding. Optional.
+     * - searchString: The finding attribute you want returned in the search. To search in a specific index, specify the index name in the request path. For example, to search findings in the indexABC index, use `searchString=indexABC’. Optional.
+     * - severity: The rule severity for which retrieve findings. Severity can be `critical`, `high`, `medium`, or `low`. Optional. (Options: critical, high, low, medium)
+     * - size: The maximum number of results returned in the response. Optional. (Default: 20)
+     * - sortOrder: The order used to sort the list of findings. Possible values are `asc` or `desc`. Optional. (Options: asc, desc)
+     * - sortString: The string used by the Alerting plugin to sort the findings. Optional. (Default: timestamp)
+     * - startIndex: The pagination index. Optional. (Default: 0)
+     * - startTime: The beginning timestamp (in ms) of the time window in which you want to retrieve findings. Optional.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getFindings(array $params = [])
@@ -94,17 +92,16 @@ class SecurityAnalyticsNamespace extends AbstractNamespace
     /**
      * List correlations for a finding.
      *
-     * $params['detector_type']   = (string) The log type of findings you want to correlate with the specified finding. Required.
-     * $params['finding']         = (string) The finding ID for which you want to find other findings that are correlated. Required.
-     * $params['nearby_findings'] = (integer) The number of nearby findings you want to return. Optional. (Default = 10)
-     * $params['time_window']     = (integer) The time window (in ms) in which all of the correlations must have occurred together. Optional. (Default = 300000)
-     * $params['pretty']          = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']           = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']     = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']          = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']     = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{detector_type?: string, finding?: string, nearby_findings?: int, time_window?: int, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - detector_type: The log type of findings you want to correlate with the specified finding. Required.
+     * - finding: The finding ID for which you want to find other findings that are correlated. Required.
+     * - nearby_findings: The number of nearby findings you want to return. Optional. (Default: 10)
+     * - time_window: The time window (in ms) in which all of the correlations must have occurred together. Optional. (Default: 300000)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function searchFindingCorrelations(array $params = [])

--- a/src/OpenSearch/Namespaces/SecurityNamespace.php
+++ b/src/OpenSearch/Namespaces/SecurityNamespace.php
@@ -103,15 +103,14 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Returns or updates authentication information for the currently authenticated user.
      *
-     * $params['auth_type']   = (string) The type of the current authentication request.
-     * $params['verbose']     = (boolean) Whether to return a verbose response.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{auth_type?: string, verbose?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - auth_type: The type of the current authentication request.
+     * - verbose: Whether to return a verbose response.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function authinfo(array $params = [])
@@ -125,13 +124,12 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Returns the authorization token for the current user.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function authtoken(array $params = [])
@@ -145,13 +143,12 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Not supported for the Cache API.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function cache(array $params = [])
@@ -165,13 +162,12 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Checks whether or not an upgrade can be performed and which security resources can be updated.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function configUpgradeCheck(array $params = [])
@@ -185,13 +181,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Assists the cluster operator with upgrading missing default values and stale default definitions.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function configUpgradePerform(array $params = [])
@@ -208,13 +204,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Creates or replaces APIs permitted for users on the allow list. Requires a super admin certificate or REST API permissions.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function createAllowlist(array $params = [])
@@ -231,13 +227,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Creates or replaces the multi-tenancy configuration. Requires super admin or REST API permissions.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function createUpdateTenancyConfig(array $params = [])
@@ -254,14 +250,14 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Creates or replaces the specified user. Legacy API.
      *
-     * $params['username']    = (string) The name of the user to create. (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{username?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - username: The name of the user to create.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function createUserLegacy(array $params = [])
@@ -280,14 +276,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Deletes the specified action group.
      *
-     * $params['action_group'] = (string) The name of the action group to delete. (Required)
-     * $params['pretty']       = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']        = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']  = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']       = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']  = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{action_group?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - action_group: The name of the action group to delete.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteActionGroup(array $params = [])
@@ -304,14 +299,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Deletes all distinguished names in the specified cluster or node allowlist. Requires super admin or REST API permissions.
      *
-     * $params['cluster_name'] = (string) The cluster name to delete from list of distinguished names. (Required)
-     * $params['pretty']       = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']        = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']  = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']       = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']  = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{cluster_name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - cluster_name: The cluster name to delete from list of distinguished names.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteDistinguishedName(array $params = [])
@@ -328,14 +322,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Deletes the specified role.
      *
-     * $params['role']        = (string) The name of the role to delete. (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{role?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - role: The name of the role to delete.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteRole(array $params = [])
@@ -352,14 +345,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Deletes the specified role mapping.
      *
-     * $params['role']        = (string) The name of the role for which to delete the role's mappings. (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{role?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - role: The name of the role for which to delete the role's mappings.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteRoleMapping(array $params = [])
@@ -376,14 +368,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Deletes the specified tenant.
      *
-     * $params['tenant']      = (string) The name of the tenant to delete. (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{tenant?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - tenant: The name of the tenant to delete.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteTenant(array $params = [])
@@ -400,14 +391,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Deletes the specified internal user.
      *
-     * $params['username']    = (string) The name of the user to delete. (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{username?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - username: The name of the user to delete.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteUser(array $params = [])
@@ -424,14 +414,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Delete the specified user. Legacy API.
      *
-     * $params['username']    = (string) The name of the user to delete. (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{username?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - username: The name of the user to delete.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteUserLegacy(array $params = [])
@@ -448,13 +437,12 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Flushes the Security plugin's user, authentication, and authorization cache.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function flushCache(array $params = [])
@@ -468,13 +456,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Generates a `On-Behalf-Of` token for the current user.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function generateOboToken(array $params = [])
@@ -491,14 +479,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Generates an authorization token for the specified user.
      *
-     * $params['username']    = (string) The name of the user for whom to issue an authorization token. (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{username?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - username: The name of the user for whom to issue an authorization token.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function generateUserToken(array $params = [])
@@ -515,14 +502,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Generates authorization token for the given user. Legacy API. Not Implemented.
      *
-     * $params['username']    = (string) The name of the user for whom to issue an authorization token. (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{username?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - username: The name of the user for whom to issue an authorization token.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function generateUserTokenLegacy(array $params = [])
@@ -539,13 +525,12 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Returns account information for the current user.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getAccountDetails(array $params = [])
@@ -559,14 +544,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Retrieves one action group.
      *
-     * $params['action_group'] = (string) The name of the action group to retrieve. (Required)
-     * $params['pretty']       = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']        = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']  = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']       = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']  = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{action_group?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - action_group: The name of the action group to retrieve.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getActionGroup(array $params = [])
@@ -583,15 +567,14 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Retrieves the cluster security certificates.
      *
-     * $params['cert_type']   = (string) The type of certificates (`HTTP`, `TRANSPORT`, or `ALL`) to retrieve from all nodes.
-     * $params['timeout']     = (string) The maximum duration, in seconds, to spend retrieving certificates from all nodes before a timeout.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{cert_type?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - cert_type: The type of certificates (`HTTP`, `TRANSPORT`, or `ALL`) to retrieve from all nodes.
+     * - timeout: The maximum duration, in seconds, to spend retrieving certificates from all nodes before a timeout.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getAllCertificates(array $params = [])
@@ -605,13 +588,12 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Retrieves the current list of allowed APIs accessible to a normal user.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getAllowlist(array $params = [])
@@ -625,13 +607,12 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Retrieves the audit configuration.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getAuditConfiguration(array $params = [])
@@ -645,13 +626,12 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Retrieves the cluster security certificates.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getCertificates(array $params = [])
@@ -665,13 +645,12 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Returns the current Security plugin configuration in a JSON format.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getConfiguration(array $params = [])
@@ -685,13 +664,12 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Retrieves the current values for dynamic security settings for OpenSearch Dashboards.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getDashboardsInfo(array $params = [])
@@ -705,15 +683,14 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Retrieves all node distinguished names. Requires super admin or REST API permissions.
      *
-     * $params['cluster_name'] = (string) The name of the cluster to retrieve that cluster's nodes DN settings. (Required)
-     * $params['show_all']     = (boolean) Whether to include or exclude any static node's DN settings from the final result.
-     * $params['pretty']       = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']        = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']  = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']       = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']  = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{cluster_name?: string, show_all?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - cluster_name: The name of the cluster to retrieve that cluster's nodes DN settings.
+     * - show_all: Whether to include or exclude any static node's DN settings from the final result.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getDistinguishedName(array $params = [])
@@ -730,16 +707,15 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Retrieves the specified node's security certificates.
      *
-     * $params['node_id']     = (string) The node ID to retrieve certificates for.
-     * $params['cert_type']   = (string) The type of certificates (`HTTP`, `TRANSPORT`, or `ALL`) to retrieve from a node.
-     * $params['timeout']     = (string) The maximum duration, in seconds, to spend retrieving certificates from all nodes before a timeout.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{node_id?: string, cert_type?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - node_id: The node ID to retrieve certificates for.
+     * - cert_type: The type of certificates (`HTTP`, `TRANSPORT`, or `ALL`) to retrieve from a node.
+     * - timeout: The maximum duration, in seconds, to spend retrieving certificates from all nodes before a timeout.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getNodeCertificates(array $params = [])
@@ -756,13 +732,12 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Retrieves the evaluated REST API permissions for the currently logged in user.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getPermissionsInfo(array $params = [])
@@ -776,14 +751,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Retrieves one role.
      *
-     * $params['role']        = (string) The name of the role to retrieve. (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{role?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - role: The name of the role to retrieve.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getRole(array $params = [])
@@ -800,14 +774,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Retrieves the specified role mapping.
      *
-     * $params['role']        = (string) The name of the role mapping to retrieve. (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{role?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - role: The name of the role mapping to retrieve.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getRoleMapping(array $params = [])
@@ -824,14 +797,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Retrieves information about the SSL configuration.
      *
-     * $params['show_dn']     = (any) Whether to include all domain names in the response.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{show_dn?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - show_dn: Whether to include all domain names in the response.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getSslinfo(array $params = [])
@@ -845,13 +817,12 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Retrieves the multi-tenancy configuration. Requires super admin or REST API permissions.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getTenancyConfig(array $params = [])
@@ -865,14 +836,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Retrieves the specified tenant.
      *
-     * $params['tenant']      = (string) The name of the tenant to retrieve. (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{tenant?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - tenant: The name of the tenant to retrieve.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getTenant(array $params = [])
@@ -889,14 +859,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Retrieve information about the specified internal user.
      *
-     * $params['username']    = (string) The name of the user to retrieve. (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{username?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - username: The name of the user to retrieve.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getUser(array $params = [])
@@ -913,14 +882,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Retrieve one user. Legacy API.
      *
-     * $params['username']    = (string) The name of the user to retrieve. (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{username?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - username: The name of the user to retrieve.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getUserLegacy(array $params = [])
@@ -937,13 +905,12 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Retrieve all internal users. Legacy API.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getUsersLegacy(array $params = [])
@@ -957,14 +924,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Checks to see if the Security plugin is running.
      *
-     * $params['mode']        = (string) A flag that determines whether to consider the security status before returning a response for a health query response. For example, `strict` mode indicates service should check the Security plugin status.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{mode?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - mode: A flag that determines whether to consider the security status before returning a response for a health query response. For example, `strict` mode indicates service should check the Security plugin status.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function health(array $params = [])
@@ -978,13 +944,12 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Migrates the security configuration from v6 to v7.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function migrate(array $params = [])
@@ -998,14 +963,14 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Updates the individual attributes of an action group.
      *
-     * $params['action_group'] = (string) The name of the action group to update. (Required)
-     * $params['pretty']       = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']        = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']  = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']       = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']  = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{action_group?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - action_group: The name of the action group to update.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function patchActionGroup(array $params = [])
@@ -1024,13 +989,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Updates the current list of APIs accessible for users on the allow list.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function patchAllowlist(array $params = [])
@@ -1047,13 +1012,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Updates the specified fields in the audit configuration.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function patchAuditConfiguration(array $params = [])
@@ -1070,13 +1035,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Updates the existing security configuration using the REST API. Requires super admin or REST API permissions.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function patchConfiguration(array $params = [])
@@ -1093,14 +1058,14 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Updates the distinguished cluster name for the specified cluster. Requires super admin or REST API permissions.
      *
-     * $params['cluster_name'] = (string) The cluster name to update the `nodesDn` value. (Required)
-     * $params['pretty']       = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']        = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']  = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']       = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']  = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{cluster_name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - cluster_name: The cluster name to update the `nodesDn` value.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function patchDistinguishedName(array $params = [])
@@ -1119,13 +1084,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Bulk updates specified node distinguished names. Requires super admin or REST API permissions.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function patchDistinguishedNames(array $params = [])
@@ -1142,14 +1107,14 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Updates the individual attributes of a role.
      *
-     * $params['role']        = (string) The name of the role to update. (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{role?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - role: The name of the role to update.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function patchRole(array $params = [])
@@ -1168,14 +1133,14 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Updates the individual attributes of a role mapping.
      *
-     * $params['role']        = (string) The name of the role to update a role mapping for (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{role?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - role: The name of the role to update a role mapping for
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function patchRoleMapping(array $params = [])
@@ -1194,14 +1159,14 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Adds, deletes, or modifies a single tenant.
      *
-     * $params['tenant']      = (string) The name of the tenant to update. (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{tenant?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - tenant: The name of the tenant to update.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function patchTenant(array $params = [])
@@ -1220,14 +1185,14 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Updates individual attributes for an internal user.
      *
-     * $params['username']    = (string) The name of the user to update. (Required)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{username?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - username: The name of the user to update.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function patchUser(array $params = [])
@@ -1246,13 +1211,12 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Retrieves the current values for dynamic security settings for OpenSearch Dashboards.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function postDashboardsInfo(array $params = [])
@@ -1266,13 +1230,12 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Reloads the HTTP communication certificates.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function reloadHttpCertificates(array $params = [])
@@ -1286,13 +1249,12 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Reloads the transport communication certificates.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function reloadTransportCertificates(array $params = [])
@@ -1306,13 +1268,12 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Retrieves the names of current tenants. Requires super admin or `kibanaserver` permissions.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function tenantInfo(array $params = [])
@@ -1326,13 +1287,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Updates the audit configuration.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function updateAuditConfiguration(array $params = [])
@@ -1349,13 +1310,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Updates the settings for an existing security configuration. Requires super admin or REST API permissions.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function updateConfiguration(array $params = [])
@@ -1372,14 +1333,14 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Adds or updates the specified distinguished names in the cluster or node allowlist. Requires super admin or REST API permissions.
      *
-     * $params['cluster_name'] = (string) The name of the cluster containing the `nodesDn` value to create or update. (Required)
-     * $params['pretty']       = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']        = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']  = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']       = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']  = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{cluster_name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - cluster_name: The name of the cluster containing the `nodesDn` value to create or update.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function updateDistinguishedName(array $params = [])
@@ -1398,14 +1359,13 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Checks whether the v6 security configuration is valid and ready to be migrated to v7.
      *
-     * $params['accept_invalid'] = (boolean) Whether an invalid v6 configuration should be allowed.
-     * $params['pretty']         = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']          = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']    = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']         = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']    = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{accept_invalid?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - accept_invalid: Whether an invalid v6 configuration should be allowed.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function validate(array $params = [])
@@ -1419,13 +1379,12 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Gets the identity information for the user currently logged in.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function whoAmI(array $params = [])
@@ -1439,13 +1398,12 @@ class SecurityNamespace extends AbstractNamespace
     /**
      * Gets the identity information for the user currently logged in. To use this operation, you must have access to this endpoint when authorization at REST layer is enabled.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function whoAmIProtected(array $params = [])

--- a/src/OpenSearch/Namespaces/SmNamespace.php
+++ b/src/OpenSearch/Namespaces/SmNamespace.php
@@ -34,14 +34,14 @@ class SmNamespace extends AbstractNamespace
     /**
      * Creates a snapshot management policy.
      *
-     * $params['policy_name'] = (string) The name of the snapshot management policy to create.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{policy_name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - policy_name: The name of the snapshot management policy to create.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function createPolicy(array $params = [])
@@ -60,14 +60,13 @@ class SmNamespace extends AbstractNamespace
     /**
      * Deletes a snapshot management policy.
      *
-     * $params['policy_name'] = (string) The name of the snapshot management policy to delete.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{policy_name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - policy_name: The name of the snapshot management policy to delete.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deletePolicy(array $params = [])
@@ -84,14 +83,13 @@ class SmNamespace extends AbstractNamespace
     /**
      * Explains the state of the snapshot management policy.
      *
-     * $params['policy_name'] = (string) The name of the snapshot management policy to explain.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{policy_name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - policy_name: The name of the snapshot management policy to explain.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function explainPolicy(array $params = [])
@@ -108,18 +106,17 @@ class SmNamespace extends AbstractNamespace
     /**
      * Retrieves all snapshot management policies with optional pagination and filtering.
      *
-     * $params['from']        = (integer) The starting index from which to retrieve snapshot management policies. (Default = 0)
-     * $params['queryString'] = (string) The query string to filter the returned snapshot management policies.
-     * $params['size']        = (integer) The number of snapshot management policies to return.
-     * $params['sortField']   = (string) The name of the field to sort the snapshot management policies by.
-     * $params['sortOrder']   = (enum) The order to sort the snapshot management policies. (Options = asc,desc)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{from?: int, queryString?: string, size?: int, sortField?: string, sortOrder?: mixed, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - from: The starting index from which to retrieve snapshot management policies. (Default: 0)
+     * - queryString: The query string to filter the returned snapshot management policies.
+     * - size: The number of snapshot management policies to return.
+     * - sortField: The name of the field to sort the snapshot management policies by.
+     * - sortOrder: The order to sort the snapshot management policies. (Options: asc, desc)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getPolicies(array $params = [])
@@ -133,14 +130,13 @@ class SmNamespace extends AbstractNamespace
     /**
      * Retrieves a specific snapshot management policy by name.
      *
-     * $params['policy_name'] = (string) The name of the snapshot management policy to retrieve.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{policy_name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - policy_name: The name of the snapshot management policy to retrieve.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getPolicy(array $params = [])
@@ -157,14 +153,13 @@ class SmNamespace extends AbstractNamespace
     /**
      * Starts a snapshot management policy.
      *
-     * $params['policy_name'] = (string) The name of the snapshot management policy to start.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{policy_name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - policy_name: The name of the snapshot management policy to start.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function startPolicy(array $params = [])
@@ -181,14 +176,13 @@ class SmNamespace extends AbstractNamespace
     /**
      * Stops a snapshot management policy.
      *
-     * $params['policy_name'] = (string) The name of the snapshot management policy to stop.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{policy_name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - policy_name: The name of the snapshot management policy to stop.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function stopPolicy(array $params = [])
@@ -205,16 +199,16 @@ class SmNamespace extends AbstractNamespace
     /**
      * Updates an existing snapshot management policy. Requires `if_seq_no` and `if_primary_term`.
      *
-     * $params['policy_name']     = (string) The name of the snapshot management policy to update.
-     * $params['if_primary_term'] = (integer) The primary term of the policy to update.
-     * $params['if_seq_no']       = (integer) The sequence number of the policy to update.
-     * $params['pretty']          = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']           = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']     = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']          = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']     = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{policy_name?: string, if_primary_term?: int, if_seq_no?: int, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - policy_name: The name of the snapshot management policy to update.
+     * - if_primary_term: The primary term of the policy to update.
+     * - if_seq_no: The sequence number of the policy to update.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function updatePolicy(array $params = [])

--- a/src/OpenSearch/Namespaces/SnapshotNamespace.php
+++ b/src/OpenSearch/Namespaces/SnapshotNamespace.php
@@ -43,17 +43,16 @@ class SnapshotNamespace extends AbstractNamespace
     /**
      * Removes any stale data from a snapshot repository.
      *
-     * $params['repository']              = (string) Snapshot repository to clean up.
-     * $params['cluster_manager_timeout'] = (string) The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node.
-     * $params['timeout']                 = (string) The amount of time to wait for a response.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{repository?: string, cluster_manager_timeout?: string, master_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - repository: Snapshot repository to clean up.
+     * - cluster_manager_timeout: The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
+     * - master_timeout: Period to wait for a connection to the cluster-manager node.
+     * - timeout: The amount of time to wait for a response.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function cleanupRepository(array $params = [])
@@ -70,19 +69,18 @@ class SnapshotNamespace extends AbstractNamespace
     /**
      * Creates a clone of all or part of a snapshot in the same repository as the original snapshot.
      *
-     * $params['repository']              = (string) The name of repository which will contain the snapshots clone.
-     * $params['snapshot']                = (string) The name of the original snapshot.
-     * $params['target_snapshot']         = (string) The name of the cloned snapshot.
-     * $params['cluster_manager_timeout'] = (string) The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
-     * $params['master_timeout']          = (string) Explicit operation timeout for connection to cluster-manager node
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) The snapshot clone definition. (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{repository?: string, snapshot?: string, target_snapshot?: string, cluster_manager_timeout?: string, master_timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - repository: The name of repository which will contain the snapshots clone.
+     * - snapshot: The name of the original snapshot.
+     * - target_snapshot: The name of the cloned snapshot.
+     * - cluster_manager_timeout: The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
+     * - master_timeout: Explicit operation timeout for connection to cluster-manager node
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The snapshot clone definition. (Required)
      * @return array
      */
     public function clone(array $params = [])
@@ -105,19 +103,18 @@ class SnapshotNamespace extends AbstractNamespace
     /**
      * Creates a snapshot within an existing repository.
      *
-     * $params['repository']              = (string) The name of the repository where the snapshot will be stored.
-     * $params['snapshot']                = (string) The name of the snapshot. Must be unique in the repository.
-     * $params['cluster_manager_timeout'] = (string) The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['wait_for_completion']     = (boolean) When `true`, the request returns a response when the snapshot is complete. When `false`, the request returns a response when the snapshot initializes. (Default = false)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) The snapshot definition.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{repository?: string, snapshot?: string, cluster_manager_timeout?: string, master_timeout?: string, wait_for_completion?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - repository: The name of the repository where the snapshot will be stored.
+     * - snapshot: The name of the snapshot. Must be unique in the repository.
+     * - cluster_manager_timeout: The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - wait_for_completion: When `true`, the request returns a response when the snapshot is complete. When `false`, the request returns a response when the snapshot initializes. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The snapshot definition.
      * @return array
      */
     public function create(array $params = [])
@@ -138,19 +135,18 @@ class SnapshotNamespace extends AbstractNamespace
     /**
      * Creates a snapshot repository.
      *
-     * $params['repository']              = (string) The name for the newly registered repository.
-     * $params['cluster_manager_timeout'] = (string) The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
-     * $params['master_timeout']          = (string) Explicit operation timeout for connection to cluster-manager node
-     * $params['timeout']                 = (string) The amount of time to wait for a response.
-     * $params['verify']                  = (boolean) When `true`, verifies the creation of the snapshot repository.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) The repository definition. (Required)
-     *
-     * @param array $params Associative array of parameters
+     * @param array{repository?: string, cluster_manager_timeout?: string, master_timeout?: string, timeout?: string, verify?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - repository: The name for the newly registered repository.
+     * - cluster_manager_timeout: The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
+     * - master_timeout: Explicit operation timeout for connection to cluster-manager node
+     * - timeout: The amount of time to wait for a response.
+     * - verify: When `true`, verifies the creation of the snapshot repository.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: The repository definition. (Required)
      * @return array
      */
     public function createRepository(array $params = [])
@@ -169,17 +165,16 @@ class SnapshotNamespace extends AbstractNamespace
     /**
      * Deletes a snapshot.
      *
-     * $params['repository']              = (string) The name of the snapshot repository to delete.
-     * $params['snapshot']                = (string) A comma-separated list of snapshot names to delete from the repository.
-     * $params['cluster_manager_timeout'] = (string) The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
-     * $params['master_timeout']          = (string) Explicit operation timeout for connection to cluster-manager node
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{repository?: string, snapshot?: string, cluster_manager_timeout?: string, master_timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - repository: The name of the snapshot repository to delete.
+     * - snapshot: A comma-separated list of snapshot names to delete from the repository.
+     * - cluster_manager_timeout: The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
+     * - master_timeout: Explicit operation timeout for connection to cluster-manager node
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function delete(array $params = [])
@@ -198,17 +193,16 @@ class SnapshotNamespace extends AbstractNamespace
     /**
      * Deletes a snapshot repository.
      *
-     * $params['repository']              = (array) The name of the snapshot repository to unregister. Wildcard (`*`) patterns are supported.
-     * $params['cluster_manager_timeout'] = (string) The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
-     * $params['master_timeout']          = (string) Explicit operation timeout for connection to cluster-manager node
-     * $params['timeout']                 = (string) The amount of time to wait for a response.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{repository?: mixed, cluster_manager_timeout?: string, master_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - repository: The name of the snapshot repository to unregister. Wildcard (`*`) patterns are supported.
+     * - cluster_manager_timeout: The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
+     * - master_timeout: Explicit operation timeout for connection to cluster-manager node
+     * - timeout: The amount of time to wait for a response.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteRepository(array $params = [])
@@ -225,19 +219,18 @@ class SnapshotNamespace extends AbstractNamespace
     /**
      * Returns information about a snapshot.
      *
-     * $params['repository']              = (string) A comma-separated list of snapshot repository names used to limit the request. Wildcard (*) expressions are supported.
-     * $params['snapshot']                = (array) A comma-separated list of snapshot names to retrieve. Also accepts wildcard expressions. (`*`). - To get information about all snapshots in a registered repository, use a wildcard (`*`) or `_all`. - To get information about any snapshots that are currently running, use `_current`.
-     * $params['cluster_manager_timeout'] = (string) The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
-     * $params['ignore_unavailable']      = (boolean) When `false`, the request returns an error for any snapshots that are unavailable. (Default = false)
-     * $params['master_timeout']          = (string) Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
-     * $params['verbose']                 = (boolean) When `true`, returns additional information about each snapshot, such as the version of OpenSearch which took the snapshot, the start and end times of the snapshot, and the number of shards contained in the snapshot. When `false`, returns only snapshot names and contained indexes. This is useful when the snapshots belong to a cloud-based repository, where each blob read is a cost or performance concern.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{repository?: string, snapshot?: mixed, cluster_manager_timeout?: string, ignore_unavailable?: bool, master_timeout?: string, verbose?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - repository: A comma-separated list of snapshot repository names used to limit the request. Wildcard (*) expressions are supported.
+     * - snapshot: A comma-separated list of snapshot names to retrieve. Also accepts wildcard expressions. (`*`). - To get information about all snapshots in a registered repository, use a wildcard (`*`) or `_all`. - To get information about any snapshots that are currently running, use `_current`.
+     * - cluster_manager_timeout: The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
+     * - ignore_unavailable: When `false`, the request returns an error for any snapshots that are unavailable. (Default: false)
+     * - master_timeout: Period to wait for a connection to the cluster-manager node. If no response is received before the timeout expires, the request fails and returns an error.
+     * - verbose: When `true`, returns additional information about each snapshot, such as the version of OpenSearch which took the snapshot, the start and end times of the snapshot, and the number of shards contained in the snapshot. When `false`, returns only snapshot names and contained indexes. This is useful when the snapshots belong to a cloud-based repository, where each blob read is a cost or performance concern.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function get(array $params = [])
@@ -256,17 +249,16 @@ class SnapshotNamespace extends AbstractNamespace
     /**
      * Returns information about a snapshot repository.
      *
-     * $params['repository']              = (array) A comma-separated list of repository names.
-     * $params['cluster_manager_timeout'] = (string) The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
-     * $params['local']                   = (boolean) Whether to get information from the local node. (Default = false)
-     * $params['master_timeout']          = (string) Explicit operation timeout for connection to cluster-manager node
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{repository?: mixed, cluster_manager_timeout?: string, local?: bool, master_timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - repository: A comma-separated list of repository names.
+     * - cluster_manager_timeout: The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
+     * - local: Whether to get information from the local node. (Default: false)
+     * - master_timeout: Explicit operation timeout for connection to cluster-manager node
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getRepository(array $params = [])
@@ -283,19 +275,18 @@ class SnapshotNamespace extends AbstractNamespace
     /**
      * Restores a snapshot.
      *
-     * $params['repository']              = (string) The name of the repository containing the snapshot
-     * $params['snapshot']                = (string) The name of the snapshot to restore.
-     * $params['cluster_manager_timeout'] = (string) The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
-     * $params['master_timeout']          = (string) Explicit operation timeout for connection to cluster-manager node
-     * $params['wait_for_completion']     = (boolean) -| Whether to return a response after the restore operation has completed. When `false`, the request returns a response when the restore operation initializes. When `true`, the request returns a response when the restore operation completes. (Default = false)
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     * $params['body']                    = (array) Determines which settings and indexes to restore when restoring a snapshot
-     *
-     * @param array $params Associative array of parameters
+     * @param array{repository?: string, snapshot?: string, cluster_manager_timeout?: string, master_timeout?: string, wait_for_completion?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - repository: The name of the repository containing the snapshot
+     * - snapshot: The name of the snapshot to restore.
+     * - cluster_manager_timeout: The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
+     * - master_timeout: Explicit operation timeout for connection to cluster-manager node
+     * - wait_for_completion: -| Whether to return a response after the restore operation has completed. When `false`, the request returns a response when the restore operation initializes. When `true`, the request returns a response when the restore operation completes. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: Determines which settings and indexes to restore when restoring a snapshot
      * @return array
      */
     public function restore(array $params = [])
@@ -316,18 +307,17 @@ class SnapshotNamespace extends AbstractNamespace
     /**
      * Returns information about the status of a snapshot.
      *
-     * $params['repository']              = (string) The name of the repository containing the snapshot.
-     * $params['snapshot']                = (array) A comma-separated list of snapshot names.
-     * $params['cluster_manager_timeout'] = (string) The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
-     * $params['ignore_unavailable']      = (boolean) Whether to ignore any unavailable snapshots, When `false`, a `SnapshotMissingException` is thrown. (Default = false)
-     * $params['master_timeout']          = (string) Explicit operation timeout for connection to cluster-manager node
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{repository?: string, snapshot?: mixed, cluster_manager_timeout?: string, ignore_unavailable?: bool, master_timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - repository: The name of the repository containing the snapshot.
+     * - snapshot: A comma-separated list of snapshot names.
+     * - cluster_manager_timeout: The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
+     * - ignore_unavailable: Whether to ignore any unavailable snapshots, When `false`, a `SnapshotMissingException` is thrown. (Default: false)
+     * - master_timeout: Explicit operation timeout for connection to cluster-manager node
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function status(array $params = [])
@@ -346,17 +336,16 @@ class SnapshotNamespace extends AbstractNamespace
     /**
      * Verifies a repository.
      *
-     * $params['repository']              = (string) The name of the repository containing the snapshot.
-     * $params['cluster_manager_timeout'] = (string) The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
-     * $params['master_timeout']          = (string) Explicit operation timeout for connection to cluster-manager node
-     * $params['timeout']                 = (string) The amount of time to wait for a response.
-     * $params['pretty']                  = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']                   = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']             = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']                  = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']             = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{repository?: string, cluster_manager_timeout?: string, master_timeout?: string, timeout?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - repository: The name of the repository containing the snapshot.
+     * - cluster_manager_timeout: The amount of time to wait for a response from the cluster manager node. For more information about supported time units, see [Common parameters](https://opensearch.org/docs/latest/api-reference/common-parameters/#time-units).
+     * - master_timeout: Explicit operation timeout for connection to cluster-manager node
+     * - timeout: The amount of time to wait for a response.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function verifyRepository(array $params = [])

--- a/src/OpenSearch/Namespaces/SqlNamespace.php
+++ b/src/OpenSearch/Namespaces/SqlNamespace.php
@@ -32,15 +32,15 @@ class SqlNamespace extends AbstractNamespace
     /**
      * Closes an open cursor to free server-side resources.
      *
-     * $params['format']      = (string) Specifies the response format (JSON or YAML).
-     * $params['sanitize']    = (boolean) Whether to escape special characters in the results. (Default = true)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{format?: string, sanitize?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - format: Specifies the response format (JSON or YAML).
+     * - sanitize: Whether to escape special characters in the results. (Default: true)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function close(array $params = [])
@@ -57,15 +57,14 @@ class SqlNamespace extends AbstractNamespace
     /**
      * Retrieves performance metrics for the SQL plugin.
      *
-     * $params['format']      = (string) Specifies the response format (JSON or YAML).
-     * $params['sanitize']    = (boolean) Whether to escape special characters in the results. (Default = true)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{format?: string, sanitize?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - format: Specifies the response format (JSON or YAML).
+     * - sanitize: Whether to escape special characters in the results. (Default: true)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getStats(array $params = [])
@@ -79,15 +78,15 @@ class SqlNamespace extends AbstractNamespace
     /**
      * Retrieves filtered performance metrics for the SQL plugin.
      *
-     * $params['format']      = (string) Specifies the response format (JSON or YAML).
-     * $params['sanitize']    = (boolean) Whether to escape special characters in the results. (Default = true)
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{format?: string, sanitize?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - format: Specifies the response format (JSON or YAML).
+     * - sanitize: Whether to escape special characters in the results. (Default: true)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function postStats(array $params = [])
@@ -104,14 +103,14 @@ class SqlNamespace extends AbstractNamespace
     /**
      * Updates SQL plugin settings in the OpenSearch cluster configuration.
      *
-     * $params['format']      = (string) Specifies the response format (JSON or YAML).
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{format?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - format: Specifies the response format (JSON or YAML).
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function settings(array $params = [])

--- a/src/OpenSearch/Namespaces/TasksNamespace.php
+++ b/src/OpenSearch/Namespaces/TasksNamespace.php
@@ -35,18 +35,17 @@ class TasksNamespace extends AbstractNamespace
     /**
      * Cancels a task, if it can be cancelled through an API.
      *
-     * $params['task_id']             = (string) The task ID.
-     * $params['actions']             = (any) A comma-separated list of actions that should be returned. Keep empty to return all.
-     * $params['nodes']               = (array) A comma-separated list of node IDs or names used to limit the returned information. Use `_local` to return information from the node you're connecting to, specify the node name to get information from a specific node, or keep the parameter empty to get information from all nodes.
-     * $params['parent_task_id']      = (string) Returns tasks with a specified parent task ID (`node_id:task_number`). Keep empty or set to -1 to return all.
-     * $params['wait_for_completion'] = (boolean) Waits for the matching task to complete. When `true`, the request is blocked until the task has completed. (Default = false)
-     * $params['pretty']              = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']               = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']         = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']              = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']         = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{task_id?: string, actions?: mixed, nodes?: mixed, parent_task_id?: string, wait_for_completion?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - task_id: The task ID.
+     * - actions: A comma-separated list of actions that should be returned. Keep empty to return all.
+     * - nodes: A comma-separated list of node IDs or names used to limit the returned information. Use `_local` to return information from the node you're connecting to, specify the node name to get information from a specific node, or keep the parameter empty to get information from all nodes.
+     * - parent_task_id: Returns tasks with a specified parent task ID (`node_id:task_number`). Keep empty or set to -1 to return all.
+     * - wait_for_completion: Waits for the matching task to complete. When `true`, the request is blocked until the task has completed. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function cancel(array $params = [])
@@ -63,16 +62,15 @@ class TasksNamespace extends AbstractNamespace
     /**
      * Returns information about a task.
      *
-     * $params['task_id']             = (string) The task ID.
-     * $params['timeout']             = (string) The amount of time to wait for a response.
-     * $params['wait_for_completion'] = (boolean) Waits for the matching task to complete. When `true`, the request is blocked until the task has completed. (Default = false)
-     * $params['pretty']              = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']               = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']         = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']              = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']         = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{task_id?: string, timeout?: string, wait_for_completion?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - task_id: The task ID.
+     * - timeout: The amount of time to wait for a response.
+     * - wait_for_completion: Waits for the matching task to complete. When `true`, the request is blocked until the task has completed. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function get(array $params = [])
@@ -89,20 +87,19 @@ class TasksNamespace extends AbstractNamespace
     /**
      * Returns a list of tasks.
      *
-     * $params['actions']             = (any) A comma-separated list of actions that should be returned. Keep empty to return all.
-     * $params['detailed']            = (boolean) When `true`, the response includes detailed information about shard recoveries. (Default = false)
-     * $params['group_by']            = (enum) Groups tasks by parent/child relationships or nodes. (Options = nodes,none,parents)
-     * $params['nodes']               = (array) A comma-separated list of node IDs or names used to limit the returned information. Use `_local` to return information from the node you're connecting to, specify the node name to get information from a specific node, or keep the parameter empty to get information from all nodes.
-     * $params['parent_task_id']      = (string) Returns tasks with a specified parent task ID (`node_id:task_number`). Keep empty or set to -1 to return all.
-     * $params['timeout']             = (string) The amount of time to wait for a response.
-     * $params['wait_for_completion'] = (boolean) Waits for the matching task to complete. When `true`, the request is blocked until the task has completed. (Default = false)
-     * $params['pretty']              = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']               = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']         = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']              = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']         = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{actions?: mixed, detailed?: bool, group_by?: mixed, nodes?: mixed, parent_task_id?: string, timeout?: string, wait_for_completion?: bool, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - actions: A comma-separated list of actions that should be returned. Keep empty to return all.
+     * - detailed: When `true`, the response includes detailed information about shard recoveries. (Default: false)
+     * - group_by: Groups tasks by parent/child relationships or nodes. (Options: nodes, none, parents)
+     * - nodes: A comma-separated list of node IDs or names used to limit the returned information. Use `_local` to return information from the node you're connecting to, specify the node name to get information from a specific node, or keep the parameter empty to get information from all nodes.
+     * - parent_task_id: Returns tasks with a specified parent task ID (`node_id:task_number`). Keep empty or set to -1 to return all.
+     * - timeout: The amount of time to wait for a response.
+     * - wait_for_completion: Waits for the matching task to complete. When `true`, the request is blocked until the task has completed. (Default: false)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function list(array $params = [])

--- a/src/OpenSearch/Namespaces/TransformsNamespace.php
+++ b/src/OpenSearch/Namespaces/TransformsNamespace.php
@@ -34,14 +34,13 @@ class TransformsNamespace extends AbstractNamespace
     /**
      * Delete an index transform.
      *
-     * $params['id']          = (string) Transform to delete
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: Transform to delete (Required)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function delete(array $params = [])
@@ -58,14 +57,13 @@ class TransformsNamespace extends AbstractNamespace
     /**
      * Returns the status and metadata of a transform job.
      *
-     * $params['id']          = (string) Transform to explain
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: Transform to explain (Required)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function explain(array $params = [])
@@ -82,14 +80,13 @@ class TransformsNamespace extends AbstractNamespace
     /**
      * Returns the status and metadata of a transform job.
      *
-     * $params['id']          = (string) Transform to access
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: Transform to access (Required)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function get(array $params = [])
@@ -106,13 +103,13 @@ class TransformsNamespace extends AbstractNamespace
     /**
      * Returns a preview of what a transformed index would look like.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function preview(array $params = [])
@@ -129,16 +126,16 @@ class TransformsNamespace extends AbstractNamespace
     /**
      * Create an index transform, or update a transform if `if_seq_no` and `if_primary_term` are provided.
      *
-     * $params['id']              = (string) Transform to create/update
-     * $params['if_primary_term'] = (number) Only perform the operation if the document has this primary term.
-     * $params['if_seq_no']       = (integer) Only perform the operation if the document has this sequence number.
-     * $params['pretty']          = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']           = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']     = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']          = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']     = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, if_primary_term?: int|float, if_seq_no?: int, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - id: Transform to create/update (Required)
+     * - if_primary_term: Only perform the operation if the document has this primary term.
+     * - if_seq_no: Only perform the operation if the document has this sequence number.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body:
      * @return array
      */
     public function put(array $params = [])
@@ -157,18 +154,17 @@ class TransformsNamespace extends AbstractNamespace
     /**
      * Returns the details of all transform jobs.
      *
-     * $params['from']          = (number) The starting transform to return. Default is `0`.
-     * $params['search']        = (string) The search term to use to filter results.
-     * $params['size']          = (number) Specifies the number of transforms to return. Default is `10`.
-     * $params['sortDirection'] = (string) Specifies the direction to sort results in. Can be `ASC` or `DESC`. Default is `ASC`.
-     * $params['sortField']     = (string) The field to sort results with.
-     * $params['pretty']        = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']         = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace']   = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']        = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path']   = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{from?: int|float, search?: string, size?: int|float, sortDirection?: string, sortField?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - from: The starting transform to return. Default is `0`.
+     * - search: The search term to use to filter results.
+     * - size: Specifies the number of transforms to return. Default is `10`.
+     * - sortDirection: Specifies the direction to sort results in. Can be `ASC` or `DESC`. Default is `ASC`.
+     * - sortField: The field to sort results with.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function search(array $params = [])
@@ -182,14 +178,13 @@ class TransformsNamespace extends AbstractNamespace
     /**
      * Start transform.
      *
-     * $params['id']          = (string) Transform to start
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: Transform to start (Required)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function start(array $params = [])
@@ -206,14 +201,13 @@ class TransformsNamespace extends AbstractNamespace
     /**
      * Stop transform.
      *
-     * $params['id']          = (string) Transform to stop
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{id?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - id: Transform to stop (Required)
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function stop(array $params = [])

--- a/src/OpenSearch/Namespaces/UbiNamespace.php
+++ b/src/OpenSearch/Namespaces/UbiNamespace.php
@@ -27,13 +27,12 @@ class UbiNamespace extends AbstractNamespace
     /**
      * Initializes the UBI indexes.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function initialize(array $params = [])

--- a/src/OpenSearch/Namespaces/WlmNamespace.php
+++ b/src/OpenSearch/Namespaces/WlmNamespace.php
@@ -30,13 +30,13 @@ class WlmNamespace extends AbstractNamespace
     /**
      * Creates a new query group and sets the resource limits for the new query group.
      *
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function createQueryGroup(array $params = [])
@@ -53,14 +53,13 @@ class WlmNamespace extends AbstractNamespace
     /**
      * Deletes the specified query group.
      *
-     * $params['name']        = (string) The name of the query group.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name: The name of the query group.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function deleteQueryGroup(array $params = [])
@@ -77,14 +76,13 @@ class WlmNamespace extends AbstractNamespace
     /**
      * Retrieves the specified query group. If no query group is specified, all query groups in the cluster are retrieved.
      *
-     * $params['name']        = (string) The name of the query group.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed} $params
+     * - name: The name of the query group.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
      * @return array
      */
     public function getQueryGroup(array $params = [])
@@ -101,14 +99,14 @@ class WlmNamespace extends AbstractNamespace
     /**
      * Updates the specified query group.
      *
-     * $params['name']        = (string) The name of the query group.
-     * $params['pretty']      = (boolean) Whether to pretty-format the returned JSON response. (Default = false)
-     * $params['human']       = (boolean) Whether to return human-readable values for statistics. (Default = false)
-     * $params['error_trace'] = (boolean) Whether to include the stack trace of returned errors. (Default = false)
-     * $params['source']      = (string) The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
-     * $params['filter_path'] = (any) A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
-     *
-     * @param array $params Associative array of parameters
+     * @param array{name?: string, pretty?: bool, human?: bool, error_trace?: bool, source?: string, filter_path?: mixed, body?: mixed} $params
+     * - name: The name of the query group.
+     * - pretty: Whether to pretty-format the returned JSON response. (Default: false)
+     * - human: Whether to return human-readable values for statistics. (Default: false)
+     * - error_trace: Whether to include the stack trace of returned errors. (Default: false)
+     * - source: The URL-encoded request definition. Useful for libraries that do not accept a request body for non-POST requests.
+     * - filter_path: A comma-separated list of filters used to filter the response. Use wildcards to match any field or part of a field's name. To exclude fields, use `-`.
+     * - body: (Required)
      * @return array
      */
     public function updateQueryGroup(array $params = [])

--- a/util/Endpoint.php
+++ b/util/Endpoint.php
@@ -459,22 +459,33 @@ class Endpoint
     public function renderDocParams(): string
     {
         $space = $this->getMaxLengthBodyPartsParams();
-
         $result = "\n    /**\n";
+
+        // Method description
         if (isset($this->content['documentation']['description'])) {
-            $result .= sprintf("     * %s\n", str_replace("\n", '', $this->content['documentation']['description']));
+            $result .= sprintf(
+                "     * %s\n",
+                str_replace("\n", '', $this->content['documentation']['description'])
+            );
             $result .= "     *\n";
         }
-        $result .= $this->extractPartsDescription($space);
-        $result .= $this->extractParamsDescription($space);
-        $result .= $this->extractBodyDescription($space);
-        $result .= "     *\n";
-        $result .= "     * @param array \$params Associative array of parameters\n";
-        $result .= sprintf("     * @return %s\n", $this->getMethod() === ['HEAD'] ? 'bool' : 'array');
 
+        // Input parameters
+        $result .= $this->extractAllParamsDescription($space);
+
+        // Return value
+        if ($this->getMethod() === ['HEAD']) {
+            $result .= "     * @return bool\n";
+        } else {
+            $result .= "     * @return array\n";
+        }
+
+        // Documentation URL
         if (isset($this->content['documentation']['url'])) {
             $result .= "     * @see {$this->content['documentation']['url']}\n";
         }
+
+        // Stability note
         if ($this->content['stability'] !== 'stable') {
             switch ($this->content['stability']) {
                 case 'experimental':
@@ -488,75 +499,115 @@ class Endpoint
                 $result .= sprintf("     *\n     * @note %s\n     *\n", $note);
             }
         }
+
         $result .= "     */";
-
         return $result;
     }
 
-    private function extractBodyDescription(int $space): string
+    private function extractAllParamsDescription(int $space): string
     {
-        if (isset($this->content['body']) && isset($this->content['body']['description'])) {
-            return sprintf(
-                "     * \$params['body']%s = (array) %s%s\n",
-                str_repeat(' ', $space - 4),
-                $this->content['body']['description'],
-                isset($this->content['body']['required']) && $this->content['body']['required'] ? ' (Required)' : ''
-            );
-        }
-        return '';
-    }
+        $shapeParts = [];
+        $descLines  = [];
+        $allParams  = [];
 
-    private function extractPartsDescription(int $space): string
-    {
-        $result = '';
-        if (empty($this->parts)) {
-            return $result;
+        // Merge parts, params, and body
+        if (!empty($this->parts)) {
+            foreach ($this->parts as $name => $values) {
+                $allParams[$name] = $values + ['source' => 'parts'];
+            }
         }
-        foreach ($this->parts as $part => $values) {
-            $result .= sprintf(
-                "     * \$params['%s']%s = %s(%s) %s%s\n",
-                $part,
-                str_repeat(' ', $space - strlen($part)),
-                $part === 'type' || (isset($values['deprecated']) && $values['deprecated']) ? 'DEPRECATED ' : '',
-                $values['type'] ?? 'any',
-                $values['description'] ?? '',
-                in_array($part, $this->requiredParts) ? ' (Required)' : ''
-            );
-            $this->addedPartInDoc[] = $part;
+        if (!empty($this->content['params'])) {
+            foreach ($this->content['params'] as $name => $values) {
+                $allParams[$name] = $values + ['source' => 'params'];
+            }
         }
-        return $result;
-    }
+        if (!empty($this->content['body'])) {
+            $allParams['body'] = $this->content['body'] + ['source' => 'body'];
+        }
 
-    private function extractParamsDescription(int $space): string
-    {
-        $result = '';
-        if (!isset($this->content['params'])) {
-            return $result;
-        }
-        foreach ($this->content['params'] as $param => $values) {
-            if (in_array($param, $this->addedPartInDoc)) {
+        $anyRequired = false;
+
+        foreach ($allParams as $name => $values) {
+            if (in_array($name, $this->addedPartInDoc, true)) {
                 continue;
             }
-            $type = 'any';
-            if (isset($values['type'])) {
-                if (is_string($values['type'])) {
-                    $type = $values['type'];
-                } elseif (is_array($values['type'])) {
-                    $type = implode('|', $values['type']);
-                }
+
+            $type = $this->mapTypeToPhpDoc($values['type'] ?? 'mixed');
+
+            // Determine if required - note: for PHPStan compatibility with $params = [],
+            // we mark all parameters as optional in the array shape but still document
+            // which ones are required in the description
+            $isRequired = $values['required'] ?? false;
+
+            if ($name === 'id') {
+                $isRequired = true; // id always required
             }
-            $result .= sprintf(
-                "     * \$params['%s']%s = (%s) %s%s%s%s\n",
-                $param,
-                str_repeat(' ', $space - strlen($param)),
-                $type,
-                $values['description'] ?? '',
-                isset($values['required']) && $values['required'] ? ' (Required)' : '',
-                isset($values['options']) ? sprintf(" (Options = %s)", implode(',', $values['options'])) : '',
-                isset($values['default']) ? sprintf(" (Default = %s)", ($type === 'boolean') ? ($values['default'] ? 'true' : 'false') : (is_array($values['default']) ? implode(',', $values['default']) : $values['default'])) : ''
-            );
+
+            // Always use optional marker for PHPStan compatibility
+            $optional = '?';
+            if ($isRequired) {
+                $anyRequired = true;
+            }
+
+            // Quote keys with dots or other special characters for PHPStan compatibility
+            $key = str_contains($name, '.') ? "'{$name}'" : $name;
+            $shapeParts[] = sprintf('%s%s: %s', $key, $optional, $type);
+
+            // Description
+            $desc = $values['description'] ?? '';
+            if ($isRequired) {
+                $desc = ($desc ? $desc . ' ' : '') . '(Required)';
+            }
+            if (isset($values['default'])) {
+                $default = $values['default'];
+                if (is_bool($default)) {
+                    $default = $default ? 'true' : 'false';
+                } elseif (is_array($default)) {
+                    $default = implode(', ', $default);
+                }
+                $desc .= ($desc ? ' ' : '') . "(Default: {$default})";
+            }
+            if (isset($values['options'])) {
+                $desc .= ($desc ? ' ' : '') . '(Options: ' . implode(', ', $values['options']) . ')';
+            }
+
+            $descLines[] = sprintf("     * - %s: %s", $name, trim($desc));
+            $this->addedPartInDoc[] = $name;
         }
+
+        // Build docblock string
+        if (empty($shapeParts)) {
+            return '';
+        }
+
+        $result  = sprintf(
+            "     * @param array{%s} \$params\n",
+            implode(', ', $shapeParts)
+        );
+        foreach ($descLines as $line) {
+            $result .= $line . "\n";
+        }
+
         return $result;
+    }
+
+    private function mapTypeToPhpDoc(mixed $type): string
+    {
+        // If the type is an array (nested schema), treat as 'array'
+        if (is_array($type)) {
+            return 'array';
+        }
+
+        return match ($type) {
+            'string'  => 'string',
+            'boolean' => 'bool',
+            'integer' => 'int',
+            'number'  => 'int|float',
+            'list'    => 'array',
+            'object'  => 'array',
+            'any'     => 'mixed',
+            default   => 'mixed',
+        };
     }
 
     private function getMaxLengthBodyPartsParams(): int


### PR DESCRIPTION
### Description
This updates the docblocks to define array shapes. This helps IDE's and PHPStan verify allowed array keys are being used.

https://phpstan.org/writing-php-code/phpdoc-types#array-shapes
https://www.jetbrains.com/help/phpstorm/php-type-checking.html#php-array-shapes-object-shapes


### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
