### PR TITLE
ci: use a distinct PR branch name for update_api.yml

### DIFF
--- a/.github/workflows/update_api.yml
+++ b/.github/workflows/update_api.yml
@@ -42,7 +42,7 @@ jobs:
           body: |
             Updated [opensearch-php](https://github.com/opensearch-project/opensearch-php) to reflect the latest [OpenSearch API spec](https://github.com/opensearch-project/opensearch-api-specification/releases/download/main-latest/opensearch-openapi.yaml)
             Date: ${{ steps.date.outputs.date }}
-          branch: automated-api-update
+          branch: automated-api-update-fork
           base: main
           delete-branch: true
           signoff: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Changed
 - Replace deprecated GitHub App token with opensearch-ci-bot in CI workflows ([#416](https://github.com/opensearch-project/opensearch-php/pull/416))
+- Rename `update_api.yml`'s PR branch to avoid colliding with a pre-existing branch of the same name on this repo
 - Upgrade `phpunit/phpunit` to `^11.5` ([#414](https://github.com/opensearch-project/opensearch-php/pull/414))
 ### Deprecated
 ### Removed


### PR DESCRIPTION
- Renames the PR branch update_api.yml creates from `automated-api-update` to `automated-api-update-fork`
- The old name already exists directly on this repo from before the switch to push-to-fork (#416), which made `peter-evans/create-pull-request` fail with an ambiguous ref between the origin and fork remotes when checking out
- Verified via a manual `workflow_dispatch` run that OPENSEARCH_CI_BOT_TOKEN itself authenticates fine; this is the only remaining blocker