### PR TITLE
fix: accept any callable as SigningClientFactory provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 ### Fixed
 - Fix `SmartSerializer` throwing `JsonException` on JSON with unpaired UTF-16 surrogate escape sequences produced by search highlighting ([#403](https://github.com/opensearch-project/opensearch-php/pull/403))
+- Accept any `callable` as the `provider` argument of `SigningClientFactory` so AWS SDK credential providers like `CredentialProvider::sso()` and `CredentialProvider::assumeRole()` can be used ([#404](https://github.com/opensearch-project/opensearch-php/issues/404))
 ### Security
 ### Updated APIs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Upgrade `phpunit/phpunit` to `^11.5` ([#414](https://github.com/opensearch-project/opensearch-php/pull/414))
 ### Deprecated
+- Passing a `CredentialProvider` instance to `SigningClientFactory` is deprecated; pass a `callable` instead ([#404](https://github.com/opensearch-project/opensearch-php/issues/404))
 ### Removed
 - Drop CI integration testing against EOL OpenSearch 1.x and legacy Elasticsearch OSS 7.10.0
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Drop CI integration testing against EOL OpenSearch 1.x and legacy Elasticsearch OSS 7.10.0
 ### Fixed
 - Fix `SmartSerializer` throwing `JsonException` on JSON with unpaired UTF-16 surrogate escape sequences produced by search highlighting ([#403](https://github.com/opensearch-project/opensearch-php/pull/403))
+- Accept any `callable` as the `provider` argument of `SigningClientFactory` so AWS SDK credential providers like `CredentialProvider::sso()` and `CredentialProvider::assumeRole()` can be used ([#404](https://github.com/opensearch-project/opensearch-php/issues/404))
 ### Security
 ### Updated APIs
 

--- a/src/OpenSearch/Aws/SigningClientFactory.php
+++ b/src/OpenSearch/Aws/SigningClientFactory.php
@@ -22,11 +22,14 @@ class SigningClientFactory
      */
     public const ALLOWED_SERVICES = ['es', 'aoss'];
 
+    protected ?\Closure $provider;
+
     public function __construct(
         protected ?SignatureInterface $signer = null,
-        protected ?CredentialProvider $provider = null,
+        ?callable $provider = null,
         protected ?LoggerInterface $logger = null,
     ) {
+        $this->provider = $provider !== null ? \Closure::fromCallable($provider) : null;
     }
 
     /**
@@ -65,7 +68,7 @@ class SigningClientFactory
      * @param array<string,mixed> $options
      *   The options array.
      */
-    protected function getCredentialProvider(array $options): CredentialProvider|\Closure|null|callable
+    protected function getCredentialProvider(array $options): callable
     {
         // Check for a provided credential provider.
         if ($this->provider) {

--- a/src/OpenSearch/Aws/SigningClientFactory.php
+++ b/src/OpenSearch/Aws/SigningClientFactory.php
@@ -24,11 +24,28 @@ class SigningClientFactory
 
     protected ?\Closure $provider;
 
+    /**
+     * @param SignatureInterface|null $signer
+     *   The request signer.
+     * @param callable|CredentialProvider|null $provider
+     *   A credential provider callable. Passing a CredentialProvider instance is
+     *   deprecated; use a callable (e.g. the result of CredentialProvider::sso()).
+     * @param LoggerInterface|null $logger
+     *   The logger.
+     */
     public function __construct(
         protected ?SignatureInterface $signer = null,
-        ?callable $provider = null,
+        callable|CredentialProvider|null $provider = null,
         protected ?LoggerInterface $logger = null,
     ) {
+        if ($provider instanceof CredentialProvider) {
+            @trigger_error(
+                'Passing a CredentialProvider instance to ' . self::class . ' is deprecated and will be removed in a future release. Pass a callable instead, e.g. the result of CredentialProvider::sso() or CredentialProvider::defaultProvider().',
+                \E_USER_DEPRECATED,
+            );
+            $provider = null;
+        }
+
         $this->provider = $provider !== null ? \Closure::fromCallable($provider) : null;
     }
 

--- a/tests/Aws/SigningClientFactoryTest.php
+++ b/tests/Aws/SigningClientFactoryTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace OpenSearch\Tests\Aws;
 
+use Aws\Credentials\CredentialProvider;
+use Aws\Credentials\Credentials;
 use OpenSearch\Aws\SigningClientFactory;
 use OpenSearch\HttpClient\SymfonyHttpClientFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -31,6 +33,22 @@ class SigningClientFactoryTest extends TestCase
         ]);
 
         // Check we get a client back.
+        $this->assertInstanceOf(ClientInterface::class, $client);
+    }
+
+    public function testCreateWithCallableProvider(): void
+    {
+        $symfonyClient = (new SymfonyHttpClientFactory())->create([
+            'base_uri' => 'http://localhost:9200',
+        ]);
+
+        $provider = CredentialProvider::fromCredentials(new Credentials('foo', 'bar'));
+
+        $client = (new SigningClientFactory(provider: $provider))->create($symfonyClient, [
+            'host' => 'example.com',
+            'region' => 'us-east-1',
+        ]);
+
         $this->assertInstanceOf(ClientInterface::class, $client);
     }
 

--- a/tests/Aws/SigningClientFactoryTest.php
+++ b/tests/Aws/SigningClientFactoryTest.php
@@ -52,6 +52,40 @@ class SigningClientFactoryTest extends TestCase
         $this->assertInstanceOf(ClientInterface::class, $client);
     }
 
+    public function testCreateWithDeprecatedCredentialProviderInstance(): void
+    {
+        $symfonyClient = (new SymfonyHttpClientFactory())->create([
+            'base_uri' => 'http://localhost:9200',
+        ]);
+
+        $deprecation = null;
+        set_error_handler(static function (int $errno, string $errstr) use (&$deprecation): bool {
+            $deprecation = $errstr;
+            return true;
+        }, \E_USER_DEPRECATED);
+
+        try {
+            $factory = new SigningClientFactory(provider: new CredentialProvider());
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertNotNull($deprecation, 'Expected a deprecation notice when passing a CredentialProvider instance.');
+        $this->assertStringContainsString('deprecated', $deprecation);
+
+        // The deprecated provider is ignored; the factory still produces a working client.
+        $client = $factory->create($symfonyClient, [
+            'host' => 'example.com',
+            'region' => 'us-east-1',
+            'credentials' => [
+                'access_key' => 'foo',
+                'secret_key' => 'bar',
+            ],
+        ]);
+
+        $this->assertInstanceOf(ClientInterface::class, $client);
+    }
+
     public function testValidateService(): void
     {
         $symfonyClient = (new SymfonyHttpClientFactory())->create([


### PR DESCRIPTION
### Description
`SigningClientFactory` typed `$provider` as `?CredentialProvider`, but `CredentialProvider::sso()` / `assumeRole()` etc. return Closures. Passing one TypeErrors out.

Switched to `?callable` (stored as `?\Closure`). Tested with a real SSO profile.

### Issues Resolved
Closes #404

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).