### PR TITLE
ci: replace deprecated GitHub App token with opensearch-ci-bot

### DIFF
--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -16,18 +16,10 @@ jobs:
       contents: write
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-      - name: GitHub App token
-        id: github_app_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # ratchet:tibdex/github-app-token@v2.1.0
-        with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
-          installation_id: 22958780
-
       - name: Check out code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
         with:
-          token: ${{ steps.github_app_token.outputs.token }}
+          token: ${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}
 
       - name: Update the changelog
         uses: dangoslen/dependabot-changelog-helper@291c8cb629d7cd7b57ea065782c435ec2bedb138 # ratchet:dangoslen/dependabot-changelog-helper@v4.3.0

--- a/.github/workflows/update_api.yml
+++ b/.github/workflows/update_api.yml
@@ -29,17 +29,14 @@ jobs:
       - name: Get current date
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-      - name: GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v3.2.0
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Create pull request
         id: cpr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # ratchet:peter-evans/create-pull-request@v8.1.1
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}
+          push-to-fork: opensearch-ci-bot/opensearch-php
+          committer: opensearch-ci-bot <opensearch-infra@amazon.com>
+          author: opensearch-ci-bot <opensearch-infra@amazon.com>
           commit-message: Updated opensearch-php to reflect the latest OpenSearch API spec (${{ steps.date.outputs.date }})
           title: Updated opensearch-php to reflect the latest OpenSearch API spec
           body: |
@@ -47,6 +44,7 @@ jobs:
             Date: ${{ steps.date.outputs.date }}
           branch: automated-api-update
           base: main
+          delete-branch: true
           signoff: true
           labels: |
               autocut

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 ### Changed
+- Replace deprecated GitHub App token with opensearch-ci-bot in CI workflows ([#416](https://github.com/opensearch-project/opensearch-php/pull/416))
 ### Deprecated
 ### Removed
 ### Fixed


### PR DESCRIPTION
- Replaces the deprecated GitHub App token in `update_api.yml` and `dependabot_pr.yml` with `secrets.OPENSEARCH_CI_BOT_TOKEN`
- `update_api.yml` now pushes via `push-to-fork: opensearch-ci-bot/opensearch-php`, following the pattern in opensearch-build's `os-increment-plugin-versions.yml`
- Rebased on main; `backport.yml` already fixed upstream via the new `backport-pr.yml` reusable workflow, so no change needed there

From Sayali Gaikawad in Slack:
> Branch creation has been blocked on opensearch-project by default. Also that APP is deprecated.

> Please update the workflow to use opensearch-ci fork.
> Example: https://github.com/opensearch-project/opensearch-build/blob/main/.github/workflows/os-increment-plugin-versions.yml#L110-L127