### PR TITLE
chore: upgrade phpunit/phpunit to ^11.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 ### Changed
+- Upgrade `phpunit/phpunit` to `^11.5` ([#414](https://github.com/opensearch-project/opensearch-php/pull/414))
 ### Deprecated
 ### Removed
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     "phpstan/phpstan-deprecation-rules": "^1.2.1",
     "phpstan/phpstan-mockery": "^1.1.3",
     "phpstan/phpstan-phpunit": "^1.4.2",
-    "phpunit/phpunit": "^10.5.58",
+    "phpunit/phpunit": "^11.5",
     "react/promise": "^v3.3",
     "symfony/console": "v6.4.31|^7.4.3|^8.0.3",
     "symfony/finder": "^v6.4.31|^7.4.3|^v8.0.3",


### PR DESCRIPTION
Bumps phpunit/phpunit from ^10.5.58 to ^11.5. All 303 unit tests pass on PHPUnit 11.5.56 with no new deprecations surfaced. PHPUnit 11 still supports PHP 8.2, matching this project's minimum PHP version, so no other compatibility changes were needed.