### PR TITLE
fix: handle unpaired UTF-16 surrogates in SmartSerializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Deprecated
 ### Removed
 ### Fixed
+- Fix `SmartSerializer` throwing `JsonException` on JSON with unpaired UTF-16 surrogate escape sequences produced by search highlighting ([#403](https://github.com/opensearch-project/opensearch-php/pull/403))
 ### Security
 ### Updated APIs
 

--- a/src/OpenSearch/Serializers/SmartSerializer.php
+++ b/src/OpenSearch/Serializers/SmartSerializer.php
@@ -80,7 +80,8 @@ class SmartSerializer implements SerializerInterface
                 $escaped = str_replace('\\', '\\\\', $data);
                 try {
                     return json_decode($escaped, true, 512, JSON_THROW_ON_ERROR);
-                } catch (\JsonException) {
+                } catch (\JsonException $e) {
+                    throw new JsonException($e->getCode(), $escaped, $e);
                 }
             }
 

--- a/src/OpenSearch/Serializers/SmartSerializer.php
+++ b/src/OpenSearch/Serializers/SmartSerializer.php
@@ -76,6 +76,14 @@ class SmartSerializer implements SerializerInterface
         try {
             return json_decode($data, true, 512, JSON_THROW_ON_ERROR);
         } catch (\JsonException $e) {
+            if ($e->getCode() === JSON_ERROR_UTF16) {
+                $escaped = str_replace('\\', '\\\\', $data);
+                try {
+                    return json_decode($escaped, true, 512, JSON_THROW_ON_ERROR);
+                } catch (\JsonException) {
+                }
+            }
+
             throw new JsonException($e->getCode(), $data, $e);
         }
     }

--- a/tests/Serializers/SmartSerializerTest.php
+++ b/tests/Serializers/SmartSerializerTest.php
@@ -55,6 +55,28 @@ class SmartSerializerTest extends TestCase
         }
     }
 
+    public function testDeserializeWithUnpairedUtf16Surrogates(): void
+    {
+        $data = '{ "data": "ud83d\\ude4f" }';
+
+        $result = $this->serializer->deserialize($data, []);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('data', $result);
+        $this->assertSame('ud83d\\ude4f', $result['data']);
+    }
+
+    public function testDeserializeWithHighlightedSurrogatePair(): void
+    {
+        $data = '{ "data": "<em>\\ud83c</em>\\udd11" }';
+
+        $result = $this->serializer->deserialize($data, []);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('data', $result);
+        $this->assertSame('<em>\\ud83c</em>\\udd11', $result['data']);
+    }
+
     public function testDeserialize(): void
     {
         $data = '{ "foo" : "bar" }';


### PR DESCRIPTION
### Description
Fixes #402

Implements the same fix as https://github.com/elastic/elasticsearch-php/pull/1179

### Issues Resolved
#402

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
