### PR TITLE
ci: drop EOL OpenSearch 1.x and legacy Elasticsearch integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,46 +131,6 @@ jobs:
       run: |
         composer run unit
 
-  integration-test-elasticsearch:
-    name: Integration Test (Elasticsearch)
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-        search-server-image:
-          - docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0
-    services:
-      search-server:
-        image: ${{ matrix.search-server-image }}
-        ports:
-          - 9200:9200
-        env:
-          discovery.type: single-node
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
-
-    - name: Use PHP 8.3
-      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # ratchet:shivammathur/setup-php@2.37.2
-      with:
-        php-version: 8.3
-        extensions: yaml, zip, curl
-      env:
-        COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-   
-    - name: Install dependencies
-      run: |
-        composer install --prefer-dist
-
-    - name: Integration tests
-      run: |
-        composer run integration
-      env:
-        OPENSEARCH_URL: 'http://localhost:9200'
-
   integration-test-opensearch:
     name: Integration Test (OpenSearch)
     runs-on: ${{ matrix.os }}
@@ -180,7 +140,6 @@ jobs:
         os:
           - ubuntu-latest
         search-server-image:
-          - opensearchproject/opensearch:1
           - opensearchproject/opensearch:2
           - opensearchproject/opensearch:3
         prefer-lowest: ["--prefer-lowest", ""]

--- a/.github/workflows/test_unreleased.yml
+++ b/.github/workflows/test_unreleased.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         entry:
-          - { opensearch_ref: "1.x", java: 11 }
           - { opensearch_ref: "2.x", java: 21, gradle-runtime: 21 }
           - { opensearch_ref: "main", java: 25, gradle-runtime: 25 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 ### Deprecated
 ### Removed
+- Drop CI integration testing against EOL OpenSearch 1.x and legacy Elasticsearch OSS 7.10.0
 ### Fixed
 - Fix `SmartSerializer` throwing `JsonException` on JSON with unpaired UTF-16 surrogate escape sequences produced by search highlighting ([#403](https://github.com/opensearch-project/opensearch-php/pull/403))
 ### Security


### PR DESCRIPTION
OpenSearch 1.x has been EOL for over a year, and the Elasticsearch OSS 7.10.0 integration job tests a fork lineage that's no longer relevant to this client. Removes the `opensearchproject/opensearch:1` matrix entry and the whole `integration-test-elasticsearch` job from test.yml, plus the `1.x` OpenSearch source-build entry from test_unreleased.yml.